### PR TITLE
feat(policy): Checker hook + reconciliation + run confirmer (Phase 1/2/4/7)

### DIFF
--- a/libs/go-common/embedding/provider.go
+++ b/libs/go-common/embedding/provider.go
@@ -8,6 +8,15 @@ import "context"
 type ProjectConfig struct {
 	Provider string `bson:"provider,omitempty" json:"provider,omitempty"`
 	Model    string `bson:"model,omitempty" json:"model,omitempty"`
+
+	// Credentials is the BYOK API key the project owner supplied via
+	// the UI. Persisted so the shape is BYOK-ready end-to-end, but
+	// ignored by the factory at runtime when an EMBEDDING_PROVIDER_API_KEY
+	// env override is present (DecisionBox Cloud injects the override
+	// today — paid plans will opt into BYOK by flipping
+	// byok_embedding_enabled, at which point the override is withheld
+	// and this field wins).
+	Credentials string `bson:"credentials,omitempty" json:"credentials,omitempty"`
 }
 
 // Provider abstracts text embedding operations.

--- a/libs/go-common/embedding/resolve.go
+++ b/libs/go-common/embedding/resolve.go
@@ -26,7 +26,7 @@ type ResolvedConfig struct {
 	Provider    string
 	Model       string
 	APIKey      string
-	Source      string // "env" | "project" | "mixed"
+	Source      string // "env" | "project" | "project-byok"
 }
 
 var ErrNoProvider = errors.New("embedding: no provider configured (neither project nor env)")

--- a/libs/go-common/embedding/resolve.go
+++ b/libs/go-common/embedding/resolve.go
@@ -61,14 +61,16 @@ func ResolveConfig(project ProjectConfig, byokEmbeddingEnabled bool) (*ResolvedC
 		}, nil
 	}
 
-	// Step 2: BYOK path — use project credentials if present.
+	// Step 2: BYOK path — use project credentials if present. Distinguish
+	// "env override was there but BYOK told us to ignore it" from
+	// "no env override at all" so observability can spot when a plan
+	// flipped to BYOK but the provisioner still leaked the env var.
 	if project.Provider == "" {
 		return nil, ErrNoProvider
 	}
 	source := "project"
 	if envKey != "" && byokEmbeddingEnabled {
-		// BYOK enabled: ignore the env key. Record intent in source.
-		source = "project"
+		source = "project-byok"
 	}
 	return &ResolvedConfig{
 		Provider: project.Provider,

--- a/libs/go-common/embedding/resolve.go
+++ b/libs/go-common/embedding/resolve.go
@@ -1,0 +1,79 @@
+package embedding
+
+import (
+	"errors"
+	"os"
+)
+
+// ResolveConfig computes the effective embedding provider/model/credentials
+// for a run, combining:
+//   - the project-persisted ProjectConfig (set by the UI),
+//   - optional EMBEDDING_PROVIDER / EMBEDDING_MODEL / EMBEDDING_PROVIDER_API_KEY
+//     environment overrides injected by the platform (DecisionBox Cloud
+//     injects these from its managed secrets today; self-hosted can
+//     set them via deployment config),
+//   - a byokEmbeddingEnabled flag that, when true, tells the resolver to
+//     prefer project-supplied credentials over the env override.
+//
+// In v1 byokEmbeddingEnabled is always false on every cloud plan, so the
+// env override always wins when present. Flipping the flag on a future
+// paid plan is the only change required to move that deployment to BYOK.
+//
+// Returns an error only when the effective provider ends up empty — that
+// is a misconfigured deployment, caller-visible so we do not silently
+// skip embeddings.
+type ResolvedConfig struct {
+	Provider    string
+	Model       string
+	APIKey      string
+	Source      string // "env" | "project" | "mixed"
+}
+
+var ErrNoProvider = errors.New("embedding: no provider configured (neither project nor env)")
+
+// ResolveConfig chooses the effective embedding provider/model/key.
+// Env vars win over project-supplied credentials, unless
+// byokEmbeddingEnabled is true, in which case the priority flips and
+// the project credentials are used.
+func ResolveConfig(project ProjectConfig, byokEmbeddingEnabled bool) (*ResolvedConfig, error) {
+	envProvider := os.Getenv("EMBEDDING_PROVIDER")
+	envModel := os.Getenv("EMBEDDING_MODEL")
+	envKey := os.Getenv("EMBEDDING_PROVIDER_API_KEY")
+
+	// Step 1: env override wins unless BYOK is explicitly enabled.
+	if envKey != "" && !byokEmbeddingEnabled {
+		provider := project.Provider
+		if envProvider != "" {
+			provider = envProvider
+		}
+		model := project.Model
+		if envModel != "" {
+			model = envModel
+		}
+		if provider == "" {
+			return nil, ErrNoProvider
+		}
+		return &ResolvedConfig{
+			Provider: provider,
+			Model:    model,
+			APIKey:   envKey,
+			Source:   "env",
+		}, nil
+	}
+
+	// Step 2: BYOK path — use project credentials if present.
+	if project.Provider == "" {
+		return nil, ErrNoProvider
+	}
+	source := "project"
+	if envKey != "" && byokEmbeddingEnabled {
+		// BYOK enabled: ignore the env key. Record intent in source.
+		source = "project"
+	}
+	return &ResolvedConfig{
+		Provider: project.Provider,
+		Model:    project.Model,
+		APIKey:   project.Credentials,
+		Source:   source,
+	}, nil
+}

--- a/libs/go-common/embedding/resolve_test.go
+++ b/libs/go-common/embedding/resolve_test.go
@@ -1,0 +1,102 @@
+package embedding
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveConfig_EnvWinsWhenBYOKDisabled(t *testing.T) {
+	t.Setenv("EMBEDDING_PROVIDER_API_KEY", "cloud-managed-key")
+	t.Setenv("EMBEDDING_PROVIDER", "openai")
+	t.Setenv("EMBEDDING_MODEL", "text-embedding-3-small")
+
+	r, err := ResolveConfig(ProjectConfig{
+		Provider:    "voyage",
+		Model:       "voyage-3",
+		Credentials: "project-key",
+	}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	if r.Source != "env" {
+		t.Errorf("Source = %q, want env", r.Source)
+	}
+	if r.APIKey != "cloud-managed-key" {
+		t.Errorf("APIKey = %q, want cloud-managed-key", r.APIKey)
+	}
+	if r.Provider != "openai" {
+		t.Errorf("Provider = %q, want openai (env override)", r.Provider)
+	}
+	if r.Model != "text-embedding-3-small" {
+		t.Errorf("Model = %q", r.Model)
+	}
+}
+
+func TestResolveConfig_EnvKeyOnly_KeepsProjectProviderAndModel(t *testing.T) {
+	t.Setenv("EMBEDDING_PROVIDER_API_KEY", "cloud-key")
+	// no EMBEDDING_PROVIDER, no EMBEDDING_MODEL
+
+	r, err := ResolveConfig(ProjectConfig{
+		Provider: "voyage",
+		Model:    "voyage-3",
+	}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.Provider != "voyage" || r.Model != "voyage-3" {
+		t.Errorf("provider/model not preserved: %+v", r)
+	}
+	if r.APIKey != "cloud-key" {
+		t.Errorf("APIKey = %q", r.APIKey)
+	}
+}
+
+func TestResolveConfig_BYOKEnabled_UsesProjectCreds(t *testing.T) {
+	t.Setenv("EMBEDDING_PROVIDER_API_KEY", "cloud-key")
+
+	r, err := ResolveConfig(ProjectConfig{
+		Provider:    "voyage",
+		Model:       "voyage-3",
+		Credentials: "project-key",
+	}, true)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.APIKey != "project-key" {
+		t.Errorf("APIKey = %q, want project-key (BYOK)", r.APIKey)
+	}
+	if r.Provider != "voyage" {
+		t.Errorf("Provider = %q", r.Provider)
+	}
+	if r.Source != "project" {
+		t.Errorf("Source = %q, want project", r.Source)
+	}
+}
+
+func TestResolveConfig_NoEnv_NoProject_Errors(t *testing.T) {
+	t.Setenv("EMBEDDING_PROVIDER_API_KEY", "")
+	_, err := ResolveConfig(ProjectConfig{}, false)
+	if !errors.Is(err, ErrNoProvider) {
+		t.Errorf("err = %v, want ErrNoProvider", err)
+	}
+}
+
+func TestResolveConfig_NoEnv_ProjectOnly(t *testing.T) {
+	t.Setenv("EMBEDDING_PROVIDER_API_KEY", "")
+
+	r, err := ResolveConfig(ProjectConfig{
+		Provider:    "voyage",
+		Model:       "voyage-3",
+		Credentials: "project-key",
+	}, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.Source != "project" {
+		t.Errorf("Source = %q", r.Source)
+	}
+	if r.APIKey != "project-key" {
+		t.Errorf("APIKey = %q", r.APIKey)
+	}
+}

--- a/libs/go-common/embedding/resolve_test.go
+++ b/libs/go-common/embedding/resolve_test.go
@@ -69,8 +69,8 @@ func TestResolveConfig_BYOKEnabled_UsesProjectCreds(t *testing.T) {
 	if r.Provider != "voyage" {
 		t.Errorf("Provider = %q", r.Provider)
 	}
-	if r.Source != "project" {
-		t.Errorf("Source = %q, want project", r.Source)
+	if r.Source != "project-byok" {
+		t.Errorf("Source = %q, want project-byok (env ignored because BYOK was on)", r.Source)
 	}
 }
 

--- a/libs/go-common/policy/checker.go
+++ b/libs/go-common/policy/checker.go
@@ -70,6 +70,23 @@ type Checker interface {
 	// affects the caller — errors are logged by the plugin. In v1 this
 	// is observe-only; a future fair-use cap will make it enforced.
 	ObserveLLMTokens(ctx context.Context, deploymentID string, event LLMUsageEvent)
+
+	// SyncCounters reconciles the tenant's persistent counters (current
+	// project count, current data-source count) with the control-plane
+	// deployment_usage document. Called periodically by a background
+	// goroutine on the community API side so drift introduced outside
+	// the reserve path (e.g., a manual Mongo import, a bug, a crash
+	// that lost a reservation) eventually converges. Non-blocking for
+	// the caller: errors are logged by the plugin, never propagated.
+	SyncCounters(ctx context.Context, deploymentID string, counts CounterSnapshot)
+}
+
+// CounterSnapshot is the ground-truth count the tenant reports to the
+// control plane during periodic reconciliation. Extended over time as
+// more persistent counters are added.
+type CounterSnapshot struct {
+	ProjectsCurrent    int
+	DataSourcesCurrent int
 }
 
 // Feature flag names used across the platform. Plugins must accept these

--- a/libs/go-common/policy/checker.go
+++ b/libs/go-common/policy/checker.go
@@ -89,18 +89,36 @@ type CounterSnapshot struct {
 	DataSourcesCurrent int
 }
 
-// Feature flag names used across the platform. Plugins must accept these
-// exact strings in FeatureEnabled.
+// Feature flag names used across the platform. These are the ONLY
+// valid wire strings for FeatureEnabled, /internal/.../features/{flag},
+// and any matching control-plane lookup. The control-plane handler
+// must accept every constant here and nothing else — any drift is
+// caught by AllFeatures below, which both sides import.
 const (
-	FeatureAudit           = "audit_enabled"
-	FeatureGovernance      = "governance_enabled"
-	FeatureCustomDomain    = "custom_domain_enabled"
-	FeatureSSOCustomerIdP  = "sso_customer_idp_enabled"
-	FeatureModelTraining   = "model_training_enabled"
-	FeatureRunScheduling   = "run_scheduling_enabled"
-	FeatureAPIAccess       = "api_access_enabled"
-	FeatureBYOKEmbedding   = "byok_embedding_enabled"
+	FeatureAudit          = "audit_enabled"
+	FeatureGovernance     = "governance_enabled"
+	FeatureCustomDomain   = "custom_domain_enabled"
+	FeatureSSOCustomerIdP = "sso_customer_idp_enabled"
+	FeatureModelTraining  = "model_training_enabled"
+	FeatureRunScheduling  = "run_scheduling_enabled"
+	FeatureAPIAccess      = "api_access_enabled"
+	FeatureBYOKEmbedding  = "byok_embedding_enabled"
 )
+
+// AllFeatures is the canonical, ordered list of wire flag names.
+// The control-plane handler asserts every entry maps to a plan-flag
+// field so a rename here without a matching handler update fails at
+// compile time on the control-plane side.
+var AllFeatures = []string{
+	FeatureAudit,
+	FeatureGovernance,
+	FeatureCustomDomain,
+	FeatureSSOCustomerIdP,
+	FeatureModelTraining,
+	FeatureRunScheduling,
+	FeatureAPIAccess,
+	FeatureBYOKEmbedding,
+}
 
 // Reservation kinds used in the /internal/deployments/{id}/usage/reserve/{kind}
 // URL path. The control plane dispatches on this string to the right

--- a/libs/go-common/policy/checker.go
+++ b/libs/go-common/policy/checker.go
@@ -1,0 +1,89 @@
+// Package policy is the OSS hook point for plan-gated features and usage
+// limits. It is neutral — no cloud-specific code lives here. Self-hosted
+// deployments use NoopChecker (allow everything). DecisionBox Cloud
+// registers a CloudChecker via init() in the cloud tenant image that
+// calls the control plane at runtime.
+//
+// Handlers call policy.GetChecker() at every chokepoint:
+//
+//	ck := policy.GetChecker()
+//	res, err := ck.CheckCreateProject(ctx, deploymentID, intent)
+//	if err != nil { /* translate PolicyError → HTTP 402/403 */ }
+//	defer ck.Release(ctx, res.ID) // released on error; superseded by caller on success
+//
+// The interface is future-ready for enforced LLM token caps — the
+// ObserveLLMTokens call today is observe-only, but upgrading to an
+// enforced reserve/confirm pair later requires only a cap field on
+// PlanLimits and flipping the endpoint. The wire shape is identical.
+package policy
+
+import "context"
+
+// Checker is the interface every community chokepoint calls. All methods
+// are safe to call concurrently. A typed *PolicyError is returned on
+// denial; any other error is infrastructural (the caller should surface
+// 500 or retry per its own policy).
+type Checker interface {
+	// CheckCreateProject reserves a slot against projects_per_deployment.
+	// Returns the reservation on success; the caller must Release it if
+	// the repo insert fails.
+	CheckCreateProject(ctx context.Context, deploymentID string, intent ProjectIntent) (*Reservation, error)
+
+	// CheckStartDiscoveryRun reserves a slot for a new discovery run.
+	// Internally enforces BOTH concurrent_runs_per_project AND
+	// discovery_runs_per_period in a single atomic check — both must
+	// pass or nothing increments.
+	CheckStartDiscoveryRun(ctx context.Context, deploymentID, projectID, runID string) (*Reservation, error)
+
+	// ConfirmDiscoveryRunEnded reports run completion so the concurrent
+	// counter decrements. The period counter stays consumed either way.
+	ConfirmDiscoveryRunEnded(ctx context.Context, reservationID string, outcome RunOutcome) error
+
+	// CheckAddDataSource reserves a slot against data_sources_per_deployment.
+	CheckAddDataSource(ctx context.Context, deploymentID string) (*Reservation, error)
+
+	// CheckLLMProviderAllowed rejects projects that try to configure a
+	// provider the plan does not permit. Feature-flag style (no reservation).
+	CheckLLMProviderAllowed(ctx context.Context, deploymentID, providerID string) error
+
+	// CheckRegisterUser records a newly-seen principal against the
+	// deployment's users_total cap. Called from three paths: portal
+	// invite, cloud-auth handoff, customer-IdP first-seen JWT.
+	CheckRegisterUser(ctx context.Context, deploymentID string, user UserIdentity) error
+
+	// FeatureEnabled gates handler entry for plan-flagged features
+	// (audit, governance, run scheduling, API access, model training).
+	FeatureEnabled(ctx context.Context, deploymentID, flag string) (bool, error)
+
+	// Release rolls back a reservation that was not consumed. Idempotent.
+	Release(ctx context.Context, reservationID string) error
+
+	// ObserveLLMTokens emits an observability event for a single LLM
+	// call. Non-blocking, fire-and-forget. Never returns an error that
+	// affects the caller — errors are logged by the plugin. In v1 this
+	// is observe-only; a future fair-use cap will make it enforced.
+	ObserveLLMTokens(ctx context.Context, deploymentID string, event LLMUsageEvent)
+}
+
+// Feature flag names used across the platform. Plugins must accept these
+// exact strings in FeatureEnabled.
+const (
+	FeatureAudit           = "audit_enabled"
+	FeatureGovernance      = "governance_enabled"
+	FeatureCustomDomain    = "custom_domain_enabled"
+	FeatureSSOCustomerIdP  = "sso_customer_idp_enabled"
+	FeatureModelTraining   = "model_training_enabled"
+	FeatureRunScheduling   = "run_scheduling_enabled"
+	FeatureAPIAccess       = "api_access_enabled"
+	FeatureBYOKEmbedding   = "byok_embedding_enabled"
+)
+
+// Reservation kinds used in the /internal/deployments/{id}/usage/reserve/{kind}
+// URL path. The control plane dispatches on this string to the right
+// counter field and cap lookup.
+const (
+	KindProjectCreate     = "project.create"
+	KindDiscoveryRunStart = "discovery-run.start"
+	KindDataSourceAdd     = "data-source.add"
+	KindUserRegister      = "user.register"
+)

--- a/libs/go-common/policy/checker.go
+++ b/libs/go-common/policy/checker.go
@@ -23,6 +23,13 @@ import "context"
 // are safe to call concurrently. A typed *PolicyError is returned on
 // denial; any other error is infrastructural (the caller should surface
 // 500 or retry per its own policy).
+//
+// The deploymentID parameter is the deployment whose policy applies.
+// Community handlers generally do not know a deployment ID (there is no
+// deployment concept in OSS) and should pass "". The cloud plugin
+// substitutes its configured DEPLOYMENT_ID env var in that case.
+// Control-plane-side library callers (e.g., portal memberships.Add)
+// pass an explicit deployment ID because they already resolve one.
 type Checker interface {
 	// CheckCreateProject reserves a slot against projects_per_deployment.
 	// Returns the reservation on success; the caller must Release it if

--- a/libs/go-common/policy/noop.go
+++ b/libs/go-common/policy/noop.go
@@ -1,0 +1,52 @@
+package policy
+
+import "context"
+
+// NoopChecker is the default Checker for self-hosted deployments. Every
+// Check* method returns nil (allow); FeatureEnabled returns true
+// (self-hosted users always have every feature); ObserveLLMTokens drops
+// its argument on the floor.
+//
+// Behavior is intentionally identical to the pre-policy codebase so the
+// OSS path is unchanged when no plugin registers.
+type NoopChecker struct{}
+
+// NewNoopChecker returns a NoopChecker. Exposed so callers can compare
+// identity in tests if they wish.
+func NewNoopChecker() *NoopChecker { return &NoopChecker{} }
+
+func (NoopChecker) CheckCreateProject(_ context.Context, deploymentID string, intent ProjectIntent) (*Reservation, error) {
+	return &Reservation{DeploymentID: deploymentID, Kind: KindProjectCreate, Subject: intent.ProjectID}, nil
+}
+
+func (NoopChecker) CheckStartDiscoveryRun(_ context.Context, deploymentID, projectID, runID string) (*Reservation, error) {
+	return &Reservation{DeploymentID: deploymentID, Kind: KindDiscoveryRunStart, Subject: runID}, nil
+}
+
+func (NoopChecker) ConfirmDiscoveryRunEnded(_ context.Context, _ string, _ RunOutcome) error {
+	return nil
+}
+
+func (NoopChecker) CheckAddDataSource(_ context.Context, deploymentID string) (*Reservation, error) {
+	return &Reservation{DeploymentID: deploymentID, Kind: KindDataSourceAdd}, nil
+}
+
+func (NoopChecker) CheckLLMProviderAllowed(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (NoopChecker) CheckRegisterUser(_ context.Context, _ string, _ UserIdentity) error {
+	return nil
+}
+
+func (NoopChecker) FeatureEnabled(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+
+func (NoopChecker) Release(_ context.Context, _ string) error {
+	return nil
+}
+
+func (NoopChecker) ObserveLLMTokens(_ context.Context, _ string, _ LLMUsageEvent) {
+	// drop
+}

--- a/libs/go-common/policy/noop.go
+++ b/libs/go-common/policy/noop.go
@@ -50,3 +50,7 @@ func (NoopChecker) Release(_ context.Context, _ string) error {
 func (NoopChecker) ObserveLLMTokens(_ context.Context, _ string, _ LLMUsageEvent) {
 	// drop
 }
+
+func (NoopChecker) SyncCounters(_ context.Context, _ string, _ CounterSnapshot) {
+	// drop
+}

--- a/libs/go-common/policy/policy_test.go
+++ b/libs/go-common/policy/policy_test.go
@@ -1,0 +1,222 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func resetRegistry() {
+	registryMu.Lock()
+	registeredChecker = nil
+	registryMu.Unlock()
+}
+
+func TestGetChecker_DefaultIsNoop(t *testing.T) {
+	resetRegistry()
+	c := GetChecker()
+	if c == nil {
+		t.Fatal("GetChecker returned nil")
+	}
+	if _, ok := c.(NoopChecker); !ok {
+		t.Errorf("default checker = %T, want NoopChecker", c)
+	}
+}
+
+func TestRegisterChecker_OverridesDefault(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	custom := &fakeChecker{}
+	RegisterChecker(custom)
+
+	c := GetChecker()
+	if c != custom {
+		t.Errorf("GetChecker() = %v, want registered custom", c)
+	}
+}
+
+func TestNoopChecker_AllowsEverything(t *testing.T) {
+	resetRegistry()
+	c := GetChecker()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"CheckCreateProject", func() error {
+			_, err := c.CheckCreateProject(ctx, "dep1", ProjectIntent{ProjectID: "p1"})
+			return err
+		}},
+		{"CheckStartDiscoveryRun", func() error {
+			_, err := c.CheckStartDiscoveryRun(ctx, "dep1", "p1", "r1")
+			return err
+		}},
+		{"ConfirmDiscoveryRunEnded", func() error {
+			return c.ConfirmDiscoveryRunEnded(ctx, "res1", RunOutcome{Status: "success"})
+		}},
+		{"CheckAddDataSource", func() error {
+			_, err := c.CheckAddDataSource(ctx, "dep1")
+			return err
+		}},
+		{"CheckLLMProviderAllowed", func() error {
+			return c.CheckLLMProviderAllowed(ctx, "dep1", "anything")
+		}},
+		{"CheckRegisterUser", func() error {
+			return c.CheckRegisterUser(ctx, "dep1", UserIdentity{PrincipalSub: "s"})
+		}},
+		{"Release", func() error {
+			return c.Release(ctx, "res1")
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); err != nil {
+				t.Errorf("noop %s returned %v, want nil", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestNoopChecker_FeatureEnabled_True(t *testing.T) {
+	resetRegistry()
+	c := GetChecker()
+	ok, err := c.FeatureEnabled(context.Background(), "dep1", FeatureAudit)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !ok {
+		t.Error("NoopChecker.FeatureEnabled should return true")
+	}
+}
+
+func TestNoopChecker_ObserveLLMTokens_IsNoOp(t *testing.T) {
+	resetRegistry()
+	c := GetChecker()
+	// Must not panic, must not block, must return immediately.
+	done := make(chan struct{})
+	go func() {
+		c.ObserveLLMTokens(context.Background(), "dep1", LLMUsageEvent{
+			Provider:   "claude",
+			Model:      "claude-opus-4-7",
+			InputTokens: 100,
+			OutputTokens: 50,
+			OccurredAt: time.Now(),
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("ObserveLLMTokens did not return quickly")
+	}
+}
+
+func TestNoopChecker_CreateReservationShape(t *testing.T) {
+	resetRegistry()
+	c := GetChecker()
+
+	res, err := c.CheckCreateProject(context.Background(), "dep42", ProjectIntent{ProjectID: "proj7"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil reservation")
+	}
+	if res.DeploymentID != "dep42" {
+		t.Errorf("DeploymentID = %q, want dep42", res.DeploymentID)
+	}
+	if res.Kind != KindProjectCreate {
+		t.Errorf("Kind = %q, want %q", res.Kind, KindProjectCreate)
+	}
+	if res.Subject != "proj7" {
+		t.Errorf("Subject = %q, want proj7", res.Subject)
+	}
+}
+
+func TestPolicyError_LimitMessage(t *testing.T) {
+	e := &PolicyError{Kind: "limit", Limit: "projects_per_deployment", Current: 1, Max: 1, PlanID: "starter_t1"}
+	msg := e.Error()
+	if !strings.Contains(msg, "starter_t1") {
+		t.Errorf("error missing plan id: %q", msg)
+	}
+	if !strings.Contains(msg, "projects_per_deployment") {
+		t.Errorf("error missing limit name: %q", msg)
+	}
+	if !strings.Contains(msg, "1/1") {
+		t.Errorf("error missing counter/max: %q", msg)
+	}
+	if !e.IsLimit() {
+		t.Error("IsLimit() = false, want true")
+	}
+	if e.IsFeature() {
+		t.Error("IsFeature() = true, want false")
+	}
+}
+
+func TestPolicyError_FeatureMessage(t *testing.T) {
+	e := &PolicyError{Kind: "feature", Feature: "audit_enabled", PlanID: "starter_t1"}
+	msg := e.Error()
+	if !strings.Contains(msg, "audit_enabled") {
+		t.Errorf("error missing feature name: %q", msg)
+	}
+	if !e.IsFeature() {
+		t.Error("IsFeature() = false, want true")
+	}
+}
+
+func TestPolicyError_ProviderAllowedMessage(t *testing.T) {
+	e := &PolicyError{Kind: "feature", Feature: "llm_provider", PlanID: "starter_t1", Allowed: []string{"claude", "openai"}}
+	msg := e.Error()
+	if !strings.Contains(msg, "claude") {
+		t.Errorf("error missing allowed list: %q", msg)
+	}
+}
+
+func TestPolicyError_ExplicitMessageWins(t *testing.T) {
+	e := &PolicyError{Kind: "limit", Message: "custom reason"}
+	if e.Error() != "custom reason" {
+		t.Errorf("Error() = %q, want %q", e.Error(), "custom reason")
+	}
+}
+
+func TestPolicyError_AsUnwrap(t *testing.T) {
+	var e error = &PolicyError{Kind: "limit", Limit: "projects_per_deployment", Current: 1, Max: 1}
+	var pe *PolicyError
+	if !errors.As(e, &pe) {
+		t.Fatal("errors.As should succeed on *PolicyError")
+	}
+	if pe.Limit != "projects_per_deployment" {
+		t.Errorf("Limit = %q", pe.Limit)
+	}
+}
+
+func TestRegisterChecker_ConcurrentSafe(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			RegisterChecker(&fakeChecker{})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = GetChecker()
+		}()
+	}
+	wg.Wait()
+
+	// No assertion beyond "doesn't race / doesn't deadlock".
+}
+
+// --- helpers ---
+
+type fakeChecker struct{ NoopChecker }

--- a/libs/go-common/policy/policy_test.go
+++ b/libs/go-common/policy/policy_test.go
@@ -95,6 +95,13 @@ func TestNoopChecker_FeatureEnabled_True(t *testing.T) {
 	}
 }
 
+func TestNoopChecker_SyncCounters_IsNoOp(t *testing.T) {
+	resetRegistry()
+	c := GetChecker()
+	// Must not panic; must return immediately; must not block.
+	c.SyncCounters(context.Background(), "dep1", CounterSnapshot{ProjectsCurrent: 5, DataSourcesCurrent: 3})
+}
+
 func TestNoopChecker_ObserveLLMTokens_IsNoOp(t *testing.T) {
 	resetRegistry()
 	c := GetChecker()

--- a/libs/go-common/policy/registry.go
+++ b/libs/go-common/policy/registry.go
@@ -1,0 +1,28 @@
+package policy
+
+import "sync"
+
+var (
+	registryMu         sync.RWMutex
+	registeredChecker  Checker
+)
+
+// RegisterChecker registers a Checker plugin. Typically called from
+// init() inside the cloud tenant's policy-plugin module. Self-hosted
+// deployments do not call this and use NoopChecker via GetChecker.
+func RegisterChecker(c Checker) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registeredChecker = c
+}
+
+// GetChecker returns the registered Checker, or NoopChecker if none is
+// registered. Never returns nil — callers can always safely dereference.
+func GetChecker() Checker {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	if registeredChecker != nil {
+		return registeredChecker
+	}
+	return NoopChecker{}
+}

--- a/libs/go-common/policy/registry.go
+++ b/libs/go-common/policy/registry.go
@@ -26,3 +26,13 @@ func GetChecker() Checker {
 	}
 	return NoopChecker{}
 }
+
+// HasRegisteredChecker reports whether a non-default Checker has been
+// registered. Server bootstrap uses this to skip background goroutines
+// (counter reconciliation, post-completion confirmer) on self-hosted
+// deployments where the Noop drops every call anyway.
+func HasRegisteredChecker() bool {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return registeredChecker != nil
+}

--- a/libs/go-common/policy/types.go
+++ b/libs/go-common/policy/types.go
@@ -22,6 +22,12 @@ type Reservation struct {
 // ProjectIntent is the policy-relevant subset of a project at create time.
 // It is decoupled from the full project model so the policy hook does not
 // depend on the community project schema.
+//
+// ProjectID may be empty: the community ProjectsHandler calls the Checker
+// before the repo assigns a Mongo ObjectID, so plugins must not rely on
+// ProjectID as a stable identifier at create time (it is provided when
+// the client supplies one, and as a human-readable label otherwise).
+// Idempotency should key on the Reservation id the Checker returns.
 type ProjectIntent struct {
 	ProjectID   string
 	Name        string

--- a/libs/go-common/policy/types.go
+++ b/libs/go-common/policy/types.go
@@ -1,0 +1,97 @@
+package policy
+
+import (
+	"fmt"
+	"time"
+)
+
+// Reservation is the handle a tenant holds after a successful reserve call.
+// The reservation must be either confirmed (work succeeded, increment is
+// permanent) or released (work failed, counter rolls back). An abandoned
+// reservation is eventually swept by the control plane after ExpiresAt.
+type Reservation struct {
+	ID             string    `json:"reservation_id"`
+	DeploymentID   string    `json:"deployment_id"`
+	Kind           string    `json:"kind"`
+	Subject        string    `json:"subject,omitempty"`
+	CounterCurrent int       `json:"counter_current"`
+	CounterMax     int       `json:"counter_max"`
+	ExpiresAt      time.Time `json:"expires_at"`
+}
+
+// ProjectIntent is the policy-relevant subset of a project at create time.
+// It is decoupled from the full project model so the policy hook does not
+// depend on the community project schema.
+type ProjectIntent struct {
+	ProjectID   string
+	Name        string
+	LLMProvider string
+}
+
+// RunOutcome reports how a discovery run ended, so the control plane can
+// record it (success/failure metrics, reservation consumed or released).
+type RunOutcome struct {
+	Status     string // "success" | "failure" | "cancelled"
+	StartedAt  time.Time
+	EndedAt    time.Time
+	Error      string
+}
+
+// UserIdentity is the identity presented at a tenant login that must be
+// counted toward the deployment's users_total cap.
+type UserIdentity struct {
+	PrincipalSub string // Auth0 sub or customer-IdP sub
+	Email        string
+	Source       string // "portal" | "cloud-auth" | "customer-idp"
+}
+
+// LLMUsageEvent is a single LLM call's observability record. Emitted by the
+// agent's LLM wrapper after every call (success or failure). In v1 the
+// control plane records tokens for monitoring only — never enforces a cap.
+type LLMUsageEvent struct {
+	ProjectID    string    `json:"project_id"`
+	RunID        string    `json:"run_id,omitempty"`
+	Provider     string    `json:"provider"`
+	Model        string    `json:"model"`
+	InputTokens  int       `json:"input_tokens"`
+	OutputTokens int       `json:"output_tokens"`
+	LatencyMs    int       `json:"latency_ms"`
+	OccurredAt   time.Time `json:"occurred_at"`
+}
+
+// PolicyError is the typed error returned by every Check* method when the
+// action is denied. Handlers unwrap this with errors.As and translate the
+// fields into the 402/403 JSON body.
+type PolicyError struct {
+	Kind     string // "limit" (counted cap reached) or "feature" (flag off / provider disallowed)
+	Limit    string // e.g. "projects_per_deployment"
+	Feature  string // e.g. "audit_enabled" or "llm_provider"
+	Current  int    // current counter value (limit errors only)
+	Max      int    // cap (limit errors only)
+	PlanID   string // plan slug for the deployment at error time
+	Allowed  []string // for provider-allow-list denials
+	Message  string
+}
+
+func (e *PolicyError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	switch e.Kind {
+	case "limit":
+		return fmt.Sprintf("plan %s: %s limit reached (%d/%d)", e.PlanID, e.Limit, e.Current, e.Max)
+	case "feature":
+		if e.Feature == "llm_provider" && len(e.Allowed) > 0 {
+			return fmt.Sprintf("plan %s: llm provider not allowed (allowed: %v)", e.PlanID, e.Allowed)
+		}
+		return fmt.Sprintf("plan %s: feature %s not enabled", e.PlanID, e.Feature)
+	default:
+		return fmt.Sprintf("plan %s: policy denied", e.PlanID)
+	}
+}
+
+// IsLimit reports whether the error was a counted-cap denial (HTTP 402).
+func (e *PolicyError) IsLimit() bool { return e.Kind == "limit" }
+
+// IsFeature reports whether the error was a feature-flag denial (HTTP 403).
+func (e *PolicyError) IsFeature() bool { return e.Kind == "feature" }

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -6,6 +6,7 @@ package agentserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -259,34 +260,51 @@ func initQdrant(ctx context.Context, cfg *config.Config) (vectorstore.Provider, 
 }
 
 func initEmbeddingProvider(ctx context.Context, project *models.Project, secretProvider gosecrets.Provider, projectID string) (goembedding.Provider, error) {
-	if project.Embedding.Provider == "" {
-		applog.Info("Embedding provider not configured — Phase 9 will skip embedding")
-		return nil, nil
+	// When BYOK_EMBEDDING_ENABLED is false, EMBEDDING_PROVIDER_API_KEY
+	// from the environment wins over project-supplied credentials.
+	// Setting the flag to true flips the priority so project credentials
+	// take precedence.
+	byok := os.Getenv("BYOK_EMBEDDING_ENABLED") == "true"
+
+	// Fill project.Credentials from the secret provider when the project
+	// does not already carry a UI-supplied key (the UI writes credentials
+	// directly into project.Embedding.Credentials; older deployments
+	// stored the key in the secret provider under "embedding-api-key").
+	if project.Embedding.Credentials == "" {
+		key, err := secretProvider.Get(ctx, projectID, "embedding-api-key")
+		if err == nil && key != "" {
+			project.Embedding.Credentials = key
+			applog.Info("Embedding API key loaded from secret provider")
+		} else if err != nil && err != gosecrets.ErrNotFound {
+			applog.WithError(err).Warn("Failed to read embedding API key from secret provider")
+		}
 	}
 
-	apiKey := ""
-	key, err := secretProvider.Get(ctx, projectID, "embedding-api-key")
-	if err == nil && key != "" {
-		apiKey = key
-		applog.Info("Embedding API key loaded from secret provider")
-	} else if err != nil && err != gosecrets.ErrNotFound {
-		applog.WithError(err).Warn("Failed to read embedding API key from secret provider")
+	resolved, err := goembedding.ResolveConfig(project.Embedding, byok)
+	if err != nil {
+		if errors.Is(err, goembedding.ErrNoProvider) {
+			applog.Info("Embedding provider not configured — Phase 9 will skip embedding")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to resolve embedding config: %w", err)
 	}
 
 	embCfg := goembedding.ProviderConfig{
-		"api_key": apiKey,
-		"model":   project.Embedding.Model,
+		"api_key": resolved.APIKey,
+		"model":   resolved.Model,
 	}
 
-	provider, err := goembedding.NewProvider(project.Embedding.Provider, embCfg)
+	provider, err := goembedding.NewProvider(resolved.Provider, embCfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create embedding provider (%s): %w", project.Embedding.Provider, err)
+		return nil, fmt.Errorf("failed to create embedding provider (%s): %w", resolved.Provider, err)
 	}
 
 	applog.WithFields(applog.Fields{
-		"provider": project.Embedding.Provider,
-		"model":    project.Embedding.Model,
-		"dims":     provider.Dimensions(),
+		"provider":        resolved.Provider,
+		"model":           resolved.Model,
+		"dims":            provider.Dimensions(),
+		"credential_src":  resolved.Source,
+		"byok_enabled":    byok,
 	}).Info("Embedding provider initialized")
 
 	return provider, nil
@@ -511,6 +529,7 @@ func runDiscovery(cfg *config.Config, projectID string, runID string, selectedAr
 	if err != nil {
 		return fmt.Errorf("failed to create AI client: %w", err)
 	}
+	aiClient.SetProvenance(projectID, runID, project.LLM.Provider)
 	if testMode {
 		aiClient.SetTestMode(true)
 	}

--- a/services/agent/internal/ai/client.go
+++ b/services/agent/internal/ai/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
+	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/debug"
 	logger "github.com/decisionbox-io/decisionbox/services/agent/internal/log"
 )
@@ -15,7 +16,10 @@ import (
 // Client provides LLM operations for the discovery agent.
 type Client struct {
 	provider     gollm.Provider
+	providerName string
 	model        string
+	projectID    string
+	runID        string
 	debugLogger  *debug.Logger
 	testMode     bool
 	promptCount  int
@@ -31,6 +35,16 @@ func New(provider gollm.Provider, model string) (*Client, error) {
 		provider: provider,
 		model:    model,
 	}, nil
+}
+
+// SetProvenance records the project/run/provider that will be attached
+// to each LLM observability event emitted from this client. Callers
+// that do not set this still get structured logs but the control-plane
+// attribution falls back to empty values.
+func (c *Client) SetProvenance(projectID, runID, providerName string) {
+	c.projectID = projectID
+	c.runID = runID
+	c.providerName = providerName
 }
 
 // ChatResult holds the full result of an LLM call (for storage/fine-tuning).
@@ -83,6 +97,7 @@ func (c *Client) CreateMessage(ctx context.Context, messages []gollm.Message, sy
 	}).Debug("Sending LLM request")
 
 	resp, err := c.provider.Chat(ctx, req)
+	latencyMs := time.Since(startTime).Milliseconds()
 
 	promptContent := ""
 	for _, msg := range messages {
@@ -90,10 +105,13 @@ func (c *Client) CreateMessage(ctx context.Context, messages []gollm.Message, sy
 	}
 
 	if err != nil {
+		// Observability: record the failed call. Provider may have
+		// returned partial usage even on error; report what we have.
+		c.emitLLMUsage(ctx, 0, 0, latencyMs, err)
 		if c.debugLogger != nil {
 			c.debugLogger.LogClaude(ctx, c.currentStep, c.currentPhase, c.model,
 				systemPrompt, promptContent, "", 0, 0,
-				time.Since(startTime).Milliseconds(), err)
+				latencyMs, err)
 		}
 		return nil, err
 	}
@@ -104,14 +122,52 @@ func (c *Client) CreateMessage(ctx context.Context, messages []gollm.Message, sy
 		"stop_reason":   resp.StopReason,
 	}).Debug("LLM response received")
 
+	c.emitLLMUsage(ctx, resp.Usage.InputTokens, resp.Usage.OutputTokens, latencyMs, nil)
+
 	if c.debugLogger != nil {
 		c.debugLogger.LogClaude(ctx, c.currentStep, c.currentPhase, c.model,
 			systemPrompt, promptContent, resp.Content,
 			resp.Usage.InputTokens, resp.Usage.OutputTokens,
-			time.Since(startTime).Milliseconds(), nil)
+			latencyMs, nil)
 	}
 
 	return resp, nil
+}
+
+// emitLLMUsage is the single observability sink for every LLM call.
+// Writes a structured log event (always, self-hosted and cloud alike)
+// and fires the policy ObserveLLMTokens hook (a no-op on self-hosted
+// via the Noop checker; on cloud, the policy plugin batches events
+// and flushes to the control plane).
+func (c *Client) emitLLMUsage(ctx context.Context, inTok, outTok int, latencyMs int64, callErr error) {
+	fields := logger.Fields{
+		"provider":      c.providerName,
+		"model":         c.model,
+		"project_id":    c.projectID,
+		"run_id":        c.runID,
+		"input_tokens":  inTok,
+		"output_tokens": outTok,
+		"latency_ms":    latencyMs,
+		"phase":         c.currentPhase,
+		"step":          c.currentStep,
+	}
+	if callErr != nil {
+		fields["error"] = callErr.Error()
+		logger.WithFields(fields).Warn("LLM call failed")
+	} else {
+		logger.WithFields(fields).Info("LLM call usage")
+	}
+
+	policy.GetChecker().ObserveLLMTokens(ctx, "", policy.LLMUsageEvent{
+		ProjectID:    c.projectID,
+		RunID:        c.runID,
+		Provider:     c.providerName,
+		Model:        c.model,
+		InputTokens:  inTok,
+		OutputTokens: outTok,
+		LatencyMs:    int(latencyMs),
+		OccurredAt:   time.Now().UTC(),
+	})
 }
 
 // ExtractText returns the text content from a response.

--- a/services/agent/internal/ai/client.go
+++ b/services/agent/internal/ai/client.go
@@ -25,6 +25,13 @@ type Client struct {
 	promptCount  int
 	currentStep  int
 	currentPhase string
+
+	// policyChecker is captured once per Client so the hot LLM path
+	// does not re-acquire the policy registry RWMutex on every call.
+	// Nil until the first emitLLMUsage call — lazy init avoids a
+	// package-init ordering problem with the cloud policy plugin
+	// which registers itself in its own init().
+	policyChecker policy.Checker
 }
 
 // New creates a new AI client backed by an llm.Provider.
@@ -41,10 +48,14 @@ func New(provider gollm.Provider, model string) (*Client, error) {
 // to each LLM observability event emitted from this client. Callers
 // that do not set this still get structured logs but the control-plane
 // attribution falls back to empty values.
+//
+// SetProvenance also primes the policy checker cache so the first
+// LLM call doesn't pay the registry lookup cost.
 func (c *Client) SetProvenance(projectID, runID, providerName string) {
 	c.projectID = projectID
 	c.runID = runID
 	c.providerName = providerName
+	c.policyChecker = policy.GetChecker()
 }
 
 // ChatResult holds the full result of an LLM call (for storage/fine-tuning).
@@ -158,7 +169,11 @@ func (c *Client) emitLLMUsage(ctx context.Context, inTok, outTok int, latencyMs 
 		logger.WithFields(fields).Info("LLM call usage")
 	}
 
-	policy.GetChecker().ObserveLLMTokens(ctx, "", policy.LLMUsageEvent{
+	checker := c.policyChecker
+	if checker == nil {
+		checker = policy.GetChecker()
+	}
+	checker.ObserveLLMTokens(ctx, "", policy.LLMUsageEvent{
 		ProjectID:    c.projectID,
 		RunID:        c.runID,
 		Provider:     c.providerName,

--- a/services/api/database/database.go
+++ b/services/api/database/database.go
@@ -140,6 +140,29 @@ func (r *ProjectRepository) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
+// Count returns the number of projects in the collection. Used by the
+// cloud policy plugin's reconciliation loop to report ground-truth
+// tenant counts to the control plane.
+func (r *ProjectRepository) Count(ctx context.Context) (int, error) {
+	n, err := r.col.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return 0, fmt.Errorf("count projects: %w", err)
+	}
+	return int(n), nil
+}
+
+// CountWithWarehouse returns the number of projects that have a
+// configured warehouse — the data-source unit used by reconciliation.
+func (r *ProjectRepository) CountWithWarehouse(ctx context.Context) (int, error) {
+	n, err := r.col.CountDocuments(ctx, bson.M{
+		"warehouse.provider": bson.M{"$nin": []any{"", nil}},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count projects with warehouse: %w", err)
+	}
+	return int(n), nil
+}
+
 func (r *ProjectRepository) EnsureIndexes(ctx context.Context) error {
 	_, err := r.col.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{Keys: bson.D{{Key: "created_at", Value: -1}}},

--- a/services/api/database/interfaces.go
+++ b/services/api/database/interfaces.go
@@ -36,6 +36,8 @@ type RunRepo interface {
 	Fail(ctx context.Context, runID string, errMsg string) error
 	Cancel(ctx context.Context, runID string) error
 	SetPolicyReservationID(ctx context.Context, runID, reservationID string) error
+	ListTerminalWithReservation(ctx context.Context, limit int) ([]*models.DiscoveryRun, error)
+	ClearPolicyReservationID(ctx context.Context, runID string) error
 }
 
 // FeedbackRepo abstracts feedback operations for handler unit testing.

--- a/services/api/database/interfaces.go
+++ b/services/api/database/interfaces.go
@@ -33,6 +33,7 @@ type RunRepo interface {
 	GetRunningByProject(ctx context.Context, projectID string) (*models.DiscoveryRun, error)
 	Fail(ctx context.Context, runID string, errMsg string) error
 	Cancel(ctx context.Context, runID string) error
+	SetPolicyReservationID(ctx context.Context, runID, reservationID string) error
 }
 
 // FeedbackRepo abstracts feedback operations for handler unit testing.

--- a/services/api/database/interfaces.go
+++ b/services/api/database/interfaces.go
@@ -15,6 +15,8 @@ type ProjectRepo interface {
 	List(ctx context.Context, limit, offset int) ([]*models.Project, error)
 	Update(ctx context.Context, id string, p *models.Project) error
 	Delete(ctx context.Context, id string) error
+	Count(ctx context.Context) (int, error)
+	CountWithWarehouse(ctx context.Context) (int, error)
 }
 
 // DiscoveryRepo abstracts discovery read operations for handler unit testing.

--- a/services/api/database/run_repo.go
+++ b/services/api/database/run_repo.go
@@ -76,6 +76,22 @@ func (r *RunRepository) GetLatestByProject(ctx context.Context, projectID string
 	return &run, nil
 }
 
+// SetPolicyReservationID stores the opaque reservation handle returned
+// by the policy Checker when the run was triggered. Persisted so exit
+// paths outside the trigger request (cancel, crash sweeper, agent
+// completion callback) can resolve the reservation back to the control
+// plane without keeping request-scoped state.
+func (r *RunRepository) SetPolicyReservationID(ctx context.Context, runID, reservationID string) error {
+	oid, err := primitive.ObjectIDFromHex(runID)
+	if err != nil {
+		return fmt.Errorf("invalid run ID: %w", err)
+	}
+	_, err = r.col.UpdateByID(ctx, oid, bson.M{
+		"$set": bson.M{"policy_reservation_id": reservationID, "updated_at": time.Now()},
+	})
+	return err
+}
+
 // Fail marks a run as failed.
 func (r *RunRepository) Fail(ctx context.Context, runID string, errMsg string) error {
 	oid, err := primitive.ObjectIDFromHex(runID)

--- a/services/api/database/run_repo.go
+++ b/services/api/database/run_repo.go
@@ -76,6 +76,48 @@ func (r *RunRepository) GetLatestByProject(ctx context.Context, projectID string
 	return &run, nil
 }
 
+// ListTerminalWithReservation returns runs that have ended (succeeded,
+// failed, or cancelled) AND still carry a non-empty policy reservation.
+// Used by the post-completion confirmer goroutine so discovery runs
+// that the agent wrote as "completed" directly to Mongo still trigger
+// a Confirm on the policy Checker. The caller typically limits the
+// scan to a handful at a time.
+func (r *RunRepository) ListTerminalWithReservation(ctx context.Context, limit int) ([]*models.DiscoveryRun, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	filter := bson.M{
+		"status":                bson.M{"$in": []string{"completed", "failed", "cancelled"}},
+		"policy_reservation_id": bson.M{"$nin": []any{"", nil}},
+	}
+	opts := options.Find().SetLimit(int64(limit))
+	cursor, err := r.col.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list terminal runs with reservation: %w", err)
+	}
+	defer cursor.Close(ctx) //nolint:errcheck
+	var runs []*models.DiscoveryRun
+	if err := cursor.All(ctx, &runs); err != nil {
+		return nil, fmt.Errorf("decode terminal runs: %w", err)
+	}
+	return runs, nil
+}
+
+// ClearPolicyReservationID unsets the reservation handle on a run so
+// the post-completion confirmer does not re-process it on the next
+// scan. Called after a successful Confirm.
+func (r *RunRepository) ClearPolicyReservationID(ctx context.Context, runID string) error {
+	oid, err := primitive.ObjectIDFromHex(runID)
+	if err != nil {
+		return fmt.Errorf("invalid run ID: %w", err)
+	}
+	_, err = r.col.UpdateByID(ctx, oid, bson.M{
+		"$unset": bson.M{"policy_reservation_id": ""},
+		"$set":   bson.M{"updated_at": time.Now()},
+	})
+	return err
+}
+
 // SetPolicyReservationID stores the opaque reservation handle returned
 // by the policy Checker when the run was triggered. Persisted so exit
 // paths outside the trigger request (cancel, crash sweeper, agent

--- a/services/api/internal/handler/discoveries.go
+++ b/services/api/internal/handler/discoveries.go
@@ -218,6 +218,8 @@ func (h *DiscoveriesHandler) TriggerDiscovery(w http.ResponseWriter, r *http.Req
 		if reservationID != "" {
 			if relErr := ck.Release(r.Context(), reservationID); relErr != nil {
 				apilog.WithError(relErr).Warn("failed to release discovery-run reservation after agent spawn failed")
+			} else if err := h.runRepo.ClearPolicyReservationID(r.Context(), runID); err != nil {
+				apilog.WithError(err).Warn("released discovery-run reservation after agent spawn failed, but failed to clear persisted reservation id on run (post-completion confirmer will retry Confirm on an already-Released reservation until the doc TTLs)")
 			}
 		}
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to start agent: %s", runErr.Error()))

--- a/services/api/internal/handler/discoveries.go
+++ b/services/api/internal/handler/discoveries.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	apilog "github.com/decisionbox-io/decisionbox/services/api/internal/log"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/runner"
@@ -125,17 +126,6 @@ func (h *DiscoveriesHandler) TriggerDiscovery(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Check if there's already a running discovery
-	running, _ := h.runRepo.GetRunningByProject(r.Context(), projectID)
-	if running != nil {
-		writeJSON(w, http.StatusConflict, map[string]string{
-			"status":  "already_running",
-			"run_id":  running.ID,
-			"message": "A discovery is already running for this project",
-		})
-		return
-	}
-
 	// Parse optional request body
 	var body struct {
 		Areas    []string `json:"areas"`     // optional: run only these areas
@@ -143,11 +133,58 @@ func (h *DiscoveriesHandler) TriggerDiscovery(w http.ResponseWriter, r *http.Req
 	}
 	_ = decodeJSON(r, &body) // body is optional
 
-	// Create a run record
+	// Create a run record first — we need a stable runID for the policy
+	// reservation and the repo-level "already running" invariant is
+	// re-enforced here (Create only returns an ID; race is closed by
+	// the policy reservation on cloud and by the runRepo uniqueness on
+	// self-hosted).
 	runID, err := h.runRepo.Create(r.Context(), projectID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create run: "+err.Error())
 		return
+	}
+
+	// Plan-gate: concurrent-runs-per-project AND runs-per-period. The
+	// self-hosted NoopChecker allows everything; the cloud plugin
+	// atomically reserves both counters in a single round-trip. On
+	// self-hosted we also keep the repo-level "already running" check
+	// below so the OSS UX does not regress.
+	ck := policy.GetChecker()
+	if _, isNoop := ck.(policy.NoopChecker); isNoop {
+		running, _ := h.runRepo.GetRunningByProject(r.Context(), projectID)
+		if running != nil && running.ID != runID {
+			if err := h.runRepo.Cancel(r.Context(), runID); err != nil {
+				apilog.WithError(err).Warn("failed to clean up runID reserved before already-running check")
+			}
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"status":  "already_running",
+				"run_id":  running.ID,
+				"message": "A discovery is already running for this project",
+			})
+			return
+		}
+	}
+
+	res, err := ck.CheckStartDiscoveryRun(r.Context(), "", projectID, runID)
+	if err != nil {
+		if failErr := h.runRepo.Fail(r.Context(), runID, "plan denied: "+err.Error()); failErr != nil {
+			apilog.WithError(failErr).Warn("failed to mark policy-denied run as failed")
+		}
+		if writePolicyError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "policy check failed: "+err.Error())
+		return
+	}
+
+	reservationID := ""
+	if res != nil {
+		reservationID = res.ID
+	}
+	if reservationID != "" {
+		if err := h.runRepo.SetPolicyReservationID(r.Context(), runID, reservationID); err != nil {
+			apilog.WithError(err).Warn("failed to persist policy reservation id on run; cancel/crash recovery will fall through to sweeper")
+		}
 	}
 
 	// Spawn the agent via the configured runner (subprocess or K8s Job)
@@ -163,11 +200,25 @@ func (h *DiscoveriesHandler) TriggerDiscovery(w http.ResponseWriter, r *http.Req
 			if err := h.runRepo.Fail(context.Background(), failedRunID, errMsg); err != nil {
 				apilog.WithError(err).Error("failed to mark run as failed")
 			}
+			if reservationID != "" {
+				if err := policy.GetChecker().ConfirmDiscoveryRunEnded(context.Background(), reservationID, policy.RunOutcome{
+					Status:  "failure",
+					EndedAt: time.Now().UTC(),
+					Error:   errMsg,
+				}); err != nil {
+					apilog.WithError(err).Warn("failed to confirm run ended to policy checker")
+				}
+			}
 		},
 	})
 	if runErr != nil {
 		if err := h.runRepo.Fail(r.Context(), runID, "failed to start: "+runErr.Error()); err != nil {
 			apilog.WithError(err).Error("failed to mark run as failed")
+		}
+		if reservationID != "" {
+			if relErr := ck.Release(r.Context(), reservationID); relErr != nil {
+				apilog.WithError(relErr).Warn("failed to release discovery-run reservation after agent spawn failed")
+			}
 		}
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to start agent: %s", runErr.Error()))
 		return
@@ -261,6 +312,19 @@ func (h *DiscoveriesHandler) CancelRun(w http.ResponseWriter, r *http.Request) {
 	// Mark as cancelled in MongoDB
 	if err := h.runRepo.Cancel(r.Context(), runID); err != nil {
 		apilog.WithError(err).Warn("failed to cancel run in database")
+	}
+
+	// Confirm the policy reservation ended. We call Confirm rather than
+	// Release so the period counter (already incremented when the run
+	// started) stays consumed — cancellation does not refund the run
+	// budget. The concurrent-runs counter decrements. Noop is a no-op.
+	if run.PolicyReservationID != "" {
+		if err := policy.GetChecker().ConfirmDiscoveryRunEnded(r.Context(), run.PolicyReservationID, policy.RunOutcome{
+			Status:  "cancelled",
+			EndedAt: time.Now().UTC(),
+		}); err != nil {
+			apilog.WithError(err).Warn("failed to confirm cancelled run to policy checker")
+		}
 	}
 
 	apilog.WithField("run_id", runID).Info("Discovery run cancelled")

--- a/services/api/internal/handler/discoveries_policy_test.go
+++ b/services/api/internal/handler/discoveries_policy_test.go
@@ -1,0 +1,170 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
+	"github.com/decisionbox-io/decisionbox/services/api/internal/runner"
+	"github.com/decisionbox-io/decisionbox/services/api/models"
+)
+
+// quietRunner is a minimal runner.Runner that succeeds without spawning
+// anything. Used when we just want to exercise the policy hook path.
+type quietRunner struct{}
+
+func (quietRunner) Run(_ context.Context, _ runner.RunOptions) error { return nil }
+func (quietRunner) RunSync(_ context.Context, _ runner.RunSyncOptions) (*runner.RunSyncResult, error) {
+	return &runner.RunSyncResult{}, nil
+}
+func (quietRunner) Cancel(_ context.Context, _ string) error { return nil }
+
+// failingRunner simulates a runner that cannot spawn the agent.
+type failingRunner struct{ err error }
+
+func (f failingRunner) Run(_ context.Context, _ runner.RunOptions) error { return f.err }
+func (f failingRunner) RunSync(_ context.Context, _ runner.RunSyncOptions) (*runner.RunSyncResult, error) {
+	return nil, f.err
+}
+func (failingRunner) Cancel(_ context.Context, _ string) error { return nil }
+
+func newTriggerRequest(projectID string) *http.Request {
+	req := httptest.NewRequest("POST", "/api/v1/projects/"+projectID+"/discover", strings.NewReader(`{}`))
+	req.SetPathValue("id", projectID)
+	return req
+}
+
+func TestDiscoveriesHandler_Trigger_PolicyDeniesStart(t *testing.T) {
+	stub := &stubChecker{
+		startRunErr: &policy.PolicyError{
+			Kind: "limit", Limit: "concurrent_runs_per_project", Current: 2, Max: 2, PlanID: "pro_t1",
+		},
+	}
+	swapChecker(t, stub)
+
+	projRepo := newMockProjectRepo()
+	projRepo.projects["p1"] = &models.Project{ID: "p1"}
+	runRepo := newMockRunRepo()
+	discRepo := newMockDiscoveryRepo()
+	h := NewDiscoveriesHandler(discRepo, projRepo, runRepo, quietRunner{})
+
+	req := newTriggerRequest("p1")
+	w := httptest.NewRecorder()
+	h.TriggerDiscovery(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402", w.Code)
+	}
+	// Run record was created but immediately marked failed with policy-denied.
+	runRepo.mu.Lock()
+	defer runRepo.mu.Unlock()
+	if len(runRepo.runs) != 1 {
+		t.Fatalf("runs = %d", len(runRepo.runs))
+	}
+	for _, r := range runRepo.runs {
+		if r.Status != "failed" {
+			t.Errorf("policy-denied run status = %q, want failed", r.Status)
+		}
+	}
+}
+
+func TestDiscoveriesHandler_Trigger_RunnerFailure_ReleasesReservation(t *testing.T) {
+	stub := &stubChecker{}
+	swapChecker(t, stub)
+
+	projRepo := newMockProjectRepo()
+	projRepo.projects["p1"] = &models.Project{ID: "p1"}
+	runRepo := newMockRunRepo()
+	discRepo := newMockDiscoveryRepo()
+
+	spawn := &spawnFailError{msg: "spawn failed"}
+	h := NewDiscoveriesHandler(discRepo, projRepo, runRepo, failingRunner{err: spawn})
+
+	req := newTriggerRequest("p1")
+	w := httptest.NewRecorder()
+	h.TriggerDiscovery(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.releases) != 1 {
+		t.Errorf("want 1 Release call for the discovery-run reservation, got %v", stub.releases)
+	}
+}
+
+func TestDiscoveriesHandler_CancelRun_ConfirmsReservation(t *testing.T) {
+	stub := &stubChecker{}
+	swapChecker(t, stub)
+
+	projRepo := newMockProjectRepo()
+	runRepo := newMockRunRepo()
+	runRepo.addRun(&models.DiscoveryRun{
+		ID:                  "run-42",
+		ProjectID:           "p1",
+		Status:              "running",
+		PolicyReservationID: "res-run-42",
+	})
+	discRepo := newMockDiscoveryRepo()
+	h := NewDiscoveriesHandler(discRepo, projRepo, runRepo, quietRunner{})
+
+	req := httptest.NewRequest("DELETE", "/api/v1/runs/run-42", nil)
+	req.SetPathValue("runId", "run-42")
+	w := httptest.NewRecorder()
+	h.CancelRun(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.confirms) != 1 {
+		t.Fatalf("want 1 Confirm, got %d", len(stub.confirms))
+	}
+	if stub.confirms[0].Status != "cancelled" {
+		t.Errorf("Confirm outcome status = %q", stub.confirms[0].Status)
+	}
+}
+
+func TestDiscoveriesHandler_Trigger_LimitError_BodyIncludesStructuredFields(t *testing.T) {
+	stub := &stubChecker{
+		startRunErr: &policy.PolicyError{
+			Kind: "limit", Limit: "discovery_runs_per_period", Current: 10, Max: 10, PlanID: "free",
+		},
+	}
+	swapChecker(t, stub)
+
+	projRepo := newMockProjectRepo()
+	projRepo.projects["p1"] = &models.Project{ID: "p1"}
+	runRepo := newMockRunRepo()
+	discRepo := newMockDiscoveryRepo()
+	h := NewDiscoveriesHandler(discRepo, projRepo, runRepo, quietRunner{})
+
+	req := newTriggerRequest("p1")
+	w := httptest.NewRecorder()
+	h.TriggerDiscovery(w, req)
+
+	var resp APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("Data was not a map: %T", resp.Data)
+	}
+	if got := data["limit"]; got != "discovery_runs_per_period" {
+		t.Errorf("body.limit = %v", got)
+	}
+	if got := data["plan_id"]; got != "free" {
+		t.Errorf("body.plan_id = %v", got)
+	}
+}
+
+type spawnFailError struct{ msg string }
+
+func (e *spawnFailError) Error() string { return e.msg }

--- a/services/api/internal/handler/mock_test.go
+++ b/services/api/internal/handler/mock_test.go
@@ -365,6 +365,34 @@ func (m *mockRunRepo) SetPolicyReservationID(_ context.Context, runID, reservati
 	return nil
 }
 
+func (m *mockRunRepo) ListTerminalWithReservation(_ context.Context, limit int) ([]*models.DiscoveryRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*models.DiscoveryRun, 0, len(m.runs))
+	for _, r := range m.runs {
+		terminal := r.Status == "completed" || r.Status == "failed" || r.Status == "cancelled"
+		if terminal && r.PolicyReservationID != "" {
+			cp := *r
+			out = append(out, &cp)
+			if limit > 0 && len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *mockRunRepo) ClearPolicyReservationID(_ context.Context, runID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.runs[runID]
+	if !ok {
+		return fmt.Errorf("run not found: %s", runID)
+	}
+	r.PolicyReservationID = ""
+	return nil
+}
+
 // addRun inserts a run directly for testing.
 func (m *mockRunRepo) addRun(run *models.DiscoveryRun) {
 	m.mu.Lock()

--- a/services/api/internal/handler/mock_test.go
+++ b/services/api/internal/handler/mock_test.go
@@ -336,6 +336,17 @@ func (m *mockRunRepo) Cancel(_ context.Context, runID string) error {
 	return nil
 }
 
+func (m *mockRunRepo) SetPolicyReservationID(_ context.Context, runID, reservationID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.runs[runID]
+	if !ok {
+		return fmt.Errorf("run not found: %s", runID)
+	}
+	r.PolicyReservationID = reservationID
+	return nil
+}
+
 // addRun inserts a run directly for testing.
 func (m *mockRunRepo) addRun(run *models.DiscoveryRun) {
 	m.mu.Lock()

--- a/services/api/internal/handler/mock_test.go
+++ b/services/api/internal/handler/mock_test.go
@@ -122,6 +122,24 @@ func (m *mockProjectRepo) Delete(_ context.Context, id string) error {
 	return nil
 }
 
+func (m *mockProjectRepo) Count(_ context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.projects), nil
+}
+
+func (m *mockProjectRepo) CountWithWarehouse(_ context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, p := range m.projects {
+		if p.Warehouse.Provider != "" {
+			n++
+		}
+	}
+	return n, nil
+}
+
 // mockDiscoveryRepo implements database.DiscoveryRepo using an in-memory slice.
 type mockDiscoveryRepo struct {
 	mu          sync.Mutex

--- a/services/api/internal/handler/policy_errors.go
+++ b/services/api/internal/handler/policy_errors.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
+)
+
+// writePolicyError translates a *policy.PolicyError into the structured
+// JSON body the dashboard renders as "Upgrade to …" UX. If the error is
+// not a PolicyError, returns false so the caller can fall back to its
+// own generic handling. Limit denials become HTTP 402, feature denials
+// become HTTP 403.
+func writePolicyError(w http.ResponseWriter, err error) bool {
+	var pe *policy.PolicyError
+	if !errors.As(err, &pe) {
+		return false
+	}
+
+	status := http.StatusForbidden
+	if pe.IsLimit() {
+		status = http.StatusPaymentRequired
+	}
+
+	body := map[string]any{
+		"error": pe.Error(),
+		"code":  pe.Kind,
+	}
+	if pe.Limit != "" {
+		body["limit"] = pe.Limit
+	}
+	if pe.Feature != "" {
+		body["feature"] = pe.Feature
+	}
+	if pe.Max > 0 {
+		body["current"] = pe.Current
+		body["max"] = pe.Max
+	}
+	if pe.PlanID != "" {
+		body["plan_id"] = pe.PlanID
+	}
+	if len(pe.Allowed) > 0 {
+		body["allowed"] = pe.Allowed
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(APIResponse{Error: pe.Error(), Data: body})
+	return true
+}

--- a/services/api/internal/handler/projects.go
+++ b/services/api/internal/handler/projects.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/telemetry"
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	apilog "github.com/decisionbox-io/decisionbox/services/api/internal/log"
@@ -56,8 +57,64 @@ func (h *ProjectsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		SeedProjectPrompts(&p, pack)
 	}
 
+	// Plan-gate: provider allow-list. Self-hosted Noop permits everything.
+	ck := policy.GetChecker()
+	if err := ck.CheckLLMProviderAllowed(r.Context(), "", p.LLM.Provider); err != nil {
+		if writePolicyError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "policy check failed: "+err.Error())
+		return
+	}
+
+	// Plan-gate: projects-per-deployment. Reservation is consumed on a
+	// successful repo insert and released on failure.
+	res, err := ck.CheckCreateProject(r.Context(), "", policy.ProjectIntent{
+		ProjectID:   p.ID,
+		Name:        p.Name,
+		LLMProvider: p.LLM.Provider,
+	})
+	if err != nil {
+		if writePolicyError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "policy check failed: "+err.Error())
+		return
+	}
+
+	// Plan-gate: data-sources-per-deployment. A project today carries
+	// exactly one warehouse (the data-source unit), so adding a project
+	// that configures a warehouse is also adding a data source.
+	// Self-hosted Noop is a no-op.
+	var dsRes *policy.Reservation
+	if p.Warehouse.Provider != "" {
+		dsRes, err = ck.CheckAddDataSource(r.Context(), "")
+		if err != nil {
+			if res != nil {
+				if relErr := ck.Release(r.Context(), res.ID); relErr != nil {
+					apilog.WithError(relErr).Warn("failed to release project-create reservation after data-source denial")
+				}
+			}
+			if writePolicyError(w, err) {
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "policy check failed: "+err.Error())
+			return
+		}
+	}
+
 	if err := h.repo.Create(r.Context(), &p); err != nil {
 		apilog.WithError(err).Error("Failed to create project")
+		if res != nil {
+			if relErr := ck.Release(r.Context(), res.ID); relErr != nil {
+				apilog.WithError(relErr).Warn("failed to release project-create reservation after insert failure")
+			}
+		}
+		if dsRes != nil {
+			if relErr := ck.Release(r.Context(), dsRes.ID); relErr != nil {
+				apilog.WithError(relErr).Warn("failed to release data-source reservation after insert failure")
+			}
+		}
 		writeError(w, http.StatusInternalServerError, "failed to create project: "+err.Error())
 		return
 	}
@@ -130,6 +187,18 @@ func (h *ProjectsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if err := decodeJSON(r, &incoming); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
+	}
+
+	// Plan-gate: if the request changes the LLM provider, validate the
+	// new provider against the plan's allow-list before persisting.
+	if incoming.LLM.Provider != "" && incoming.LLM.Provider != existing.LLM.Provider {
+		if err := policy.GetChecker().CheckLLMProviderAllowed(r.Context(), "", incoming.LLM.Provider); err != nil {
+			if writePolicyError(w, err) {
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "policy check failed: "+err.Error())
+			return
+		}
 	}
 
 	// Merge: update only fields that are present in the request

--- a/services/api/internal/handler/projects_policy_test.go
+++ b/services/api/internal/handler/projects_policy_test.go
@@ -1,0 +1,206 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
+)
+
+// stubChecker is a test double for policy.Checker that records calls and
+// returns scripted decisions. Only the methods the handler touches are
+// fleshed out — the rest are no-ops.
+type stubChecker struct {
+	policy.NoopChecker
+
+	mu sync.Mutex
+
+	createErr error
+	createRes *policy.Reservation
+
+	llmProviderErr error
+
+	addDSErr error
+	addDSRes *policy.Reservation
+
+	releases []string
+
+	startRunErr error
+	startRunRes *policy.Reservation
+	confirms    []policy.RunOutcome
+
+	observeCalls atomic.Int64
+}
+
+func (s *stubChecker) CheckCreateProject(_ context.Context, _ string, _ policy.ProjectIntent) (*policy.Reservation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	if s.createRes != nil {
+		return s.createRes, nil
+	}
+	return &policy.Reservation{ID: "res-create-1"}, nil
+}
+
+func (s *stubChecker) CheckLLMProviderAllowed(_ context.Context, _ string, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.llmProviderErr
+}
+
+func (s *stubChecker) CheckAddDataSource(_ context.Context, _ string) (*policy.Reservation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.addDSErr != nil {
+		return nil, s.addDSErr
+	}
+	if s.addDSRes != nil {
+		return s.addDSRes, nil
+	}
+	return &policy.Reservation{ID: "res-ds-1"}, nil
+}
+
+func (s *stubChecker) CheckStartDiscoveryRun(_ context.Context, _ string, _ string, _ string) (*policy.Reservation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.startRunErr != nil {
+		return nil, s.startRunErr
+	}
+	if s.startRunRes != nil {
+		return s.startRunRes, nil
+	}
+	return &policy.Reservation{ID: "res-run-1"}, nil
+}
+
+func (s *stubChecker) ConfirmDiscoveryRunEnded(_ context.Context, _ string, outcome policy.RunOutcome) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.confirms = append(s.confirms, outcome)
+	return nil
+}
+
+func (s *stubChecker) Release(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.releases = append(s.releases, id)
+	return nil
+}
+
+func (s *stubChecker) ObserveLLMTokens(_ context.Context, _ string, _ policy.LLMUsageEvent) {
+	s.observeCalls.Add(1)
+}
+
+// swapChecker registers ck and returns a cleanup function that restores
+// the previous checker. Tests must defer the cleanup.
+func swapChecker(t *testing.T, ck policy.Checker) {
+	t.Helper()
+	policy.RegisterChecker(ck)
+	t.Cleanup(func() { policy.RegisterChecker(nil) })
+}
+
+func TestProjectsHandler_Create_LLMProviderDenied(t *testing.T) {
+	stub := &stubChecker{llmProviderErr: &policy.PolicyError{
+		Kind: "feature", Feature: "llm_provider", PlanID: "starter_t1", Allowed: []string{"claude", "openai"},
+	}}
+	swapChecker(t, stub)
+
+	repo := newMockProjectRepo()
+	h := NewProjectsHandler(repo, nil)
+
+	body := `{"name":"p","domain":"gaming","category":"match3","llm":{"provider":"bedrock"}}`
+	req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Create(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (feature denial)", w.Code)
+	}
+	var resp APIResponse
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if !strings.Contains(resp.Error, "llm provider not allowed") {
+		t.Errorf("error body = %q", resp.Error)
+	}
+	if len(repo.projects) != 0 {
+		t.Errorf("repo was called despite denial")
+	}
+}
+
+func TestProjectsHandler_Create_ProjectsCapReached(t *testing.T) {
+	stub := &stubChecker{createErr: &policy.PolicyError{
+		Kind: "limit", Limit: "projects_per_deployment", Current: 1, Max: 1, PlanID: "free",
+	}}
+	swapChecker(t, stub)
+
+	repo := newMockProjectRepo()
+	h := NewProjectsHandler(repo, nil)
+
+	body := `{"name":"p","domain":"gaming","category":"match3"}`
+	req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Create(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402 (limit denial)", w.Code)
+	}
+	if len(repo.projects) != 0 {
+		t.Errorf("repo created a project despite cap")
+	}
+}
+
+func TestProjectsHandler_Create_ReleaseOnRepoFailure(t *testing.T) {
+	stub := &stubChecker{}
+	swapChecker(t, stub)
+
+	repo := newMockProjectRepo()
+	repo.createErr = errInject
+	h := NewProjectsHandler(repo, nil)
+
+	body := `{"name":"p","domain":"gaming","category":"match3","warehouse":{"provider":"bigquery"}}`
+	req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Create(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.releases) != 2 {
+		t.Errorf("expected 2 Release calls (project + data source), got %d: %v", len(stub.releases), stub.releases)
+	}
+}
+
+func TestProjectsHandler_Create_DataSourceSkippedWhenNoWarehouse(t *testing.T) {
+	stub := &stubChecker{}
+	swapChecker(t, stub)
+
+	repo := newMockProjectRepo()
+	h := NewProjectsHandler(repo, nil)
+
+	body := `{"name":"p","domain":"gaming","category":"match3"}`
+	req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Create(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", w.Code)
+	}
+	// No warehouse → CheckAddDataSource was not called (stub would have
+	// recorded a release only if the repo insert had failed afterward).
+}
+
+// --- helpers ---
+
+var errInject = &injectedError{msg: "injected"}
+
+type injectedError struct{ msg string }
+
+func (e *injectedError) Error() string { return e.msg }

--- a/services/api/internal/handler/search_test.go
+++ b/services/api/internal/handler/search_test.go
@@ -41,6 +41,10 @@ func (m *mockProjectRepoForSearch) Update(_ context.Context, _ string, _ *models
 	return nil
 }
 func (m *mockProjectRepoForSearch) Delete(_ context.Context, _ string) error { return nil }
+func (m *mockProjectRepoForSearch) Count(_ context.Context) (int, error)    { return 0, nil }
+func (m *mockProjectRepoForSearch) CountWithWarehouse(_ context.Context) (int, error) {
+	return 0, nil
+}
 
 // mockVectorStoreForSearch returns pre-set search results.
 type mockVectorStoreForSearch struct {

--- a/services/api/internal/server/server.go
+++ b/services/api/internal/server/server.go
@@ -235,9 +235,13 @@ const counterReconcileInterval = 5 * time.Minute
 // registered policy Checker for reconciliation. Does nothing visible
 // on self-hosted because the Noop Checker drops the call.
 //
-// The goroutine runs for the process lifetime; a context leak here is
-// acceptable because the community API exits via os.Interrupt at
-// which point the HTTP server shuts down and the process exits.
+// Shutdown: the goroutine runs on context.Background() for the
+// process lifetime. The community API exits by SIGTERM / SIGINT which
+// terminates the whole process — no graceful-shutdown path is
+// wired because there is no in-flight state worth preserving (the
+// next process's startup tick re-reports ground truth). If finer-
+// grained shutdown becomes necessary, thread a shared context from
+// apiserver.Run() through this function.
 func startCounterReconciliation(projectRepo database.ProjectRepo) {
 	go func() {
 		ctx := context.Background()

--- a/services/api/internal/server/server.go
+++ b/services/api/internal/server/server.go
@@ -3,9 +3,11 @@ package server
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/decisionbox-io/decisionbox/libs/go-common/auth"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/health"
+	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/secrets"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/vectorstore"
 	"github.com/decisionbox-io/decisionbox/services/api/database"
@@ -52,6 +54,13 @@ func New(db *database.DB, healthHandler *health.Handler, secretProvider secrets.
 		// Fall back to subprocess mode
 		agentRunner = runner.NewSubprocessRunner()
 	}
+
+	// Policy-plugin reconciliation: periodically report the tenant's
+	// ground-truth project and data-source counts to the control plane
+	// so any drift (manual Mongo import, lost reservation, etc.)
+	// eventually converges. Noop on self-hosted because the default
+	// Checker drops the call.
+	startCounterReconciliation(projectRepo)
 
 	// Seed pricing from registered providers (if not yet in MongoDB)
 	handler.SeedPricingFromProviders(context.Background(), pricingRepo)
@@ -205,6 +214,50 @@ func New(db *database.DB, healthHandler *health.Handler, secretProvider secrets.
 
 	// Middleware chain: CORS → Logging → Auth → RBAC → Router
 	return corsMiddleware(handler.LoggingMiddleware(root))
+}
+
+// counterReconcileInterval is how often the reconciliation goroutine
+// counts projects + data sources and reports them to the policy
+// Checker. Five minutes is comfortably longer than any reserve/confirm
+// round-trip, so steady-state drift is bounded by one tick.
+const counterReconcileInterval = 5 * time.Minute
+
+// startCounterReconciliation launches a goroutine that periodically
+// counts the tenant's persistent resources and forwards them to the
+// registered policy Checker for reconciliation. Does nothing visible
+// on self-hosted because the Noop Checker drops the call.
+//
+// The goroutine runs for the process lifetime; a context leak here is
+// acceptable because the community API exits via os.Interrupt at
+// which point the HTTP server shuts down and the process exits.
+func startCounterReconciliation(projectRepo database.ProjectRepo) {
+	go func() {
+		ctx := context.Background()
+		ticker := time.NewTicker(counterReconcileInterval)
+		defer ticker.Stop()
+		// Fire once on startup so the counter is warm before the first tick.
+		reconcileOnce(ctx, projectRepo)
+		for range ticker.C {
+			reconcileOnce(ctx, projectRepo)
+		}
+	}()
+}
+
+func reconcileOnce(ctx context.Context, projectRepo database.ProjectRepo) {
+	projects, err := projectRepo.Count(ctx)
+	if err != nil {
+		apilog.WithError(err).Warn("counter reconciliation: project count failed")
+		return
+	}
+	dataSources, err := projectRepo.CountWithWarehouse(ctx)
+	if err != nil {
+		apilog.WithError(err).Warn("counter reconciliation: data-source count failed")
+		return
+	}
+	policy.GetChecker().SyncCounters(ctx, "", policy.CounterSnapshot{
+		ProjectsCurrent:    projects,
+		DataSourcesCurrent: dataSources,
+	})
 }
 
 func corsMiddleware(next http.Handler) http.Handler {

--- a/services/api/internal/server/server.go
+++ b/services/api/internal/server/server.go
@@ -55,20 +55,14 @@ func New(db *database.DB, healthHandler *health.Handler, secretProvider secrets.
 		agentRunner = runner.NewSubprocessRunner()
 	}
 
-	// Policy-plugin reconciliation: periodically report the tenant's
-	// ground-truth project and data-source counts to the control plane
-	// so any drift (manual Mongo import, lost reservation, etc.)
-	// eventually converges. Noop on self-hosted because the default
-	// Checker drops the call.
-	startCounterReconciliation(projectRepo)
-
-	// Post-completion confirmer: the agent writes a run as completed
-	// directly to Mongo, so the API never gets a request-scoped hook
-	// to call ConfirmDiscoveryRunEnded. This goroutine scans for
-	// terminal runs that still carry a reservation id, confirms them
-	// (which decrements concurrent_runs_by_project on cloud), and
-	// clears the field. Noop on self-hosted.
-	startRunConfirmer(runRepo)
+	// Policy-plugin reconciliation + post-completion confirmer only
+	// run when a non-default Checker is registered. On self-hosted the
+	// Noop drops every call, so the background Mongo queries would be
+	// pure waste.
+	if policy.HasRegisteredChecker() {
+		startCounterReconciliation(projectRepo)
+		startRunConfirmer(runRepo)
+	}
 
 	// Seed pricing from registered providers (if not yet in MongoDB)
 	handler.SeedPricingFromProviders(context.Background(), pricingRepo)
@@ -290,6 +284,24 @@ func startRunConfirmer(runRepo database.RunRepo) {
 	}()
 }
 
+// policyStatusFromDB maps a DiscoveryRun.Status ("completed", "failed",
+// "cancelled") to the policy.RunOutcome vocabulary ("success",
+// "failure", "cancelled") used by the handler-side confirm paths, so
+// the control plane receives a consistent value regardless of which
+// code path closed the reservation.
+func policyStatusFromDB(dbStatus string) string {
+	switch dbStatus {
+	case "completed":
+		return "success"
+	case "failed":
+		return "failure"
+	case "cancelled":
+		return "cancelled"
+	default:
+		return dbStatus
+	}
+}
+
 func confirmTerminalRuns(ctx context.Context, runRepo database.RunRepo) {
 	runs, err := runRepo.ListTerminalWithReservation(ctx, 50)
 	if err != nil {
@@ -301,7 +313,7 @@ func confirmTerminalRuns(ctx context.Context, runRepo database.RunRepo) {
 	}
 	checker := policy.GetChecker()
 	for _, run := range runs {
-		outcome := policy.RunOutcome{Status: run.Status}
+		outcome := policy.RunOutcome{Status: policyStatusFromDB(run.Status)}
 		if run.CompletedAt != nil {
 			outcome.EndedAt = *run.CompletedAt
 		}

--- a/services/api/internal/server/server.go
+++ b/services/api/internal/server/server.go
@@ -62,6 +62,14 @@ func New(db *database.DB, healthHandler *health.Handler, secretProvider secrets.
 	// Checker drops the call.
 	startCounterReconciliation(projectRepo)
 
+	// Post-completion confirmer: the agent writes a run as completed
+	// directly to Mongo, so the API never gets a request-scoped hook
+	// to call ConfirmDiscoveryRunEnded. This goroutine scans for
+	// terminal runs that still carry a reservation id, confirms them
+	// (which decrements concurrent_runs_by_project on cloud), and
+	// clears the field. Noop on self-hosted.
+	startRunConfirmer(runRepo)
+
 	// Seed pricing from registered providers (if not yet in MongoDB)
 	handler.SeedPricingFromProviders(context.Background(), pricingRepo)
 
@@ -258,6 +266,54 @@ func reconcileOnce(ctx context.Context, projectRepo database.ProjectRepo) {
 		ProjectsCurrent:    projects,
 		DataSourcesCurrent: dataSources,
 	})
+}
+
+// runConfirmerInterval is how often the confirmer scans for terminal
+// runs carrying a reservation. A short tick keeps the concurrent-runs
+// counter accurate between a run completing and the cap freeing up
+// on the dashboard; the sweeper TTL (minutes) is the slower backstop.
+const runConfirmerInterval = 15 * time.Second
+
+func startRunConfirmer(runRepo database.RunRepo) {
+	go func() {
+		ctx := context.Background()
+		ticker := time.NewTicker(runConfirmerInterval)
+		defer ticker.Stop()
+		confirmTerminalRuns(ctx, runRepo)
+		for range ticker.C {
+			confirmTerminalRuns(ctx, runRepo)
+		}
+	}()
+}
+
+func confirmTerminalRuns(ctx context.Context, runRepo database.RunRepo) {
+	runs, err := runRepo.ListTerminalWithReservation(ctx, 50)
+	if err != nil {
+		apilog.WithError(err).Warn("run confirmer: list terminal runs failed")
+		return
+	}
+	if len(runs) == 0 {
+		return
+	}
+	checker := policy.GetChecker()
+	for _, run := range runs {
+		outcome := policy.RunOutcome{Status: run.Status}
+		if run.CompletedAt != nil {
+			outcome.EndedAt = *run.CompletedAt
+		}
+		if run.Error != "" {
+			outcome.Error = run.Error
+		}
+		if err := checker.ConfirmDiscoveryRunEnded(ctx, run.PolicyReservationID, outcome); err != nil {
+			apilog.WithFields(apilog.Fields{"run_id": run.ID, "error": err.Error()}).
+				Warn("run confirmer: policy confirm failed; will retry on next tick")
+			continue
+		}
+		if err := runRepo.ClearPolicyReservationID(ctx, run.ID); err != nil {
+			apilog.WithFields(apilog.Fields{"run_id": run.ID, "error": err.Error()}).
+				Warn("run confirmer: clearing reservation id failed; may double-confirm on next tick")
+		}
+	}
 }
 
 func corsMiddleware(next http.Handler) http.Handler {

--- a/services/api/models/run.go
+++ b/services/api/models/run.go
@@ -23,6 +23,15 @@ type DiscoveryRun struct {
 	SuccessfulQueries int `bson:"successful_queries" json:"successful_queries"`
 	FailedQueries     int `bson:"failed_queries" json:"failed_queries"`
 	InsightsFound     int `bson:"insights_found" json:"insights_found"`
+
+	// PolicyReservationID is the reservation the API opened when the run
+	// was triggered (plan-gated concurrent-runs-per-project and
+	// runs-per-period counters). Empty when the policy Checker is Noop
+	// (self-hosted) or when the reservation has already been confirmed
+	// or released. Persisted so exit handlers outside the trigger
+	// request scope (cancel, agent-completion callback, crash sweeper)
+	// can resolve it back to the control plane.
+	PolicyReservationID string `bson:"policy_reservation_id,omitempty" json:"-"`
 }
 
 type RunStep struct {


### PR DESCRIPTION
## Summary

Adds a `policy.Checker` hook in `libs/go-common/policy` that lets a downstream plugin (e.g. a cloud tenant) gate agent runs, LLM calls, and counter reconciliation without any cloud-specific code living in the community platform. OSS default is a `NoopChecker` — zero behavioral change for self-hosted.

## What this introduces

- `libs/go-common/policy` — `Checker` interface with `CheckCanStartRun`, `ConfirmDiscoveryRunEnded`, `CheckLLMProviderAllowed`, `SyncCounters`, etc., plus a registry with `NoopChecker` default and `AllFeatures` canonical list for drift detection.
- `services/api` — community handlers call the registered `Checker` at each gated chokepoint (project create, discovery-run start, data-source add, LLM provider selection, LLM-provider update). Structured `402` / `403` responses with plan / limit / allowed-provider details so dashboards can render "Upgrade to …" CTAs without parsing error strings.
- `services/agent` — `ai.Client` captures the registered `Checker` on `SetProvenance` and emits a structured log plus a fire-and-forget `ObserveLLMTokens` call after every LLM request. `ObserveLLMTokens` is a no-op on self-hosted.
- Embedding resolver — `ResolveConfig` in `libs/go-common/embedding` picks the effective provider/model/key: env vars win unless `BYOK_EMBEDDING_ENABLED=true` flips the priority to project credentials.
- Periodic reconciliation — `startCounterReconciliation` in `services/api/internal/server` reports project + data-source counts to the registered `Checker` every 5 minutes.
- Post-completion run confirmer — 15 s ticker lists terminal runs carrying a non-empty `policy_reservation_id`, calls `ConfirmDiscoveryRunEnded`, clears the id.

## Test plan

- [x] Unit tests: Noop / registry / wrapper / typed error translation
- [x] Agent LLM wrapper honors `CheckLLMProviderAllowed` and emits `ObserveLLMTokens`
- [x] API handler path enforces `CheckCanStartRun`, `CheckCreateProject`, `CheckAddDataSource`
- [x] Reservation released on agent spawn failure and on repo insert failure
- [x] Confirmer fires on run terminal state (success / fail / cancel)
- [x] `ResolveConfig` — env wins, BYOK flip, no-provider error
- [x] `make build`, `make test`, `make lint-go` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)