### PR TITLE
docs: update Helm docs to reference public chart repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - AI-powered data discovery agent with autonomous SQL exploration
 - REST API for project, discovery, and configuration management
 - Web dashboard with live discovery progress, insights table, and recommendation cards
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Subprocess runner for local development
 - Docker Compose setup for local development
 - Helm charts for Kubernetes deployment (API, Dashboard, MongoDB subchart)
+- Public Helm chart repository at `https://decisionbox-io.github.io/decisionbox-platform`
 - GCP Terraform module (GKE, VPC, IAM, BigQuery)
 - GitHub Actions CI for Docker image builds
 - 350+ tests (unit, integration, testcontainers)

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -37,9 +37,9 @@ The API is internal only (`ClusterIP`) — never exposed to the internet. The da
 ## Quick Start
 
 ```bash
-# Clone the repository
-git clone https://github.com/decisionbox-io/decisionbox-platform.git
-cd decisionbox-platform
+# Add the DecisionBox Helm repository
+helm repo add decisionbox https://decisionbox-io.github.io/decisionbox-platform
+helm repo update
 
 # Create namespace
 kubectl create namespace decisionbox
@@ -50,12 +50,12 @@ kubectl create secret generic decisionbox-api-secrets \
   -n decisionbox
 
 # Deploy API (with bundled MongoDB for quick start)
-helm upgrade --install decisionbox-api ./helm-charts/decisionbox-api \
+helm upgrade --install decisionbox-api decisionbox/decisionbox-api \
   --set "extraEnvFrom[0].secretRef.name=decisionbox-api-secrets" \
   -n decisionbox
 
 # Deploy Dashboard
-helm upgrade --install decisionbox-dashboard ./helm-charts/decisionbox-dashboard \
+helm upgrade --install decisionbox-dashboard decisionbox/decisionbox-dashboard \
   -n decisionbox
 
 # Verify
@@ -71,7 +71,13 @@ kubectl get ingress -n decisionbox
 
 ## Charts
 
-DecisionBox ships two Helm charts:
+DecisionBox charts are published to a public Helm repository.
+Source code is in `helm-charts/`.
+
+```bash
+helm repo add decisionbox https://decisionbox-io.github.io/decisionbox-platform
+helm repo update
+```
 
 | Chart | Description | Default Port | Ingress |
 |-------|-------------|-------------|---------|
@@ -92,7 +98,7 @@ kubectl create secret generic decisionbox-api-secrets \
   -n decisionbox
 
 # Reference it in Helm
-helm upgrade --install decisionbox-api ./helm-charts/decisionbox-api \
+helm upgrade --install decisionbox-api decisionbox/decisionbox-api \
   --set "extraEnvFrom[0].secretRef.name=decisionbox-api-secrets" \
   -n decisionbox
 ```
@@ -113,7 +119,7 @@ kubectl create secret generic decisionbox-api-secrets \
   -n decisionbox
 
 # Deploy with external MongoDB
-helm upgrade --install decisionbox-api ./helm-charts/decisionbox-api \
+helm upgrade --install decisionbox-api decisionbox/decisionbox-api \
   --set mongodb.enabled=false \
   --set env.MONGODB_DB=decisionbox \
   --set "extraEnvFrom[0].secretRef.name=decisionbox-api-secrets" \
@@ -126,7 +132,7 @@ By default, secrets are encrypted with AES-256 and stored in MongoDB. For produc
 
 **GCP Secret Manager (with Workload Identity):**
 ```bash
-helm upgrade --install decisionbox-api ./helm-charts/decisionbox-api \
+helm upgrade --install decisionbox-api decisionbox/decisionbox-api \
   --set env.SECRET_PROVIDER=gcp \
   --set env.SECRET_GCP_PROJECT_ID=my-gcp-project \
   --set env.SECRET_NAMESPACE=decisionbox \
@@ -139,7 +145,7 @@ The `serviceAccountAnnotations` binds the K8s service account to a GCP service a
 
 **AWS Secrets Manager (with IRSA or EKS Pod Identity):**
 ```bash
-helm upgrade --install decisionbox-api ./helm-charts/decisionbox-api \
+helm upgrade --install decisionbox-api decisionbox/decisionbox-api \
   --set env.SECRET_PROVIDER=aws \
   --set env.SECRET_AWS_REGION=us-east-1 \
   --set env.SECRET_NAMESPACE=decisionbox \
@@ -189,7 +195,7 @@ ingress:
 The dashboard proxies `/api/*` requests to the API service. The default `API_URL` is `http://decisionbox-api-service:8080`, which assumes the API release name is `decisionbox-api`. If you use a different release name, update the dashboard's `env.API_URL`:
 
 ```bash
-helm upgrade --install my-dashboard ./helm-charts/decisionbox-dashboard \
+helm upgrade --install my-dashboard decisionbox/decisionbox-dashboard \
   --set env.API_URL="http://my-custom-api-service:8080" \
   -n decisionbox
 ```
@@ -228,7 +234,7 @@ resources:
 
 Deploy with:
 ```bash
-helm upgrade --install decisionbox-api ./helm-charts/decisionbox-api \
+helm upgrade --install decisionbox-api decisionbox/decisionbox-api \
   -f values-prod.yaml -n decisionbox
 ```
 
@@ -274,10 +280,10 @@ helm test decisionbox-dashboard -n decisionbox
 ## Updating
 
 ```bash
-helm upgrade decisionbox-api ./helm-charts/decisionbox-api \
+helm upgrade decisionbox-api decisionbox/decisionbox-api \
   -f values-prod.yaml -n decisionbox
 
-helm upgrade decisionbox-dashboard ./helm-charts/decisionbox-dashboard \
+helm upgrade decisionbox-dashboard decisionbox/decisionbox-dashboard \
   -n decisionbox
 ```
 

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -2,7 +2,15 @@
 
 > **Version**: 0.1.0
 
-Complete reference for all Helm chart values. Both charts are in `helm-charts/`.
+Complete reference for all Helm chart values.
+Charts are published to the DecisionBox Helm repository:
+
+```bash
+helm repo add decisionbox https://decisionbox-io.github.io/decisionbox-platform
+helm repo update
+```
+
+Source code for the charts is in `helm-charts/`.
 
 ## decisionbox-api
 
@@ -14,7 +22,7 @@ Complete reference for all Helm chart values. Both charts are in `helm-charts/`.
 | `image.repository` | string | `ghcr.io/decisionbox-io/decisionbox-api` | Container image |
 | `image.tag` | string | `main` | Image tag (defaults to `appVersion` if not set) |
 | `image.pullPolicy` | string | `Always` | Pull policy |
-| `imagePullSecrets` | list | `[{name: ghcr-secret}]` | Image pull secrets (not needed for public repo) |
+| `imagePullSecrets` | list | `[]` | Image pull secrets (set for private registries) |
 
 ### Deployment
 
@@ -125,7 +133,7 @@ For production, set `mongodb.enabled=false` and provide `env.MONGODB_URI` pointi
 | `image.repository` | string | `ghcr.io/decisionbox-io/decisionbox-dashboard` | Container image |
 | `image.tag` | string | `main` | Image tag |
 | `image.pullPolicy` | string | `Always` | Pull policy |
-| `imagePullSecrets` | list | `[{name: ghcr-secret}]` | Image pull secrets (not needed for public repo) |
+| `imagePullSecrets` | list | `[]` | Image pull secrets (set for private registries) |
 
 ### Deployment
 


### PR DESCRIPTION
## Summary

- Replace all local chart paths (`./helm-charts/`) with the published Helm repo (`decisionbox/decisionbox-api`, `decisionbox/decisionbox-dashboard`)
- Add `helm repo add` instructions to Quick Start and Charts sections in `kubernetes.md`
- Add Helm repo setup block to `helm-values.md`
- Fix stale `imagePullSecrets` default from `[{name: ghcr-secret}]` to `[]` (changed in #71 but docs were not updated)
- Add public Helm repo entry to `CHANGELOG.md`

## Files changed

- `docs/deployment/kubernetes.md` — all `helm upgrade --install` commands now use `decisionbox/` prefix
- `docs/reference/helm-values.md` — repo setup instructions, fixed imagePullSecrets default
- `CHANGELOG.md` — new entry for Helm chart repository

## Test plan

- [ ] Verify `helm repo add decisionbox https://decisionbox-io.github.io/decisionbox-platform` works
- [ ] Verify all `helm install` commands in docs use correct repo reference
- [ ] Verify no remaining `./helm-charts/` references in deployment docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)