### PR TITLE
docs: fix stale reference and add License Check to CI table

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@
 #   make dev-api                      # runs API directly (needs MongoDB on localhost:27017)
 #   make dev-dashboard                # runs dashboard directly
 #
-# All environment variables documented below. Copy .env.example to .env for overrides.
+# All environment variables documented below. Override values directly or set env vars before running.
 
 services:
   mongodb:

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -39,6 +39,7 @@ The CI workflow runs automatically on every PR and push to main:
 | Go Lint | golangci-lint on all modules | Go files changed |
 | Dashboard Build | Next.js build | Dashboard files changed |
 | Dashboard Test & Lint | Jest + ESLint | Dashboard files changed |
+| License Check | SBOM generation (Syft) + license policy validation (Grant) | Go or Dashboard files changed |
 | Integration Tests | MongoDB integration tests | Push to main, or PR with `run-integration-tests` label |
 
 To trigger integration tests on a PR, add the `run-integration-tests` label.


### PR DESCRIPTION
## Summary

- Remove stale `.env.example` reference in docker-compose.yml (file was deleted)
- Add License Check job to CI pipeline table in testing.md

## Related Issue

Addresses #60 (partially — doc accuracy fixes)