### PR TITLE
feat(infra): add Helm chart publishing workflow via GitHub Pages

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,33 @@
+name: Helm Charts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "helm-charts/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: helm-charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow using `helm/chart-releaser-action` to publish Helm charts
- Triggers on push to `main` when `helm-charts/**` changes
- Packages charts, creates GitHub Releases, publishes `index.yaml` to `gh-pages` branch
- GitHub Pages enabled on `gh-pages` branch

After merge, users can install charts via:
```bash
helm repo add decisionbox https://decisionbox-io.github.io/decisionbox-platform
helm install decisionbox-api decisionbox/decisionbox-api -n decisionbox
helm install decisionbox-dashboard decisionbox/decisionbox-dashboard -n decisionbox
```

Closes #73

## Test plan
- [ ] Merge to main with helm-charts/ change triggers the workflow
- [ ] chart-releaser creates GitHub Releases for both charts (0.1.0)
- [ ] `index.yaml` published to gh-pages branch
- [ ] `helm repo add` + `helm install` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)