### PR TITLE
fix(llm): respect LLM_TIMEOUT in Ollama provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,10 @@ services:
       # Values: debug | info | warn | error
       - LOG_LEVEL=info
 
+      # Timeout per LLM API call (inherited by agent subprocess when RUNNER_MODE=subprocess)
+      # Values: Go duration string (e.g., 30s, 2m, 600s)
+      - LLM_TIMEOUT=600s
+
     depends_on:
       mongodb:
         condition: service_healthy
@@ -211,7 +215,7 @@ services:
 
       # Timeout per LLM API call
       # Values: Go duration string (e.g., 30s, 2m, 120s)
-      - LLM_TIMEOUT=120s
+      - LLM_TIMEOUT=600s
 
       # Delay between consecutive LLM calls (rate limiting / cost control)
       # Values: milliseconds (0 = no delay)

--- a/providers/llm/ollama/provider.go
+++ b/providers/llm/ollama/provider.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,7 +37,12 @@ func init() {
 			return nil, fmt.Errorf("ollama: model is required")
 		}
 
-		return NewOllamaProvider(host, model)
+		timeoutSec, _ := strconv.Atoi(cfg["timeout_seconds"])
+		if timeoutSec == 0 {
+			timeoutSec = 300
+		}
+
+		return NewOllamaProvider(host, model, time.Duration(timeoutSec)*time.Second)
 	}, gollm.ProviderMeta{
 		Name:        "Ollama (Local)",
 		Description: "Run open-source models locally via Ollama",
@@ -60,13 +66,14 @@ type OllamaProvider struct {
 }
 
 // NewOllamaProvider creates a new Ollama LLM provider.
-func NewOllamaProvider(host, model string) (*OllamaProvider, error) {
+// timeout is the per-request HTTP client timeout; ctx cancellation still applies.
+func NewOllamaProvider(host, model string, timeout time.Duration) (*OllamaProvider, error) {
 	parsedURL, err := url.Parse(host)
 	if err != nil {
 		return nil, fmt.Errorf("ollama: invalid host URL: %w", err)
 	}
 
-	client := ollamaapi.NewClient(parsedURL, &http.Client{Timeout: 5 * time.Minute})
+	client := ollamaapi.NewClient(parsedURL, &http.Client{Timeout: timeout})
 
 	return &OllamaProvider{
 		client: client,

--- a/providers/llm/ollama/provider_test.go
+++ b/providers/llm/ollama/provider_test.go
@@ -3,6 +3,7 @@ package ollama
 import (
 	"context"
 	"testing"
+	"time"
 
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
 )
@@ -103,7 +104,7 @@ func TestOllamaProvider_DefaultHost(t *testing.T) {
 }
 
 func TestOllamaProvider_Validate_ServerDown(t *testing.T) {
-	p, err := NewOllamaProvider("http://localhost:1", "qwen2.5:0.5b")
+	p, err := NewOllamaProvider("http://localhost:1", "qwen2.5:0.5b", 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +114,7 @@ func TestOllamaProvider_Validate_ServerDown(t *testing.T) {
 }
 
 func TestNewOllamaProvider_InvalidURL(t *testing.T) {
-	_, err := NewOllamaProvider("://invalid", "model")
+	_, err := NewOllamaProvider("://invalid", "model", 5*time.Second)
 	if err == nil {
 		t.Error("should error on invalid URL")
 	}

--- a/services/agent/ollama_integration_test.go
+++ b/services/agent/ollama_integration_test.go
@@ -48,7 +48,7 @@ func setupOllama(t *testing.T) (gollm.Provider, func()) {
 	}
 
 	// Create provider
-	provider, err := ollamaprovider.NewOllamaProvider(endpoint, testOllamaModel)
+	provider, err := ollamaprovider.NewOllamaProvider(endpoint, testOllamaModel, 5*time.Minute)
 	if err != nil {
 		container.Terminate(ctx)
 		t.Fatalf("Failed to create Ollama provider: %v", err)


### PR DESCRIPTION
## Summary

- The Ollama provider hardcoded `http.Client.Timeout = 5 * time.Minute`, ignoring the `timeout_seconds` config the agent passes from `LLM_TIMEOUT`. Slow local models (e.g. `gemma4:31b` on CPU) time out at the 5m ceiling regardless of what `LLM_TIMEOUT` is set to.
- Fix: read `timeout_seconds` from the provider config and apply it to the HTTP client — matching the pattern already used by Claude, Bedrock, Vertex, and Azure providers. Default remains 300s when unset.
- Bumps `docker-compose` defaults: API service had no `LLM_TIMEOUT` (Go default applied), agent service was 120s. Both set to 600s for adequate headroom on slower providers without inflating latency on fast ones.

## Why

Observed in practice: running a discovery with Ollama + `gemma4:31b` locally, LLM calls took ~6.5 min each. The hardcoded 5m client timeout fired before `LLM_TIMEOUT=600s` could take effect, producing `Client.Timeout exceeded while awaiting headers` errors every step 1.

## Test plan

- [x] `go build` + `go vet` + `go test ./...` pass in `providers/llm/ollama`
- [x] Verified end-to-end: set `LLM_TIMEOUT=600s`, rebuilt API container, ran discovery with `gemma4:31b` locally — calls that previously failed at 5m now complete at ~6.5m
- [x] Plumbing verified: agent `config.go` reads `LLM_TIMEOUT` → `cfg.LLM.Timeout` → `agentserver.go` serializes to `timeout_seconds` → Ollama provider init applies it to `http.Client.Timeout`
- [ ] Reviewer: confirm no regression for short-prompt Ollama use cases (default 300s still applies when env unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)