### PR TITLE
fix(infra): add delete timeouts to VPC/subnet for GKE NEG cleanup

### DIFF
--- a/terraform/gcp/modules/decisionbox/networking.tf
+++ b/terraform/gcp/modules/decisionbox/networking.tf
@@ -4,6 +4,14 @@ resource "google_compute_network" "vpc" {
   project                 = var.project_id
   auto_create_subnetworks = false
 
+  # GKE creates NEGs (network endpoint groups) for load balancers/ingress.
+  # These are cleaned up asynchronously after the cluster is deleted.
+  # The extended delete timeout gives GCP time to remove them before
+  # Terraform tries to delete the VPC.
+  timeouts {
+    delete = "10m"
+  }
+
   depends_on = [google_project_service.apis["compute.googleapis.com"]]
 }
 
@@ -33,6 +41,11 @@ resource "google_compute_subnetwork" "gke_subnet" {
       flow_sampling        = var.flow_log_sampling
       metadata             = var.flow_log_metadata
     }
+  }
+
+  # GKE NEGs reference subnets — allow time for async cleanup after cluster deletion
+  timeouts {
+    delete = "10m"
   }
 }
 


### PR DESCRIPTION
## Summary

`terraform destroy` fails with "network is already being used by NEG" because GKE creates network endpoint groups (NEGs) for load balancers/ingress, and they're garbage-collected asynchronously after cluster deletion.

## Root Cause

GKE auto-creates NEGs outside of Terraform's state. When Terraform deletes the cluster, GCP starts async cleanup of these NEGs. Terraform then immediately tries to delete the VPC/subnet, which fails because the NEGs still reference them.

## Fix

Added 10-minute `timeouts { delete }` blocks to both `google_compute_network` and `google_compute_subnetwork` resources. This gives Terraform enough retry time for GCP to finish NEG cleanup before attempting VPC/subnet deletion.

## Test plan
- [ ] `terraform destroy` completes without NEG errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)