### PR TITLE
refactor(apiserver): move subcommand routing into Run()

### DIFF
--- a/services/api/apiserver/apiserver.go
+++ b/services/api/apiserver/apiserver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/decisionbox-io/decisionbox/libs/go-common/vectorstore"
 	goversion "github.com/decisionbox-io/decisionbox/libs/go-common/version"
 	qdrantstore "github.com/decisionbox-io/decisionbox/libs/go-common/vectorstore/qdrant"
+	"github.com/decisionbox-io/decisionbox/services/api/internal/backfill"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/config"
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	apilog "github.com/decisionbox-io/decisionbox/services/api/internal/log"
@@ -57,10 +58,29 @@ import (
 	_ "github.com/decisionbox-io/decisionbox/providers/embedding/voyage"
 )
 
-// Run starts the DecisionBox API server.
+// Run starts the DecisionBox API server, OR dispatches a CLI subcommand
+// if one is provided as the first argument.
+//
 // Plugins (auth providers, etc.) can register via init() in their
 // packages — import them with blank imports before calling Run().
+//
+// Subcommands handled here so any caller of Run() (community main.go,
+// enterprise cmd/api/main.go, future custom builds) inherits CLI tooling
+// without per-binary main.go drift:
+//
+//	decisionbox-api backfill-embeddings [flags]
+//
+// When a subcommand is invoked, Run() routes to it and returns without
+// starting the HTTP server.
 func Run() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "backfill-embeddings":
+			backfill.RunBackfillEmbeddings(os.Args[2:])
+			return
+		}
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		apilog.WithError(err).Error("Failed to load config")

--- a/services/api/apiserver/apiserver.go
+++ b/services/api/apiserver/apiserver.go
@@ -73,12 +73,9 @@ import (
 // When a subcommand is invoked, Run() routes to it and returns without
 // starting the HTTP server.
 func Run() {
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "backfill-embeddings":
-			backfill.RunBackfillEmbeddings(os.Args[2:])
-			return
-		}
+	if len(os.Args) > 1 && os.Args[1] == "backfill-embeddings" {
+		backfill.RunBackfillEmbeddings(os.Args[2:])
+		return
 	}
 
 	cfg, err := config.Load()

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -1,17 +1,9 @@
 package main
 
 import (
-	"os"
-
 	"github.com/decisionbox-io/decisionbox/services/api/apiserver"
-	"github.com/decisionbox-io/decisionbox/services/api/internal/backfill"
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "backfill-embeddings" {
-		backfill.RunBackfillEmbeddings(os.Args[2:])
-		return
-	}
-
 	apiserver.Run()
 }


### PR DESCRIPTION
## Problem

The community \`services/api/main.go\` had a hand-rolled subcommand check before calling \`apiserver.Run()\`:

\`\`\`go
func main() {
    if len(os.Args) > 1 && os.Args[1] == "backfill-embeddings" {
        backfill.RunBackfillEmbeddings(os.Args[2:])
        return
    }
    apiserver.Run()
}
\`\`\`

\`decisionbox-enterprise/cmd/api/main.go\` shipped its own thinner version that just called \`apiserver.Run()\` with no preamble. As a result, the \`backfill-embeddings\` subcommand was completely unreachable from the enterprise binary — when you ran \`decisionbox-api backfill-embeddings\` inside an enterprise pod, it skipped the subcommand and tried to start the HTTP server (which then failed with \`bind: address already in use\` because the actual API was already listening).

This is the third instance today of "enterprise main.go has a gap community didn't think to expose":

1. \`/health\` was behind the auth middleware (fixed in enterprise#10)
2. \`/logo-icon.png\` was behind the auth middleware matcher (fixed in enterprise#12)
3. \`backfill-embeddings\` subcommand wasn't wired up (this PR)

Each time the fix has been to mirror something into the enterprise side. That's brittle — every new community subcommand or every new public asset becomes a re-sync chore.

## Fix

Move subcommand routing **into \`apiserver.Run()\`** itself. Both binaries inherit it for free.

\`\`\`go
// services/api/apiserver/apiserver.go
func Run() {
    if len(os.Args) > 1 {
        switch os.Args[1] {
        case "backfill-embeddings":
            backfill.RunBackfillEmbeddings(os.Args[2:])
            return
        }
    }
    // ...existing HTTP startup...
}
\`\`\`

Community \`services/api/main.go\` shrinks to a single \`apiserver.Run()\` call. Enterprise \`cmd/api/main.go\` is unchanged but now exposes the subcommand automatically because it links against the new \`apiserver\` package.

## Why this is the right place for it

- **Same module, no internal-package wall**: \`apiserver\` and \`internal/backfill\` are both under \`services/api/\`, so apiserver can import \`internal/backfill\` directly. Trying to do this from \`decisionbox-enterprise/cmd/api/main.go\` doesn't work because Go's \`internal\` rule blocks external module access — we'd have to either move backfill out of \`internal/\` or duplicate the import on every consumer.
- **Plugin init() ordering is preserved**: blank-import plugins still register via init() before \`Run()\` is invoked. On the subcommand path, \`Run()\` returns before any plugin middleware activates — only the secret provider (used by the backfill itself) is touched.
- **Single source of truth for CLI surface**: future subcommands (e.g., \`migrate\`, \`reindex\`, \`audit-export\`) get added in one place and every consumer of \`apiserver.Run()\` picks them up automatically. No re-sync, no drift.

## Validated locally

- ✅ \`go build ./services/api/\` clean
- ✅ \`./decisionbox-api backfill-embeddings -h\` prints the flag help correctly from the community binary
- ✅ \`go build ./cmd/api/\` clean on \`decisionbox-enterprise\` (cross-module via go.mod replace directives)
- ✅ \`./decisionbox-api backfill-embeddings -h\` prints the flag help correctly from the **enterprise** binary — without any enterprise-side change
- ✅ Plugin init() lines (\`[slack] MONGODB_URI not set, skipping...\`) still print on the enterprise binary path before the subcommand help, confirming the import side effects still run

## Test plan

- [ ] CI green (build, lint, test on services/api)
- [ ] After merge, decisionbox-enterprise v0.1.2 release rebuilds against this and \`kubectl exec deploy/decisionbox-api -- decisionbox-api backfill-embeddings --project-id <id>\` runs to completion against the EKS deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)