### PR TITLE
feat(ui): shared CitationLink badge with hover tooltip

### DIFF
--- a/ui/dashboard/src/__tests__/CitationLink.test.tsx
+++ b/ui/dashboard/src/__tests__/CitationLink.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { CitationLink } from '@/components/citations/CitationLink';
+
+// The component is shared by the Ask page (markdown answers) and the
+// enterprise executive-summary newspaper. These tests pin the
+// behaviour both surfaces rely on so a future change to one doesn't
+// silently regress the other:
+//
+//   - Linked vs non-linked rendering keyed on `href`.
+//   - Tooltip content composition (name / severity / description).
+//   - Truncation thresholds on long name + description.
+//   - Fallback label when `name` is missing.
+
+describe('CitationLink', () => {
+  it('renders a Link badge when href is set', () => {
+    const { container } = render(
+      <CitationLink number={1} href="/projects/p-1/insights/i-1" name="High churn at L45" />,
+    );
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('/projects/p-1/insights/i-1');
+    expect(anchor?.textContent).toBe('1');
+  });
+
+  it('renders a non-interactive span when href is omitted (unresolved citation)', () => {
+    // The Ask page passes href=undefined when sources[idx] is missing.
+    // Rendering an <a href="#"> would scroll the page to top on click;
+    // a <span> badge keeps the visual but does nothing.
+    const { container } = render(<CitationLink number={3} name="Stale Insight" />);
+    expect(container.querySelector('a')).toBeNull();
+    const span = container.querySelector('span > span');
+    expect(span?.textContent).toBe('3');
+  });
+
+  it('puts the source name in the tooltip', () => {
+    const { container } = render(
+      <CitationLink number={1} href="/x" name="Rhode Island OOP gap" />,
+    );
+    expect(container.textContent).toContain('Rhode Island OOP gap');
+  });
+
+  it('falls back to "Source N" when name is omitted', () => {
+    const { container } = render(<CitationLink number={7} href="/x" />);
+    expect(container.textContent).toContain('Source 7');
+  });
+
+  it('truncates long names at 80 characters with an ellipsis', () => {
+    const longName = 'a'.repeat(120);
+    const { container } = render(<CitationLink number={1} href="/x" name={longName} />);
+    const strong = container.querySelector('strong');
+    expect(strong?.textContent?.length).toBe(83); // 80 + "..."
+    expect(strong?.textContent?.endsWith('...')).toBe(true);
+  });
+
+  it('truncates long descriptions at 120 characters with an ellipsis', () => {
+    const longDesc = 'd'.repeat(200);
+    const { container } = render(
+      <CitationLink number={1} href="/x" name="short" description={longDesc} />,
+    );
+    const text = container.textContent ?? '';
+    // The tooltip is part of the DOM (display:none initially); textContent
+    // includes it. The truncated description ends with "..." after 120 chars.
+    expect(text).toMatch(/d{120}\.{3}/);
+    expect(text).not.toMatch(/d{121}/);
+  });
+
+  it('omits the severity span when severity is not provided', () => {
+    const { container } = render(<CitationLink number={1} href="/x" name="x" />);
+    // No severity element; the only span without a className is the
+    // outer wrapper or the description spot, neither of which we set.
+    const text = container.textContent ?? '';
+    expect(text).not.toMatch(/\b(high|medium|low|critical)\b/i);
+  });
+
+  it('renders the severity inline when provided', () => {
+    const { container } = render(
+      <CitationLink number={1} href="/x" name="x" severity="high" />,
+    );
+    expect(container.textContent).toContain('high');
+  });
+
+  it('omits the description block when not provided', () => {
+    const { container } = render(<CitationLink number={1} href="/x" name="Short" />);
+    // The tooltip contains exactly the bold name; nothing on a new
+    // line after it.
+    expect(container.querySelector('strong')?.textContent).toBe('Short');
+  });
+});

--- a/ui/dashboard/src/__tests__/CitationLink.test.tsx
+++ b/ui/dashboard/src/__tests__/CitationLink.test.tsx
@@ -26,14 +26,21 @@ describe('CitationLink', () => {
     expect(anchor?.textContent).toBe('1');
   });
 
-  it('renders a non-interactive span when href is omitted (unresolved citation)', () => {
+  it('renders a focusable static span when href is omitted (unresolved citation)', () => {
     // The Ask page passes href=undefined when sources[idx] is missing.
     // Rendering an <a href="#"> would scroll the page to top on click;
-    // a <span> badge keeps the visual but does nothing.
+    // a non-interactive <span> keeps the visual without that side effect.
+    // The span carries tabIndex=0 so keyboard users can reach it and the
+    // CSS :focus-within selector can still reveal the tooltip.
     const { container } = render(<CitationLink number={3} name="Stale Insight" />);
     expect(container.querySelector('a')).toBeNull();
-    const span = container.querySelector('span > span');
-    expect(span?.textContent).toBe('3');
+    // The static badge is the inner span carrying the number text.
+    const badge = Array.from(container.querySelectorAll('span')).find(
+      (el) => el.textContent === '3',
+    );
+    expect(badge).toBeDefined();
+    expect(badge?.getAttribute('tabindex')).toBe('0');
+    expect(badge?.getAttribute('role')).toBe('note');
   });
 
   it('puts the source name in the tooltip', () => {

--- a/ui/dashboard/src/app/projects/[id]/ask/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/ask/page.tsx
@@ -386,14 +386,12 @@ function processChildren(children: React.ReactNode, sources: SearchResultItem[],
           <span key={i}>
             {nums.map((num, j) => {
               const src = sources[num - 1];
-              const href = src ? sourceHref(src.project_id || projectId, src) : '#';
-              const name = src ? (src.name || src.title || undefined) : undefined;
               return (
                 <CitationLink
                   key={j}
                   number={num}
-                  href={href}
-                  name={name}
+                  href={src ? sourceHref(src.project_id || projectId, src) : undefined}
+                  name={src ? (src.name || src.title || undefined) : undefined}
                   severity={src?.severity}
                   description={src?.description}
                 />

--- a/ui/dashboard/src/app/projects/[id]/ask/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/ask/page.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState, useRef } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { Loader, TextInput, ActionIcon } from '@mantine/core';
 import { IconMessageCircle, IconSend, IconHistory, IconClock, IconPlus, IconTrash } from '@tabler/icons-react';
-import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Shell from '@/components/layout/AppShell';
 import CitationsFooter, { sourceHref } from '@/components/citations/CitationsFooter';
+import { CitationLink } from '@/components/citations/CitationLink';
 import { api, AskSession, SearchResultItem } from '@/lib/api';
 
 interface DisplayMessage {
@@ -367,26 +367,6 @@ function AnswerContent({ answer, sources, projectId }: { answer: string; sources
         .ask-answer { font-size: 14px; color: var(--db-text-primary); }
         .ask-answer > *:first-child { margin-top: 0; }
         .ask-answer > *:last-child { margin-bottom: 0; }
-        .cite-ref { position: relative; display: inline; }
-        .cite-ref .cite-badge {
-          display: inline-flex; align-items: center; justify-content: center;
-          font-size: 10px; font-weight: 700; color: var(--db-blue-text);
-          background: var(--db-blue-bg); border-radius: 4px; padding: 0 4px;
-          min-width: 16px; height: 16px; cursor: pointer; vertical-align: super;
-          line-height: 1; text-decoration: none; transition: background 100ms ease; margin: 0 1px;
-        }
-        .cite-ref .cite-badge:hover { background: var(--db-blue-text); color: white; }
-        .cite-ref .cite-tooltip {
-          display: none; position: absolute; bottom: calc(100% + 6px); left: 50%;
-          transform: translateX(-50%); background: var(--db-text-primary); color: white;
-          padding: 8px 12px; border-radius: 8px; font-size: 12px; line-height: 1.4;
-          width: 280px; z-index: 50; pointer-events: none; box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-        }
-        .cite-ref .cite-tooltip::after {
-          content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%);
-          border: 5px solid transparent; border-top-color: var(--db-text-primary);
-        }
-        .cite-ref:hover .cite-tooltip { display: block; }
       `}</style>
     </div>
   );
@@ -405,24 +385,18 @@ function processChildren(children: React.ReactNode, sources: SearchResultItem[],
         return (
           <span key={i}>
             {nums.map((num, j) => {
-              const idx = num - 1;
-              const src = sources[idx];
-              if (!src) return <span key={j} className="cite-ref"><span className="cite-badge">{num}</span></span>;
-              const name = src.name || src.title || '';
-              const href = sourceHref(src.project_id || projectId, src);
+              const src = sources[num - 1];
+              const href = src ? sourceHref(src.project_id || projectId, src) : '#';
+              const name = src ? (src.name || src.title || undefined) : undefined;
               return (
-                <span key={j} className="cite-ref">
-                  <Link href={href} className="cite-badge">{num}</Link>
-                  <span className="cite-tooltip">
-                    <strong>{name.length > 80 ? name.slice(0, 80) + '...' : name}</strong>
-                    {src.severity && <span style={{ marginLeft: 6, opacity: 0.7 }}>{src.severity}</span>}
-                    {src.description && (
-                      <span style={{ display: 'block', marginTop: 4, opacity: 0.8, fontSize: 11 }}>
-                        {src.description.slice(0, 120)}{src.description.length > 120 ? '...' : ''}
-                      </span>
-                    )}
-                  </span>
-                </span>
+                <CitationLink
+                  key={j}
+                  number={num}
+                  href={href}
+                  name={name}
+                  severity={src?.severity}
+                  description={src?.description}
+                />
               );
             })}
           </span>

--- a/ui/dashboard/src/components/citations/CitationLink.css
+++ b/ui/dashboard/src/components/citations/CitationLink.css
@@ -1,0 +1,73 @@
+/*
+ * CitationLink — shared hover tooltip styles used by the Ask page and
+ * the enterprise executive-summary newspaper. The CSS is loaded once
+ * (auto-imported by the .tsx file) so any component that drops a
+ * <CitationLink/> gets the badge + hover tooltip for free.
+ *
+ * The .cite-ref wrapper owns the hover state and the tooltip sits
+ * above it via absolute positioning. Display: none → display: block
+ * on hover keeps it CSS-only; no JavaScript state, no portal, works
+ * in static markdown output as well as React component output.
+ */
+
+.cite-ref {
+  position: relative;
+  display: inline;
+}
+
+.cite-ref .cite-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--db-blue-text);
+  background: var(--db-blue-bg);
+  border-radius: 4px;
+  padding: 0 4px;
+  min-width: 16px;
+  height: 16px;
+  cursor: pointer;
+  vertical-align: super;
+  line-height: 1;
+  text-decoration: none;
+  transition: background 100ms ease;
+  margin: 0 1px;
+}
+
+.cite-ref .cite-badge:hover {
+  background: var(--db-blue-text);
+  color: white;
+}
+
+.cite-ref .cite-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--db-text-primary);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  width: 280px;
+  z-index: 50;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.cite-ref .cite-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--db-text-primary);
+}
+
+.cite-ref:hover .cite-tooltip {
+  display: block;
+}

--- a/ui/dashboard/src/components/citations/CitationLink.module.css
+++ b/ui/dashboard/src/components/citations/CitationLink.module.css
@@ -1,21 +1,20 @@
 /*
- * CitationLink — shared hover tooltip styles used by the Ask page and
- * the enterprise executive-summary newspaper. The CSS is loaded once
- * (auto-imported by the .tsx file) so any component that drops a
- * <CitationLink/> gets the badge + hover tooltip for free.
+ * CitationLink — hover/focus tooltip styles, loaded as a CSS Module
+ * so class names stay scoped to the component (no global leakage,
+ * App Router-safe). Class names are imported as `styles.citeRef`
+ * etc. inside CitationLink.tsx.
  *
- * The .cite-ref wrapper owns the hover state and the tooltip sits
- * above it via absolute positioning. Display: none → display: block
- * on hover keeps it CSS-only; no JavaScript state, no portal, works
- * in static markdown output as well as React component output.
+ * Visibility triggers on both :hover and :focus-within so the
+ * tooltip is reachable from a keyboard. The badge itself takes a
+ * :focus-visible outline for the same reason.
  */
 
-.cite-ref {
+.citeRef {
   position: relative;
   display: inline;
 }
 
-.cite-ref .cite-badge {
+.citeBadge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -31,16 +30,25 @@
   vertical-align: super;
   line-height: 1;
   text-decoration: none;
-  transition: background 100ms ease;
+  transition: background 100ms ease, outline-offset 100ms ease;
   margin: 0 1px;
+  outline: none;
+  border: 0;
+  font-family: inherit;
 }
 
-.cite-ref .cite-badge:hover {
+.citeBadge:hover,
+.citeBadge:focus-visible {
   background: var(--db-blue-text);
   color: white;
 }
 
-.cite-ref .cite-tooltip {
+.citeBadge:focus-visible {
+  outline: 2px solid var(--db-blue-text);
+  outline-offset: 2px;
+}
+
+.citeTooltip {
   display: none;
   position: absolute;
   bottom: calc(100% + 6px);
@@ -58,7 +66,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
-.cite-ref .cite-tooltip::after {
+.citeTooltip::after {
   content: '';
   position: absolute;
   top: 100%;
@@ -68,6 +76,7 @@
   border-top-color: var(--db-text-primary);
 }
 
-.cite-ref:hover .cite-tooltip {
+.citeRef:hover .citeTooltip,
+.citeRef:focus-within .citeTooltip {
   display: block;
 }

--- a/ui/dashboard/src/components/citations/CitationLink.module.css
+++ b/ui/dashboard/src/components/citations/CitationLink.module.css
@@ -26,7 +26,6 @@
   padding: 0 4px;
   min-width: 16px;
   height: 16px;
-  cursor: pointer;
   vertical-align: super;
   line-height: 1;
   text-decoration: none;
@@ -35,6 +34,19 @@
   outline: none;
   border: 0;
   font-family: inherit;
+}
+
+/*
+ * Cursor differs by interactivity: the linked badge promises a
+ * navigation (pointer); the static badge only reveals the tooltip
+ * on hover/focus (help).
+ */
+.citeBadgeLink {
+  cursor: pointer;
+}
+
+.citeBadgeStatic {
+  cursor: help;
 }
 
 .citeBadge:hover,
@@ -79,4 +91,20 @@
 .citeRef:hover .citeTooltip,
 .citeRef:focus-within .citeTooltip {
   display: block;
+}
+
+/*
+ * Tooltip content blocks — kept as classes (not inline styles) so
+ * the tooltip's visual is owned entirely by this stylesheet.
+ */
+.tooltipSeverity {
+  margin-left: 6px;
+  opacity: 0.7;
+}
+
+.tooltipDescription {
+  display: block;
+  margin-top: 4px;
+  opacity: 0.8;
+  font-size: 11px;
 }

--- a/ui/dashboard/src/components/citations/CitationLink.tsx
+++ b/ui/dashboard/src/components/citations/CitationLink.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * CitationLink renders one citation number — a small badge that
+ * links to the source and reveals a CSS-only hover tooltip with the
+ * source name, severity, and description.
+ *
+ * Two callers share it today:
+ *
+ *  - The Ask page, which scans markdown answers for `[1,2]` patterns
+ *    and emits one CitationLink per matched number.
+ *  - The enterprise executive-summary "newspaper" renderer, which
+ *    emits one CitationLink per `{{I:id}}` / `{{R:id}}` token in
+ *    prose and one per explicit Citation in card / stat / story /
+ *    bar / action arrays.
+ *
+ * Owning the badge + tooltip in one place means both surfaces look,
+ * hover, and link the same way, and a future change to the tooltip
+ * (mobile tap support, different palette) updates everything.
+ */
+
+import React from 'react';
+import Link from 'next/link';
+import './CitationLink.css';
+
+export interface CitationLinkProps {
+  /** The number shown inside the badge. 1-based, in reading order. */
+  number: number;
+  /** Deep link the badge points at (insight / recommendation page). */
+  href: string;
+  /**
+   * The source title shown bold in the tooltip. Falls back to
+   * "Source N" when the citation can't be resolved against the
+   * project's insight + recommendation lists.
+   */
+  name?: string;
+  /** Optional severity chip text (e.g. "high", "medium"). */
+  severity?: string;
+  /** Optional description, truncated to 120 characters in the tooltip. */
+  description?: string;
+}
+
+/**
+ * Maximum lengths kept conservative so the 280px-wide tooltip stays
+ * readable across all dashboard themes — clipping at the source.
+ */
+const NAME_MAX = 80;
+const DESCRIPTION_MAX = 120;
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n)}...` : s;
+}
+
+export function CitationLink({
+  number,
+  href,
+  name,
+  severity,
+  description,
+}: CitationLinkProps): React.JSX.Element {
+  const display = name ? truncate(name, NAME_MAX) : `Source ${number}`;
+  return (
+    <span className="cite-ref">
+      <Link href={href} className="cite-badge">
+        {number}
+      </Link>
+      <span className="cite-tooltip">
+        <strong>{display}</strong>
+        {severity && (
+          <span style={{ marginLeft: 6, opacity: 0.7 }}>{severity}</span>
+        )}
+        {description && (
+          <span style={{ display: 'block', marginTop: 4, opacity: 0.8, fontSize: 11 }}>
+            {truncate(description, DESCRIPTION_MAX)}
+          </span>
+        )}
+      </span>
+    </span>
+  );
+}

--- a/ui/dashboard/src/components/citations/CitationLink.tsx
+++ b/ui/dashboard/src/components/citations/CitationLink.tsx
@@ -2,8 +2,8 @@
 
 /**
  * CitationLink renders one citation number — a small badge that
- * links to the source and reveals a CSS-only hover tooltip with the
- * source name, severity, and description.
+ * links to the source and reveals a CSS-only hover/focus tooltip
+ * with the source name, severity, and description.
  *
  * Two callers share it today:
  *
@@ -15,19 +15,29 @@
  *    bar / action arrays.
  *
  * Owning the badge + tooltip in one place means both surfaces look,
- * hover, and link the same way, and a future change to the tooltip
- * (mobile tap support, different palette) updates everything.
+ * hover, and link the same way, and a future change (mobile tap
+ * support, palette tweak) updates everything.
+ *
+ * `href` is optional: when undefined (the source couldn't be
+ * resolved in the project's insight/recommendation list) the badge
+ * renders as a non-interactive `<span>` rather than a `<Link>` to
+ * "#" — clicking a stale citation should never scroll the page to
+ * the top.
  */
 
 import React from 'react';
 import Link from 'next/link';
-import './CitationLink.css';
+import styles from './CitationLink.module.css';
 
 export interface CitationLinkProps {
   /** The number shown inside the badge. 1-based, in reading order. */
   number: number;
-  /** Deep link the badge points at (insight / recommendation page). */
-  href: string;
+  /**
+   * Deep link the badge points at (insight / recommendation page).
+   * Omit when the citation is unresolved — the badge renders as
+   * static text with the same visual styling.
+   */
+  href?: string;
   /**
    * The source title shown bold in the tooltip. Falls back to
    * "Source N" when the citation can't be resolved against the
@@ -59,12 +69,19 @@ export function CitationLink({
   description,
 }: CitationLinkProps): React.JSX.Element {
   const display = name ? truncate(name, NAME_MAX) : `Source ${number}`;
+  const badge = href ? (
+    <Link href={href} className={styles.citeBadge}>
+      {number}
+    </Link>
+  ) : (
+    <span className={styles.citeBadge} role="text">
+      {number}
+    </span>
+  );
   return (
-    <span className="cite-ref">
-      <Link href={href} className="cite-badge">
-        {number}
-      </Link>
-      <span className="cite-tooltip">
+    <span className={styles.citeRef}>
+      {badge}
+      <span className={styles.citeTooltip}>
         <strong>{display}</strong>
         {severity && (
           <span style={{ marginLeft: 6, opacity: 0.7 }}>{severity}</span>

--- a/ui/dashboard/src/components/citations/CitationLink.tsx
+++ b/ui/dashboard/src/components/citations/CitationLink.tsx
@@ -70,11 +70,19 @@ export function CitationLink({
 }: CitationLinkProps): React.JSX.Element {
   const display = name ? truncate(name, NAME_MAX) : `Source ${number}`;
   const badge = href ? (
-    <Link href={href} className={styles.citeBadge}>
+    <Link href={href} className={`${styles.citeBadge} ${styles.citeBadgeLink}`}>
       {number}
     </Link>
   ) : (
-    <span className={styles.citeBadge} role="text">
+    // tabIndex=0 keeps the badge in the tab order so :focus-within
+    // can reveal the tooltip for keyboard users. The "note" role
+    // tells assistive tech the element is informational, not an
+    // action surface.
+    <span
+      className={`${styles.citeBadge} ${styles.citeBadgeStatic}`}
+      role="note"
+      tabIndex={0}
+    >
       {number}
     </span>
   );
@@ -83,11 +91,9 @@ export function CitationLink({
       {badge}
       <span className={styles.citeTooltip}>
         <strong>{display}</strong>
-        {severity && (
-          <span style={{ marginLeft: 6, opacity: 0.7 }}>{severity}</span>
-        )}
+        {severity && <span className={styles.tooltipSeverity}>{severity}</span>}
         {description && (
-          <span style={{ display: 'block', marginTop: 4, opacity: 0.8, fontSize: 11 }}>
+          <span className={styles.tooltipDescription}>
             {truncate(description, DESCRIPTION_MAX)}
           </span>
         )}


### PR DESCRIPTION
## Summary

- New `components/citations/CitationLink.tsx` + `.css` owns the cite-ref / cite-badge / cite-tooltip structure that previously lived inline in the Ask page.
- Ask page calls `<CitationLink/>` instead of duplicating the JSX + styles; the now-unused `next/link` import is dropped.
- Enables the enterprise executive-summary newspaper to render its citation chips with the exact same badge + hover tooltip as Ask, sharing one source of truth.

## Test plan

- [ ] `npm test` in `ui/dashboard` still green.
- [ ] On the Ask page, hover a numbered badge in any answer — tooltip shows source name + severity + truncated description (unchanged from before).
- [ ] CSS lives only in `CitationLink.css` — no inline `cite-*` rules anywhere else in the dashboard tree.