### PR TITLE
fix(terraform): grant LLM IAM to API role, not just agent

### DIFF
--- a/terraform/aws/modules/decisionbox/iam.tf
+++ b/terraform/aws/modules/decisionbox/iam.tf
@@ -319,15 +319,13 @@ resource "aws_iam_role" "irsa_agent" {
   tags = local.common_tags
 }
 
-# ─── Bedrock IAM (Agent) ──────────────────────────────────────────────────
+# ─── Bedrock IAM (API + Agent) ────────────────────────────────────────────
+# Both roles need Bedrock when the deployment uses the bedrock LLM provider:
+#   - Agent calls Bedrock during discovery runs (SQL generation, analysis).
+#   - API calls Bedrock for /ask synthesis and any other LLM-powered endpoints.
 
-resource "aws_iam_role_policy" "bedrock" {
-  count = var.enable_bedrock_iam ? 1 : 0
-
-  name = "bedrock-invoke"
-  role = aws_iam_role.irsa_agent.id
-
-  policy = jsonencode({
+locals {
+  bedrock_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
       Sid    = "BedrockInvoke"
@@ -342,4 +340,20 @@ resource "aws_iam_role_policy" "bedrock" {
       ]
     }]
   })
+}
+
+resource "aws_iam_role_policy" "bedrock_api" {
+  count = var.enable_bedrock_iam ? 1 : 0
+
+  name   = "bedrock-invoke"
+  role   = aws_iam_role.irsa_api.id
+  policy = local.bedrock_policy
+}
+
+resource "aws_iam_role_policy" "bedrock_agent" {
+  count = var.enable_bedrock_iam ? 1 : 0
+
+  name   = "bedrock-invoke"
+  role   = aws_iam_role.irsa_agent.id
+  policy = local.bedrock_policy
 }

--- a/terraform/aws/modules/decisionbox/variables.tf
+++ b/terraform/aws/modules/decisionbox/variables.tf
@@ -203,7 +203,7 @@ variable "secret_namespace" {
 
 # Optional: Bedrock IAM
 variable "enable_bedrock_iam" {
-  description = "Grant Bedrock InvokeModel access to the agent IRSA role"
+  description = "Grant Bedrock InvokeModel access to the API and agent IRSA roles. The agent uses Bedrock during discovery runs; the API uses it for /ask synthesis and other LLM-powered endpoints. Both need the policy when the deployment's LLM provider is bedrock."
   type        = bool
   default     = false
 }

--- a/terraform/gcp/modules/decisionbox/variables.tf
+++ b/terraform/gcp/modules/decisionbox/variables.tf
@@ -359,7 +359,7 @@ variable "enable_bigquery_iam" {
 
 # Optional: Vertex AI IAM
 variable "enable_vertex_ai_iam" {
-  description = "Grant Vertex AI access to the agent SA for LLM calls (Claude via Vertex, Gemini)"
+  description = "Grant Vertex AI access (roles/aiplatform.user) to BOTH the API and agent Workload Identity SAs. The agent uses Vertex during discovery runs; the API uses it for /ask synthesis and other LLM-powered endpoints. Both need the role when the deployment's LLM provider is vertex-ai."
   type        = bool
   default     = false
 }

--- a/terraform/gcp/modules/decisionbox/vertex-ai.tf
+++ b/terraform/gcp/modules/decisionbox/vertex-ai.tf
@@ -1,6 +1,16 @@
-# Vertex AI IAM — granted to the agent SA for LLM access via Vertex AI.
-# Required when using vertex-ai LLM provider (Claude via Vertex, Gemini).
-# The API does not call Vertex AI directly — only the agent does.
+# Vertex AI IAM — granted to BOTH the API and agent Workload Identity SAs
+# when the deployment uses the vertex-ai LLM provider (Claude via Vertex,
+# Gemini, etc.).
+#
+#   - Agent calls Vertex during discovery runs (SQL generation, analysis).
+#   - API calls Vertex for /ask synthesis and other LLM-powered endpoints.
+
+resource "google_project_iam_member" "api_vertex_ai_user" {
+  count   = var.enable_vertex_ai_iam ? 1 : 0
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.workload_identity.email}"
+}
 
 resource "google_project_iam_member" "agent_vertex_ai_user" {
   count   = var.enable_vertex_ai_iam ? 1 : 0


### PR DESCRIPTION
## Problem

The AWS and GCP terraform modules grant LLM IAM (Bedrock \`InvokeModel\` / Vertex AI \`aiplatform.user\`) **only to the agent** IRSA / Workload Identity SA. That was accurate when the API process never called LLMs directly — but the API now calls LLM providers for \`/ask\` synthesis, and as more LLM-powered endpoints land (search-with-reranking, auto-summaries, future agent endpoints), that gap grows.

Observed failure: on an EKS deployment provisioned via setup.sh with \`enable_bedrock_iam = true\`, \`/ask\` returns 500 and the dashboard shows the generic \`"Sorry, I could not answer this question. Make sure embedding is configured for this project."\` message. The real error is hidden because the handler's catch-all returns a generic string, but the API process is getting AccessDenied from Bedrock because the API's IRSA role has no \`bedrock:*\` permissions.

Community \`setup.sh\` wires \`enable_bedrock_iam\` / \`enable_vertex_ai_iam\` through to the terraform module, so any user opting into "LLM IAM" expects both the API and agent to work. The current module breaks that contract silently.

## Fix

### AWS

Split the single \`aws_iam_role_policy.bedrock\` resource into \`bedrock_api\` + \`bedrock_agent\`, sharing the policy document via \`locals.bedrock_policy\` so there's no duplication. Both resources gate on the same \`var.enable_bedrock_iam\`.

\`\`\`hcl
locals {
  bedrock_policy = jsonencode({ ... })  # single source of truth
}

resource "aws_iam_role_policy" "bedrock_api" {
  count  = var.enable_bedrock_iam ? 1 : 0
  name   = "bedrock-invoke"
  role   = aws_iam_role.irsa_api.id
  policy = local.bedrock_policy
}

resource "aws_iam_role_policy" "bedrock_agent" {
  count  = var.enable_bedrock_iam ? 1 : 0
  name   = "bedrock-invoke"
  role   = aws_iam_role.irsa_agent.id
  policy = local.bedrock_policy
}
\`\`\`

### GCP

Add \`google_project_iam_member.api_vertex_ai_user\` alongside the existing \`agent_vertex_ai_user\`. Both gate on \`var.enable_vertex_ai_iam\` and grant \`roles/aiplatform.user\` to the respective workload identity SA.

Also removes the stale comment in \`vertex-ai.tf\` that said:
> The API does not call Vertex AI directly — only the agent does.

which is no longer true.

### Azure

**No change.** The \`azure-foundry\` LLM provider uses API keys (stored in the secret provider), not IAM. Validated by checking \`providers/llm/azure-foundry/provider.go\` — all auth paths go through the \`api_key\` config field. If Azure ever adds a managed-identity mode for ai-foundry, that'll be a separate change.

### Variable descriptions

\`enable_bedrock_iam\` and \`enable_vertex_ai_iam\` descriptions updated to say "BOTH the API and agent" explicitly, so setup.sh prompts and docs stay consistent with the new behavior.

## Migration for existing deployments

Re-apply the module:

\`\`\`bash
cd terraform/aws/prod  # or terraform/gcp/prod
terraform plan    # should show 1 new resource (bedrock_api or api_vertex_ai_user) if you already had enable_*_iam = true
terraform apply
\`\`\`

**Rename note for AWS**: existing deployments have \`aws_iam_role_policy.bedrock[0]\` in state. This PR renames the resource to \`bedrock_agent[0]\`, so terraform will plan a destroy+create if the state isn't migrated. Two options:

1. **State migration** (clean, no downtime): \`terraform state mv 'aws_iam_role_policy.bedrock[0]' 'aws_iam_role_policy.bedrock_agent[0]'\` before apply
2. **Just apply** — the destroy+create happens on the agent inline policy, which is a ~1 second window where the agent is missing Bedrock. Only matters if a discovery run is mid-execution.

I'll include the \`terraform state mv\` command in the apply instructions for the decisionbox-internal cluster when I run it post-merge.

## Validation

- ✅ \`terraform init\` + \`terraform validate\` clean on \`terraform/aws/modules/decisionbox\`, \`terraform/aws/prod\`, and \`terraform/gcp/modules/decisionbox\`
- ✅ No state format change — both clouds still use the same resource types (\`aws_iam_role_policy\`, \`google_project_iam_member\`)
- ⏳ Will verify \`/ask\` works on decisionbox-internal after post-merge terraform apply

## Test plan

- [ ] CI green
- [ ] \`terraform plan\` on an existing aws deployment with \`enable_bedrock_iam = true\` shows the expected new resource (bedrock_api) + rename of existing (bedrock → bedrock_agent)
- [ ] \`terraform plan\` on an existing gcp deployment with \`enable_vertex_ai_iam = true\` shows the expected new resource (api_vertex_ai_user)
- [ ] After apply on decisionbox-internal (AWS), \`/ask\` on a project using bedrock LLM returns a real answer (not the generic error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)