### PR TITLE
fix(infra): use inbound-cidrs for AWS ALB IP restriction

### DIFF
--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -1679,10 +1679,11 @@ do_helm_deploy() {
       --set "ingress.annotations.alb\.ingress\.kubernetes\.io/scheme=internet-facing"
       --set "ingress.annotations.alb\.ingress\.kubernetes\.io/target-type=ip"
     )
-    # Attach IP allowlist security group to ALB if IP restriction is configured
-    ALB_SG_ID=$(terraform -chdir="$TF_DIR" output -raw ip_allowlist_security_group_id 2>/dev/null || echo "")
-    if [[ -n "$ALB_SG_ID" ]]; then
-      DASH_ARGS+=(--set "ingress.annotations.alb\.ingress\.kubernetes\.io/security-groups=${ALB_SG_ID}")
+    # Restrict ALB inbound traffic to allowed CIDRs if IP restriction is configured.
+    # Uses inbound-cidrs (not security-groups) so the controller keeps managing
+    # its own backend SG rules for ALB-to-pod connectivity.
+    if [[ -n "${ALLOWED_IP_RANGES:-}" ]]; then
+      DASH_ARGS+=(--set "ingress.annotations.alb\.ingress\.kubernetes\.io/inbound-cidrs=${ALLOWED_IP_RANGES}")
     fi
   elif [[ "$CLOUD" == "azure" ]]; then
     DASH_ARGS+=(


### PR DESCRIPTION
## Summary

- Replaces `security-groups` annotation with `inbound-cidrs` for AWS ALB IP restriction
- Reads `ALLOWED_IP_RANGES` directly instead of Terraform SG output

**Root cause of 504**: The `security-groups` annotation tells the ALB controller to stop managing backend SG rules entirely (`"backend SG": null` in controller logs). It revokes the existing pod inbound rule and doesn't create a new one — the ALB can't reach pods on port 3000.

**Fix**: `inbound-cidrs` restricts the controller's auto-created frontend SG to the specified CIDRs while keeping its backend SG management intact. Verified working on `decisionbox-internal-prod`.

## Test plan

- [x] Verified on AWS prod — dashboard reachable after switching annotation
- [ ] Deploy with `setup.sh` on a fresh cluster with `allowed_ip_ranges` set
- [ ] Deploy without IP restriction — verify no `inbound-cidrs` annotation added

🤖 Generated with [Claude Code](https://claude.com/claude-code)