### PR TITLE
ci: add license compliance check with Anchore Grant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,39 @@ jobs:
       - name: Lint
         run: cd ui/dashboard && npm run lint
 
+  license-check:
+    name: License Check
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.go == 'true' || needs.detect-changes.outputs.dashboard == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: |
+            services/api/go.sum
+            services/agent/go.sum
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Install Grant
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/grant/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Generate SBOM (Agent)
+        run: syft dir:services/agent -o spdx-json > /tmp/sbom-agent.json
+
+      - name: Generate SBOM (API)
+        run: syft dir:services/api -o spdx-json > /tmp/sbom-api.json
+
+      - name: Check Agent licenses
+        run: grant check sbom:/tmp/sbom-agent.json -c .grant.yaml
+
+      - name: Check API licenses
+        run: grant check sbom:/tmp/sbom-api.json -c .grant.yaml
+
   # Optional: triggered by PR label or manual dispatch
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -227,7 +227,7 @@ jobs:
         if: matrix.changed == 'true' || github.ref_type == 'tag'
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/grant/main/install.sh | sh -s -- -b /usr/local/bin
-          grant check sbom:sbom-${{ matrix.service }}.spdx.json --dry-run
+          grant check sbom:sbom-${{ matrix.service }}.spdx.json -c .grant.yaml
 
   push:
     name: Push ${{ matrix.service }}

--- a/.grant.yaml
+++ b/.grant.yaml
@@ -1,0 +1,41 @@
+# Grant license compliance policy for DecisionBox (AGPL-3.0)
+# https://github.com/anchore/grant
+
+rules:
+  # Allow permissive licenses compatible with AGPL-3.0
+  - pattern: "*"
+    mode: "allow"
+    licenses:
+      - MIT
+      - Apache-2.0
+      - BSD-2-Clause
+      - BSD-3-Clause
+      - ISC
+      - 0BSD
+      - Unlicense
+      - CC0-1.0
+      - CC-BY-3.0
+      - CC-BY-4.0
+      - MPL-2.0
+      - LGPL-2.1-only
+      - LGPL-2.1-or-later
+      - LGPL-3.0-only
+      - LGPL-3.0-or-later
+      - AGPL-3.0-only
+      - AGPL-3.0-or-later
+      - GPL-3.0-only
+      - GPL-3.0-or-later
+      - PostgreSQL
+      - Zlib
+      - BlueOak-1.0.0
+
+  # Deny licenses incompatible with AGPL-3.0 or non-OSI
+  - pattern: "*"
+    mode: "deny"
+    licenses:
+      - GPL-2.0-only
+      - SSPL-1.0
+      - BSL-1.1
+      - EUPL-1.1
+      - CPAL-1.0
+      - Artistic-1.0


### PR DESCRIPTION
## Summary

- Add `.grant.yaml` policy file with AGPL-3.0 compatible license allow-list
- Add license-check job to CI workflow (generates SBOMs with Syft, validates with Grant)
- Remove `--dry-run` from docker-publish workflow so Grant enforces the policy

## Changes

**New:**
- `.grant.yaml` — License policy (allowed: MIT, Apache-2.0, BSD, ISC, LGPL, GPL-3.0+, etc. Denied: GPL-2.0, SSPL, BSL, EUPL)

**Updated:**
- `.github/workflows/ci.yml` — New `license-check` job runs on Go/Dashboard changes
- `.github/workflows/docker-publish.yml` — Grant now uses `.grant.yaml` config instead of `--dry-run`

## Test Plan

- [ ] CI license-check job passes (SBOM generation + Grant validation)
- [ ] No false positives on current dependencies

Closes #24