### PR TITLE
feat(helm): add extraEnv + extraEnvFrom support to dashboard chart

### DIFF
--- a/helm-charts/decisionbox-dashboard/Chart.yaml
+++ b/helm-charts/decisionbox-dashboard/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: decisionbox-dashboard
 description: DecisionBox Dashboard
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"

--- a/helm-charts/decisionbox-dashboard/templates/deployment.yaml
+++ b/helm-charts/decisionbox-dashboard/templates/deployment.yaml
@@ -48,6 +48,14 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/decisionbox-dashboard/values.yaml
+++ b/helm-charts/decisionbox-dashboard/values.yaml
@@ -20,6 +20,21 @@ containerPort: 3000
 env:
   API_URL: "http://decisionbox-api-service:8080"
 
+# Additional env vars merged with `env` above. Exists so that overlays
+# (e.g., the enterprise auth overlay) can add values without restating the
+# community defaults. Values must be strings — use `extraEnvFrom` for secrets.
+extraEnv: {}
+
+# Mount K8s Secret or ConfigMap references as env vars. Recommended for
+# AUTH_CLIENT_SECRET, NEXTAUTH_SECRET, and any other sensitive dashboard
+# configuration. Each entry is a standard envFrom source.
+#
+# Example:
+#   extraEnvFrom:
+#     - secretRef:
+#         name: decisionbox-dashboard-auth
+extraEnvFrom: []
+
 securityContext:
   runAsNonRoot: true
   runAsUser: 1000


### PR DESCRIPTION
## Summary

Brings the dashboard Helm chart to parity with the api chart by adding `extraEnv` and `extraEnvFrom` values. Enables overlays (enterprise auth in particular) to inject env vars — especially secrets via \`secretRef\` — without editing the chart itself.

## Motivation

The enterprise auth overlay at \`decisionbox-enterprise/helm/values-dashboard.yaml\` references \`extraEnvFrom: []\` — but the community dashboard chart never wired that key through to the Deployment template. Injecting \`AUTH_CLIENT_SECRET\` and \`NEXTAUTH_SECRET\` as env vars was impossible without modifying the chart. This PR closes that gap.

## Changes

- \`values.yaml\`: add \`extraEnv: {}\` and \`extraEnvFrom: []\` with descriptive comments and an example
- \`templates/deployment.yaml\`: render \`extraEnv\` entries after the base \`env\` block, then render \`envFrom:\` if \`extraEnvFrom\` is non-empty
- \`Chart.yaml\`: bump version \`0.1.0\` → \`0.1.1\`

## Validation

\`\`\`
helm template test ./helm-charts/decisionbox-dashboard \\
  --set 'extraEnv.AUTH_ENABLED=true' \\
  --set 'extraEnvFrom[0].secretRef.name=decisionbox-dashboard-auth'
\`\`\`

Renders the expected env entry and \`envFrom: - secretRef: name: decisionbox-dashboard-auth\`.

## Test plan

- [ ] CI green
- [ ] \`helm lint helm-charts/decisionbox-dashboard\` clean
- [ ] \`helm template\` with no \`extraEnv\`/\`extraEnvFrom\` still matches prior output (no diff for existing users)
- [ ] Enterprise overlay deployment injects \`AUTH_CLIENT_SECRET\` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)