### PR TITLE
fix(api): ship decisionbox-agent binary inside API image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Related items promoted + right sidebar TOC** — Related recommendations (on insight pages) and related insights (on recommendation pages) now appear in a sticky right-column TOC at the top of the viewport, alongside semantic-search similar items. On narrow screens the TOC collapses to a horizontally-scrollable chip strip above the main content. The inline mid-page "Related" cards and bottom "Similar" blocks were removed — everything lives in the sidebar now.
 - **API endpoints** for the above: `POST/GET/PATCH/DELETE /api/v1/projects/{id}/lists`, `POST/DELETE /api/v1/projects/{id}/lists/{listId}/items`, `GET /api/v1/projects/{id}/bookmarks`, `POST/DELETE/GET /api/v1/projects/{id}/reads`. Every record carries a `user_id` field sourced from `auth.UserFromContext(ctx).Sub` — `"anonymous"` under NoAuth, the OIDC sub claim under enterprise. Same schema, same handlers in both modes; enterprise deployments get per-user scoping without schema migration.
 
+### Fixed
+
+- **Docker Compose Quick Start: `decisionbox-agent` missing from API image** — The API container's default `RUNNER_MODE=subprocess` spawns the agent via `exec.Command("decisionbox-agent", ...)`, but `services/api/Dockerfile` only shipped the `decisionbox-api` binary. Starting a discovery failed with `exec: "decisionbox-agent": executable file not found in $PATH`. The API image now also builds and installs `decisionbox-agent` into `/usr/local/bin`, so `docker compose up -d` works end-to-end out of the box. Kubernetes deployments are unaffected — they use `RUNNER_MODE=kubernetes` and run the agent as a Job from its own image.
+
 ## [0.4.0] - 2026-04-14
 
 ### Added

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -30,8 +30,11 @@ COPY providers/secrets/gcp/go.mod providers/secrets/gcp/go.sum providers/secrets
 COPY providers/secrets/aws/go.mod providers/secrets/aws/go.sum providers/secrets/aws/
 COPY providers/secrets/azure/go.mod providers/secrets/azure/go.sum providers/secrets/azure/
 COPY services/api/go.mod services/api/go.sum services/api/
+COPY services/agent/go.mod services/agent/go.sum services/agent/
 # Download deps
 WORKDIR /workspace/services/api
+RUN go mod download
+WORKDIR /workspace/services/agent
 RUN go mod download
 
 # Copy all source
@@ -39,10 +42,17 @@ WORKDIR /workspace
 COPY libs/ libs/
 COPY providers/ providers/
 COPY services/api/ services/api/
+COPY services/agent/ services/agent/
 
 # Build API binary
 WORKDIR /workspace/services/api
 RUN CGO_ENABLED=0 GOOS=linux go build -o /decisionbox-api .
+
+# Build agent binary — required by API subprocess runner (RUNNER_MODE=subprocess),
+# the default mode for docker-compose. In kubernetes mode the agent runs as a Job
+# from its own image and this binary is unused.
+WORKDIR /workspace/services/agent
+RUN CGO_ENABLED=0 GOOS=linux go build -o /decisionbox-agent .
 
 FROM alpine:3.22
 RUN apk add --no-cache ca-certificates tzdata && \
@@ -52,6 +62,7 @@ RUN apk add --no-cache ca-certificates tzdata && \
 WORKDIR /app
 
 COPY --from=builder /decisionbox-api /usr/local/bin/decisionbox-api
+COPY --from=builder /decisionbox-agent /usr/local/bin/decisionbox-agent
 
 EXPOSE 8080
 USER app


### PR DESCRIPTION
## Summary

- The API's default `RUNNER_MODE=subprocess` spawns the agent via `exec.Command(\"decisionbox-agent\", ...)`, but `services/api/Dockerfile` only shipped `decisionbox-api`. Following the Docker Compose Quick Start and starting a discovery failed with `exec: \"decisionbox-agent\": executable file not found in $PATH`.
- The API Dockerfile now also builds and installs `decisionbox-agent` into `/usr/local/bin`, so `docker compose up -d` works end-to-end out of the box.
- Kubernetes deployments are unaffected — they use `RUNNER_MODE=kubernetes` and run the agent as a Job from its own image. The standalone `services/agent/Dockerfile` is unchanged.

## Test plan

- [x] \`docker build -f services/api/Dockerfile .\` succeeds
- [x] \`which decisionbox-api\` and \`which decisionbox-agent\` both resolve inside the image
- [x] \`decisionbox-agent --help\` runs and shows the flags \`SubprocessRunner\` passes (\`--project-id\`, \`--run-id\`, \`--areas\`, \`--max-steps\`)
- [ ] Full Quick Start: \`docker compose up -d\` → create project → run discovery → completes without the PATH error

🤖 Generated with [Claude Code](https://claude.com/claude-code)