### PR TITLE
chore(infra): bump decisionbox-api chart to 0.1.1

### DIFF
--- a/helm-charts/decisionbox-api/Chart.yaml
+++ b/helm-charts/decisionbox-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: decisionbox-api
 description: DecisionBox API
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"
 
 dependencies:


### PR DESCRIPTION
## Summary
- Bumps `decisionbox-api` Helm chart version from `0.1.0` to `0.1.1`
- Reflects the addition of Qdrant as a chart dependency

## Test plan
- [ ] Verify `helm template` renders correctly with new version
- [ ] Verify `helm dependency update` resolves Qdrant subchart

🤖 Generated with [Claude Code](https://claude.com/claude-code)