### PR TITLE
fix(api): set restricted PodSecurity-compliant SecurityContext on agent K8s Jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Agent K8s Job pods satisfy PodSecurity `restricted` admission** — `KubernetesRunner.buildJob()` now stamps a full pod + container `SecurityContext` (`RunAsNonRoot=true`, `RunAsUser/Group=1000`, `FSGroup=1000`, `AllowPrivilegeEscalation=false`, `ReadOnlyRootFilesystem=true`, `Capabilities.Drop=[ALL]`, `SeccompProfile.Type=RuntimeDefault`) on every Job it creates (discovery runs, schema indexing, test-connection). Without these fields, namespaces labeled `pod-security.kubernetes.io/enforce=restricted` reject every agent Job and the dashboard shows "Schema index: Not indexed" indefinitely. To keep `ReadOnlyRootFilesystem=true` compatible with cloud SDKs that opportunistically write disk caches (gosnowflake OCSP, AWS/GCP token files), the spec also declares an `emptyDir` volume mounted at `/tmp` and points `TMPDIR=/tmp` + `HOME=/tmp`. The agent image (Alpine + static Go binary) already runs as UID 1000 with no capabilities — this is a spec-only fix with no runtime behavior change.
+
 ## [0.5.0] - 2026-05-15
 
 ### Added

--- a/services/api/internal/runner/kubernetes.go
+++ b/services/api/internal/runner/kubernetes.go
@@ -66,6 +66,11 @@ func (r *KubernetesRunner) buildJob(spec jobSpec) *batchv1.Job {
 	envVars := []corev1.EnvVar{
 		{Name: "MONGODB_URI", Value: getEnv("MONGODB_URI", "mongodb://localhost:27017")},
 		{Name: "MONGODB_DB", Value: getEnv("MONGODB_DB", "decisionbox")},
+		// Point any disk-touching SDKs (gosnowflake OCSP cache, AWS/GCP token
+		// caches) at the /tmp emptyDir below — required because the container
+		// runs with ReadOnlyRootFilesystem=true.
+		{Name: "TMPDIR", Value: "/tmp"},
+		{Name: "HOME", Value: "/tmp"},
 	}
 	for _, kv := range []struct{ key, envKey string }{
 		{"SECRET_PROVIDER", "SECRET_PROVIDER"},
@@ -82,6 +87,11 @@ func (r *KubernetesRunner) buildJob(spec jobSpec) *batchv1.Job {
 
 	backoffLimit := int32(0)
 
+	// SecurityContext fields satisfy PodSecurity "restricted" admission: agent
+	// pods run on tenant namespaces labeled pod-security.kubernetes.io/enforce=
+	// restricted, which rejects pods missing any of these. The agent image
+	// (Alpine + static Go binary) already runs as UID 1000 and needs no
+	// capabilities, so these are spec-only changes — no runtime behavior change.
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      spec.name,
@@ -97,12 +107,43 @@ func (r *KubernetesRunner) buildJob(spec jobSpec) *batchv1.Job {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: r.config.ServiceAccountName,
 					RestartPolicy:      corev1.RestartPolicyNever,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: boolPtr(true),
+						RunAsUser:    int64Ptr(1000),
+						RunAsGroup:   int64Ptr(1000),
+						FSGroup:      int64Ptr(1000),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name:         "tmp",
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "agent",
 							Image: r.config.AgentImage,
 							Args:  spec.args,
 							Env:   envVars,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: boolPtr(false),
+								RunAsNonRoot:             boolPtr(true),
+								RunAsUser:                int64Ptr(1000),
+								RunAsGroup:               int64Ptr(1000),
+								ReadOnlyRootFilesystem:   boolPtr(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "tmp", MountPath: "/tmp"},
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse(spec.cpuReq),
@@ -121,6 +162,9 @@ func (r *KubernetesRunner) buildJob(spec jobSpec) *batchv1.Job {
 	}
 	return job
 }
+
+func boolPtr(b bool) *bool    { return &b }
+func int64Ptr(i int64) *int64 { return &i }
 
 func (r *KubernetesRunner) Run(ctx context.Context, opts RunOptions) error {
 	jobName := fmt.Sprintf("discovery-%s", opts.RunID[:min(len(opts.RunID), 20)])

--- a/services/api/internal/runner/runner_test.go
+++ b/services/api/internal/runner/runner_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -221,6 +223,106 @@ func TestKubernetesRunner_Run_CreatesJob(t *testing.T) {
 	if *job.Spec.TTLSecondsAfterFinished != 3600 {
 		t.Errorf("TTL = %d, want 3600", *job.Spec.TTLSecondsAfterFinished)
 	}
+}
+
+// assertRestrictedSecurityContext verifies that a Job created by buildJob() is
+// admissible under PodSecurity "restricted" enforcement. Tenant namespaces in
+// cloud are labeled pod-security.kubernetes.io/enforce=restricted, which
+// rejects pods that don't set every one of these fields — see the regression
+// that motivated this fix.
+func assertRestrictedSecurityContext(t *testing.T, job batchv1.Job) {
+	t.Helper()
+
+	pod := job.Spec.Template.Spec
+	if pod.SecurityContext == nil {
+		t.Fatal("pod.SecurityContext is nil — restricted PodSecurity will reject the pod")
+	}
+	if pod.SecurityContext.RunAsNonRoot == nil || !*pod.SecurityContext.RunAsNonRoot {
+		t.Error("pod.SecurityContext.RunAsNonRoot must be true")
+	}
+	if pod.SecurityContext.RunAsUser == nil || *pod.SecurityContext.RunAsUser != 1000 {
+		t.Error("pod.SecurityContext.RunAsUser must be 1000")
+	}
+	if pod.SecurityContext.SeccompProfile == nil ||
+		pod.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("pod.SecurityContext.SeccompProfile.Type must be RuntimeDefault")
+	}
+
+	if len(pod.Containers) == 0 {
+		t.Fatal("no containers on pod")
+	}
+	c := pod.Containers[0]
+	if c.SecurityContext == nil {
+		t.Fatal("container.SecurityContext is nil — restricted PodSecurity will reject the pod")
+	}
+	if c.SecurityContext.AllowPrivilegeEscalation == nil || *c.SecurityContext.AllowPrivilegeEscalation {
+		t.Error("container.AllowPrivilegeEscalation must be false")
+	}
+	if c.SecurityContext.RunAsNonRoot == nil || !*c.SecurityContext.RunAsNonRoot {
+		t.Error("container.RunAsNonRoot must be true")
+	}
+	if c.SecurityContext.ReadOnlyRootFilesystem == nil || !*c.SecurityContext.ReadOnlyRootFilesystem {
+		t.Error("container.ReadOnlyRootFilesystem must be true")
+	}
+	if c.SecurityContext.Capabilities == nil || len(c.SecurityContext.Capabilities.Drop) == 0 ||
+		c.SecurityContext.Capabilities.Drop[0] != "ALL" {
+		t.Error("container.Capabilities must drop [ALL]")
+	}
+	if c.SecurityContext.SeccompProfile == nil ||
+		c.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("container.SecurityContext.SeccompProfile.Type must be RuntimeDefault")
+	}
+
+	// /tmp emptyDir is mandatory because ReadOnlyRootFilesystem=true blocks
+	// any SDK that wants to write temp/cache files (e.g., gosnowflake OCSP).
+	var hasTmpVol bool
+	for _, v := range pod.Volumes {
+		if v.Name == "tmp" && v.EmptyDir != nil {
+			hasTmpVol = true
+			break
+		}
+	}
+	if !hasTmpVol {
+		t.Error("pod must declare an emptyDir Volume named 'tmp' for writable scratch")
+	}
+	var hasTmpMount bool
+	for _, m := range c.VolumeMounts {
+		if m.Name == "tmp" && m.MountPath == "/tmp" {
+			hasTmpMount = true
+			break
+		}
+	}
+	if !hasTmpMount {
+		t.Error("container must mount 'tmp' volume at /tmp")
+	}
+
+	envMap := make(map[string]string)
+	for _, e := range c.Env {
+		envMap[e.Name] = e.Value
+	}
+	if envMap["TMPDIR"] != "/tmp" {
+		t.Errorf("TMPDIR env = %q, want /tmp", envMap["TMPDIR"])
+	}
+	if envMap["HOME"] != "/tmp" {
+		t.Errorf("HOME env = %q, want /tmp", envMap["HOME"])
+	}
+}
+
+// TestKubernetesRunner_Run_SetsRestrictedSecurityContext exercises the
+// discovery-run path. Without this, agent K8s Jobs are rejected by the
+// admission controller on namespaces enforcing pod-security restricted.
+func TestKubernetesRunner_Run_SetsRestrictedSecurityContext(t *testing.T) {
+	r := newFakeK8sRunner()
+	ctx := context.Background()
+
+	if err := r.Run(ctx, RunOptions{ProjectID: "p", RunID: "run-sec-1234567890"}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	jobs, _ := r.client.BatchV1().Jobs("test-ns").List(ctx, metav1.ListOptions{})
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
+	}
+	assertRestrictedSecurityContext(t, jobs.Items[0])
 }
 
 func TestKubernetesRunner_Run_NoAreas(t *testing.T) {
@@ -551,6 +653,72 @@ func TestKubernetesRunner_RunSync_CreatesJob(t *testing.T) {
 	if memLim.String() != "256Mi" {
 		t.Errorf("memory limit = %q, want 256Mi", memLim.String())
 	}
+}
+
+// TestKubernetesRunner_RunSync_SetsRestrictedSecurityContext exercises the
+// test-connection path. Same buildJob() call site, so the assertion is
+// duplicated to lock in the contract per call site.
+func TestKubernetesRunner_RunSync_SetsRestrictedSecurityContext(t *testing.T) {
+	r := newFakeK8sRunner()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Simulate K8s controller succeeding the job after a tick.
+	go func() {
+		for {
+			time.Sleep(50 * time.Millisecond)
+			jobs, _ := r.client.BatchV1().Jobs("test-ns").List(context.Background(), metav1.ListOptions{})
+			if len(jobs.Items) == 0 {
+				continue
+			}
+			job := jobs.Items[0]
+			job.Status.Succeeded = 1
+			_, _ = r.client.BatchV1().Jobs("test-ns").UpdateStatus(context.Background(), &job, metav1.UpdateOptions{})
+			return
+		}
+	}()
+
+	if _, err := r.RunSync(ctx, RunSyncOptions{ProjectID: "p", Args: []string{"--test-connection", "warehouse"}}); err != nil {
+		t.Fatalf("RunSync failed: %v", err)
+	}
+	jobs, _ := r.client.BatchV1().Jobs("test-ns").List(context.Background(), metav1.ListOptions{})
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
+	}
+	assertRestrictedSecurityContext(t, jobs.Items[0])
+}
+
+// TestKubernetesRunner_RunIndexSchema_SetsRestrictedSecurityContext exercises
+// the schema-indexing path — the one originally observed failing under
+// restricted PodSecurity (job name prefix "index-").
+func TestKubernetesRunner_RunIndexSchema_SetsRestrictedSecurityContext(t *testing.T) {
+	r := newFakeK8sRunner()
+	// RunIndexSchema polls on a 5s ticker — keep the context longer than one tick.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	go func() {
+		for {
+			time.Sleep(50 * time.Millisecond)
+			jobs, _ := r.client.BatchV1().Jobs("test-ns").List(context.Background(), metav1.ListOptions{})
+			if len(jobs.Items) == 0 {
+				continue
+			}
+			job := jobs.Items[0]
+			job.Status.Succeeded = 1
+			_, _ = r.client.BatchV1().Jobs("test-ns").UpdateStatus(context.Background(), &job, metav1.UpdateOptions{})
+			return
+		}
+	}()
+
+	if err := r.RunIndexSchema(ctx, IndexSchemaOptions{ProjectID: "p", RunID: "idx-run-1"}); err != nil {
+		t.Fatalf("RunIndexSchema failed: %v", err)
+	}
+	jobs, _ := r.client.BatchV1().Jobs("test-ns").List(context.Background(), metav1.ListOptions{})
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
+	}
+	assertRestrictedSecurityContext(t, jobs.Items[0])
 }
 
 func TestKubernetesRunner_RunSync_JobFails(t *testing.T) {


### PR DESCRIPTION
## Summary

- `KubernetesRunner.buildJob()` now stamps a full pod + container `SecurityContext` (`runAsNonRoot=true`, `runAsUser/Group=1000`, `fsGroup=1000`, `allowPrivilegeEscalation=false`, `readOnlyRootFilesystem=true`, `capabilities.drop=[ALL]`, `seccompProfile.type=RuntimeDefault`) on every Job — discovery runs, schema indexing, and test-connection. Same fields the API and Dashboard Helm charts already use, so behavior matches the rest of the platform.
- Adds an `emptyDir` volume mounted at `/tmp` plus `TMPDIR=/tmp` and `HOME=/tmp` env vars so SDKs that opportunistically write disk caches (gosnowflake OCSP, AWS/GCP token files) keep working alongside `readOnlyRootFilesystem=true`.
- Three new unit tests assert the contract per call site (`Run`, `RunSync`, `RunIndexSchema`) via a shared `assertRestrictedSecurityContext` helper.

## Why

Tenant namespaces labeled `pod-security.kubernetes.io/enforce=restricted` reject the previous Job spec with:

```
violates PodSecurity "restricted:latest":
  allowPrivilegeEscalation != false,
  unrestricted capabilities,
  runAsNonRoot != true,
  seccompProfile
```

Symptom: schema-index / discovery / test-connection Jobs never start, the dashboard shows "Schema index: Not indexed" indefinitely. The agent image (Alpine + static Go binary) already runs as UID 1000 with no capabilities — this is a spec-only fix, no runtime behavior change.

## Test plan

- [x] `go test ./internal/runner/...` in `services/api` — full package PASS (incl. three new tests)
- [x] `golangci-lint run ./...` in `services/api` — 0 issues
- [x] `go build ./...` in `services/api` — clean
- [ ] On a tenant cluster with `pod-security.kubernetes.io/enforce=restricted`, trigger a schema-index run and confirm the Job pod is admitted and completes
- [ ] Same cluster: trigger a discovery run and a warehouse test-connection, confirm both admit and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)