### PR TITLE
fix(helm): default imagePullSecrets to empty array

### DIFF
--- a/helm-charts/decisionbox-api/values.yaml
+++ b/helm-charts/decisionbox-api/values.yaml
@@ -10,8 +10,8 @@ namespace: decisionbox
 nameOverride: ""
 fullnameOverride: ""
 
-imagePullSecrets:
-  - name: ghcr-secret
+# Set for private registries (e.g., [{name: ghcr-secret}]). Not needed for public GHCR images.
+imagePullSecrets: []
 
 serviceAccountName: "decisionbox-api"
 serviceAccountAnnotations: {}

--- a/helm-charts/decisionbox-dashboard/values.yaml
+++ b/helm-charts/decisionbox-dashboard/values.yaml
@@ -10,8 +10,8 @@ namespace: decisionbox
 nameOverride: ""
 fullnameOverride: ""
 
-imagePullSecrets:
-  - name: ghcr-secret
+# Set for private registries (e.g., [{name: ghcr-secret}]). Not needed for public GHCR images.
+imagePullSecrets: []
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary
- Default `imagePullSecrets` to `[]` in both API and Dashboard Helm charts
- GHCR images are now public — no pull secret needed
- Users deploying without a `ghcr-secret` K8s Secret were getting `ImagePullBackOff`

Closes #15

## Test plan
- [ ] `helm template` both charts and verify no `imagePullSecrets` in output
- [ ] Deploy to cluster without `ghcr-secret` — pods should pull successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)