### PR TITLE
chore(terraform/aws): remove orphaned ip_allowlist security group

### DIFF
--- a/docs/deployment/terraform-aws.md
+++ b/docs/deployment/terraform-aws.md
@@ -226,7 +226,7 @@ Set `region` and `cluster_name` to match your environment.
 | `secret_namespace` | string | `decisionbox` | Secret name prefix for IAM scoping |
 | `enable_bedrock_iam` | bool | `false` | Grant Bedrock InvokeModel access (Agent) |
 | `enable_redshift_iam` | bool | `false` | Grant Redshift Data API read access (Agent) |
-| `allowed_ip_ranges` | list(string) | `[]` | CIDR blocks allowed for HTTP/HTTPS. Empty = unrestricted. Creates a security group for ALB attachment. |
+| `allowed_ip_ranges` | list(string) | `[]` | CIDR blocks allowed for HTTP/HTTPS. Empty = unrestricted. Applied via the `alb.ingress.kubernetes.io/inbound-cidrs` annotation. |
 
 ### Tags
 

--- a/terraform/aws/modules/decisionbox/outputs.tf
+++ b/terraform/aws/modules/decisionbox/outputs.tf
@@ -59,8 +59,3 @@ output "redshift_iam_enabled" {
   description = "Whether Redshift IAM was enabled"
   value       = var.enable_redshift_iam
 }
-
-output "ip_allowlist_security_group_id" {
-  description = "Security group ID for IP allowlisting (empty if no IP restriction). Attach to ALBs via alb.ingress.kubernetes.io/security-groups annotation."
-  value       = length(var.allowed_ip_ranges) > 0 && var.create_vpc ? aws_security_group.ip_allowlist[0].id : ""
-}

--- a/terraform/aws/modules/decisionbox/vpc.tf
+++ b/terraform/aws/modules/decisionbox/vpc.tf
@@ -256,59 +256,8 @@ resource "aws_iam_role_policy" "flow_log" {
   })
 }
 
-# ─── IP Restriction Security Group ──────────────────────────────────────────
-# When allowed_ip_ranges is populated, creates a security group that only
-# permits inbound HTTP/HTTPS from the specified CIDRs. Attach to ALBs via
-# the annotation: alb.ingress.kubernetes.io/security-groups
-
-resource "aws_security_group" "ip_allowlist" {
-  count = var.create_vpc && length(var.allowed_ip_ranges) > 0 ? 1 : 0
-
-  name_prefix = "${var.cluster_name}-ip-allowlist-"
-  vpc_id      = local.vpc_id
-  description = "Restricts HTTP/HTTPS access to allowed IP ranges"
-
-  tags = merge(local.common_tags, {
-    Name = "${var.cluster_name}-ip-allowlist"
-  })
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "ip_allowlist_http" {
-  count = var.create_vpc && length(var.allowed_ip_ranges) > 0 ? 1 : 0
-
-  type              = "ingress"
-  from_port         = 80
-  to_port           = 80
-  protocol          = "tcp"
-  cidr_blocks       = var.allowed_ip_ranges
-  security_group_id = aws_security_group.ip_allowlist[0].id
-  description       = "Allow HTTP from allowed IP ranges"
-}
-
-resource "aws_security_group_rule" "ip_allowlist_https" {
-  count = var.create_vpc && length(var.allowed_ip_ranges) > 0 ? 1 : 0
-
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = var.allowed_ip_ranges
-  security_group_id = aws_security_group.ip_allowlist[0].id
-  description       = "Allow HTTPS from allowed IP ranges"
-}
-
-resource "aws_security_group_rule" "ip_allowlist_egress" {
-  count = var.create_vpc && length(var.allowed_ip_ranges) > 0 ? 1 : 0
-
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.ip_allowlist[0].id
-  description       = "Allow all outbound"
-}
+# IP allowlisting for the ALB is enforced via the
+# `alb.ingress.kubernetes.io/inbound-cidrs` annotation that setup.sh sets
+# from `allowed_ip_ranges`. The AWS Load Balancer Controller manages its
+# own backend security group rules in that mode, so no separate Terraform
+# security group is needed.

--- a/terraform/aws/prod/outputs.tf
+++ b/terraform/aws/prod/outputs.tf
@@ -44,8 +44,3 @@ output "redshift_iam_enabled" {
   description = "Whether Redshift IAM was enabled"
   value       = module.decisionbox.redshift_iam_enabled
 }
-
-output "ip_allowlist_security_group_id" {
-  description = "Security group ID for IP allowlisting (empty if not configured)"
-  value       = module.decisionbox.ip_allowlist_security_group_id
-}


### PR DESCRIPTION
## Summary

setup.sh switched to \`alb.ingress.kubernetes.io/inbound-cidrs\` for AWS IP allowlisting in #155. With that annotation, the AWS Load Balancer Controller stays in its default "I manage backend SG rules" mode and the standalone \`aws_security_group.ip_allowlist\` resource is no longer attached to anything — it's dead code created on every \`terraform apply\` and never used.

This PR removes it.

## What it removes

- \`aws_security_group.ip_allowlist\` (and its 3 supporting \`aws_security_group_rule\` resources for HTTP/HTTPS ingress + egress)
- \`ip_allowlist_security_group_id\` output (both the module-level output in \`modules/decisionbox/outputs.tf\` and the proxied output in \`prod/outputs.tf\`)
- Stale comment block in \`vpc.tf\` that referenced the old \`alb.ingress.kubernetes.io/security-groups\` attachment pattern (replaced with a short note pointing at the inbound-cidrs approach)
- Outdated description for \`allowed_ip_ranges\` in \`docs/deployment/terraform-aws.md\` (which still said "Creates a security group for ALB attachment")

## What it does NOT change

- \`var.allowed_ip_ranges\` is still the variable users set. setup.sh still consumes it and passes it to the helm chart as \`inbound-cidrs\`.
- The GCP \`google_compute_security_policy.ip_allowlist\` (Cloud Armor) is unrelated and stays.

## Why this is safe

The resource was created on \`terraform apply\` whenever \`allowed_ip_ranges\` was non-empty, but nothing in the helm chart, the module, or setup.sh has referenced its ID since #155 landed. Any deployment that already migrated to the inbound-cidrs flow will see the SG removed on the next \`terraform apply\` with no functional impact.

For deployments that are still on the OLD security-groups annotation flow: they need to migrate the helm release to inbound-cidrs FIRST (remove the \`security-groups\` annotation, add \`inbound-cidrs\`), then \`terraform apply\` to clean up the SG. Otherwise the apply will fail trying to delete a SG that's still attached to an in-use ALB.

## Validation

- \`terraform validate\` clean on \`terraform/aws/modules/decisionbox\`
- \`terraform validate\` clean on \`terraform/aws/prod\`
- \`grep -rn 'ip_allowlist' terraform/aws docs/\` shows zero residual references in the AWS tree (all remaining hits are GCP Cloud Armor)

## Test plan

- [ ] CI green
- [ ] On a fresh AWS install (\`./setup.sh --cloud aws\` with \`allowed_ip_ranges\` set), verify the ALB ingress is reachable from the allowed CIDR and rejected from outside, and that no orphaned SG exists in the account
- [ ] On the existing internal cluster, the helm release is migrated to inbound-cidrs first, then \`terraform apply\` cleanly removes the unused SG

🤖 Generated with [Claude Code](https://claude.com/claude-code)