### PR TITLE
fix(infra): create agent K8s service account via Helm chart

### DIFF
--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -30,8 +30,10 @@ Source code for the charts is in `helm-charts/`.
 |-----|------|---------|-------------|
 | `namespace` | string | `decisionbox` | Kubernetes namespace |
 | `containerPort` | int | `8080` | Container port |
-| `serviceAccountName` | string | `decisionbox-api` | Service account name |
-| `serviceAccountAnnotations` | map | `{}` | SA annotations (e.g., Workload Identity) |
+| `serviceAccountName` | string | `decisionbox-api` | API service account name |
+| `serviceAccountAnnotations` | map | `{}` | API SA annotations (e.g., Workload Identity) |
+| `agentServiceAccount.name` | string | `decisionbox-agent` | Agent service account name (for K8s Jobs) |
+| `agentServiceAccount.annotations` | map | `{}` | Agent SA annotations (e.g., Workload Identity for read-only access) |
 
 ### Environment Variables
 

--- a/helm-charts/decisionbox-api/templates/serviceaccount.yaml
+++ b/helm-charts/decisionbox-api/templates/serviceaccount.yaml
@@ -11,3 +11,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+---
+{{- if .Values.agentServiceAccount.name }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agentServiceAccount.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "decisionbox-api.labels" . | nindent 4 }}
+    app: decisionbox-agent
+  {{- with .Values.agentServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/decisionbox-api/values.yaml
+++ b/helm-charts/decisionbox-api/values.yaml
@@ -17,6 +17,13 @@ serviceAccountName: "decisionbox-api"
 serviceAccountAnnotations: {}
   # iam.gke.io/gcp-service-account: "<cluster-name>-api@<project-id>.iam.gserviceaccount.com"
 
+# Agent service account — created by this chart for agent K8s Jobs.
+# Needs Workload Identity annotation for GCP Secret Manager + BigQuery access.
+agentServiceAccount:
+  name: "decisionbox-agent"
+  annotations: {}
+    # iam.gke.io/gcp-service-account: "<cluster-name>-agent@<project-id>.iam.gserviceaccount.com"
+
 nodeSelector: {}
 
 containerPort: 8080

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -520,6 +520,7 @@ EOF
     K8S_SA="decisionbox-api"
     K8S_AGENT_SA="decisionbox-agent"
     GCP_SA="${CLUSTER_NAME}-api@${PROJECT_ID}.iam.gserviceaccount.com"
+    GCP_AGENT_SA="${CLUSTER_NAME}-agent@${PROJECT_ID}.iam.gserviceaccount.com"
 
     if [[ "$ENABLE_SECRETS" == "true" ]]; then
       cat > "$HELM_VALUES" <<EOF
@@ -530,6 +531,11 @@ namespace: ${K8S_NS}
 serviceAccountName: ${K8S_SA}
 serviceAccountAnnotations:
   iam.gke.io/gcp-service-account: "${GCP_SA}"
+
+agentServiceAccount:
+  name: ${K8S_AGENT_SA}
+  annotations:
+    iam.gke.io/gcp-service-account: "${GCP_AGENT_SA}"
 
 automountServiceAccountToken: true
 
@@ -550,6 +556,9 @@ EOF
 namespace: ${K8S_NS}
 
 serviceAccountName: ${K8S_SA}
+
+agentServiceAccount:
+  name: ${K8S_AGENT_SA}
 
 extraEnvFrom:
   - secretRef:


### PR DESCRIPTION
## Summary

Agent Jobs fail with `serviceaccount "decisionbox-agent" not found` because the K8s SA was never created. Terraform creates the GCP SA + Workload Identity binding, but the K8s SA was missing.

## Fix

The API Helm chart now creates both service accounts:
- `decisionbox-api` (existing) — for API pods
- `decisionbox-agent` (new) — for agent Job pods

Both support Workload Identity annotations via values.

This works for all deployment paths:
- **Helm only** — agent SA created by chart with annotations from values
- **setup.sh** — generates `agentServiceAccount` block in `values-secrets.yaml` with WI annotation
- **Manual kubectl** — `kubectl create sa decisionbox-agent -n decisionbox`

## Changes
- `helm-charts/decisionbox-api/templates/serviceaccount.yaml` — added agent SA
- `helm-charts/decisionbox-api/values.yaml` — added `agentServiceAccount` block
- `terraform/setup.sh` — generates agent SA WI annotation in Helm values
- `docs/reference/helm-values.md` — added `agentServiceAccount` docs

## Test plan
- [x] `helm template` renders both SAs correctly
- [x] `bash -n` setup.sh valid
- [ ] CI passes
- [ ] Deploy on GKE and run discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)