### PR TITLE
fix(api): propagate QDRANT_URL and QDRANT_API_KEY to agent Jobs

### DIFF
--- a/services/api/internal/runner/kubernetes.go
+++ b/services/api/internal/runner/kubernetes.go
@@ -72,6 +72,8 @@ func (r *KubernetesRunner) buildJob(spec jobSpec) *batchv1.Job {
 		{"SECRET_NAMESPACE", "SECRET_NAMESPACE"},
 		{"SECRET_ENCRYPTION_KEY", "SECRET_ENCRYPTION_KEY"},
 		{"SECRET_GCP_PROJECT_ID", "SECRET_GCP_PROJECT_ID"},
+		{"QDRANT_URL", "QDRANT_URL"},
+		{"QDRANT_API_KEY", "QDRANT_API_KEY"},
 	} {
 		if v := getEnv(kv.envKey, ""); v != "" {
 			envVars = append(envVars, corev1.EnvVar{Name: kv.key, Value: v})

--- a/services/api/internal/runner/runner_test.go
+++ b/services/api/internal/runner/runner_test.go
@@ -284,6 +284,67 @@ func TestKubernetesRunner_Cancel_NotFound(t *testing.T) {
 	}
 }
 
+// TestKubernetesRunner_Run_PropagatesQdrantEnv verifies that QDRANT_URL and
+// QDRANT_API_KEY set on the API process are forwarded to agent Job containers.
+// Without these, the agent treats Qdrant as unconfigured and silently skips the
+// embed_index phase, leaving insights un-indexed for search/ask.
+func TestKubernetesRunner_Run_PropagatesQdrantEnv(t *testing.T) {
+	os.Setenv("QDRANT_URL", "qdrant.svc:6334")
+	os.Setenv("QDRANT_API_KEY", "test-qdrant-key")
+	defer os.Unsetenv("QDRANT_URL")
+	defer os.Unsetenv("QDRANT_API_KEY")
+
+	r := newFakeK8sRunner()
+	ctx := context.Background()
+
+	err := r.Run(ctx, RunOptions{ProjectID: "proj-qdrant", RunID: "run-qdrant-env-1234"})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	jobs, _ := r.client.BatchV1().Jobs("test-ns").List(ctx, metav1.ListOptions{})
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
+	}
+	c := jobs.Items[0].Spec.Template.Spec.Containers[0]
+
+	envMap := make(map[string]string)
+	for _, e := range c.Env {
+		envMap[e.Name] = e.Value
+	}
+	if envMap["QDRANT_URL"] != "qdrant.svc:6334" {
+		t.Errorf("QDRANT_URL = %q, want qdrant.svc:6334", envMap["QDRANT_URL"])
+	}
+	if envMap["QDRANT_API_KEY"] != "test-qdrant-key" {
+		t.Errorf("QDRANT_API_KEY = %q, want test-qdrant-key", envMap["QDRANT_API_KEY"])
+	}
+}
+
+// TestKubernetesRunner_Run_OmitsQdrantEnvWhenUnset verifies we do NOT inject
+// empty QDRANT_URL / QDRANT_API_KEY vars when they are unset on the API
+// process. Keeps the Job spec clean and avoids masking real values.
+func TestKubernetesRunner_Run_OmitsQdrantEnvWhenUnset(t *testing.T) {
+	os.Unsetenv("QDRANT_URL")
+	os.Unsetenv("QDRANT_API_KEY")
+
+	r := newFakeK8sRunner()
+	ctx := context.Background()
+
+	err := r.Run(ctx, RunOptions{ProjectID: "proj-no-qdrant", RunID: "run-no-qdrant-1234"})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	jobs, _ := r.client.BatchV1().Jobs("test-ns").List(ctx, metav1.ListOptions{})
+	c := jobs.Items[0].Spec.Template.Spec.Containers[0]
+
+	for _, e := range c.Env {
+		if e.Name == "QDRANT_URL" || e.Name == "QDRANT_API_KEY" {
+			t.Errorf("expected %s to be absent from Job env, got value %q", e.Name, e.Value)
+		}
+	}
+}
+
 func TestKubernetesRunner_MultipleRuns(t *testing.T) {
 	r := newFakeK8sRunner()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Agent discovery Jobs were missing `QDRANT_URL` and `QDRANT_API_KEY` env vars. The agent's `initQdrant()` returned nil, the orchestrator's `vectorStore` was nil, and `phase_embed_index` was **silently skipped** on every run — leaving insights saved to MongoDB but never indexed in Qdrant.
- This broke the **Ask** feature and project-scoped **semantic search** for every project running under Kubernetes mode. Ask's RAG retrieval returned zero matches and fell through to the "No relevant insights found" fallback message.
- The API pod itself has `QDRANT_URL` set via the Kubernetes service — the value just wasn't being forwarded when spawning agent Jobs in `services/api/internal/runner/kubernetes.go`.

## Fix

Two lines added to the env-var propagation list in `buildJob`:

```go
{"QDRANT_URL", "QDRANT_URL"},
{"QDRANT_API_KEY", "QDRANT_API_KEY"},
```

Uses the same conditional-propagation pattern as the existing `SECRET_*` vars: only set on the Job if set on the API process. Unset → absent from Job spec (not empty string, which would look "configured" but broken).

## Tests

Added two unit tests in `runner_test.go` using the existing fake K8s client setup:

- `TestKubernetesRunner_Run_PropagatesQdrantEnv` — sets both env vars, runs a Job, asserts both land in the container spec with correct values.
- `TestKubernetesRunner_Run_OmitsQdrantEnvWhenUnset` — asserts they do NOT appear in the Job env when unset on the API process.

Both pass locally. Full `./internal/runner/...` suite green. `golangci-lint` clean.

## Impact

- Any existing discoveries on this or similar clusters already have un-embedded insights. Operators can run `decisionbox-api backfill-embeddings --project-id <id>` in the API pod to catch up. After this PR is deployed, new runs self-index as they complete.
- No config changes needed on the API side — `QDRANT_URL` is already set in the API pod env.
- Helm chart values (`values.yaml`) already document `QDRANT_URL` on the API deployment; no chart changes required.

## Test plan

- [x] `make test-go` (runner package) — passes
- [x] `make lint-go` (runner package) — 0 issues
- [x] Build clean on services/api
- [ ] Verify in internal-prod cluster after merge: next discovery run should see `QDRANT_URL` in its pod env (`kubectl describe pod discovery-*`), and insights should appear in Qdrant without manual backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)