### PR TITLE
fix(ui): hide SchemaIndexPanel when status is ready on home + pack-gen-pending

### DIFF
--- a/ui/dashboard/src/__tests__/SchemaIndexPanel.test.tsx
+++ b/ui/dashboard/src/__tests__/SchemaIndexPanel.test.tsx
@@ -27,6 +27,14 @@ function mount(onChange?: jest.Mock) {
   );
 }
 
+function mountHideWhenReady(onChange?: jest.Mock) {
+  return render(
+    <MantineProvider>
+      <SchemaIndexPanel projectId="p1" onStatusChange={onChange} hideWhenReady />
+    </MantineProvider>
+  );
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   // Panel's log-tail effect triggers listSchemaIndexLogs when the
@@ -200,5 +208,71 @@ describe('SchemaIndexPanel', () => {
     (await screen.findByRole('button', { name: /Cancel indexing/i })).click();
     (await screen.findByRole('button', { name: /Yes, cancel/i })).click();
     await waitFor(() => expect(screen.getByText(/network down/i)).toBeInTheDocument());
+  });
+
+  // hideWhenReady is the opt-in the project home + pack-gen-pending
+  // surfaces pass — those convey "ready" via their own badge / helper
+  // copy, so the verbose panel banner is duplicative noise in
+  // steady state. Polling continues so the panel re-appears the
+  // moment status flips to anything actionable.
+  it('hideWhenReady=true + status=ready renders nothing (steady-state hidden)', async () => {
+    const onChange = jest.fn();
+    mockedApi.getSchemaIndexStatus.mockResolvedValue({
+      status: 'ready',
+      updated_at: '2026-05-22T18:00:00Z',
+    });
+    const { container } = mountHideWhenReady(onChange);
+    // onStatusChange still fires once polling lands — the parent
+    // needs the status to drive its own gating UI even when the
+    // panel itself is invisible.
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ status: 'ready' })));
+    // The panel renders no visible DOM beyond what the wrapping
+    // Mantine provider injects. The Re-index button + banner are
+    // both gone — Settings → Clear cache is the path to flip to
+    // needs_reindex and bring the panel back.
+    expect(screen.queryByText(/Schema index:/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Re-index/i })).not.toBeInTheDocument();
+    // Sanity — no Card / Alert mounted by our component (only the
+    // Mantine portal node Notifications would inject).
+    expect(container.querySelector('[class*="mantine-Alert-root"]')).toBeNull();
+  });
+
+  it('hideWhenReady=true + status=indexing still renders the in-flight banner', async () => {
+    // The hide gate is specifically "ready" — anything actionable
+    // (indexing, pending_indexing, failed, cancelled, needs_reindex)
+    // still surfaces so the operator never loses sight of a real
+    // workflow state.
+    mockedApi.getSchemaIndexStatus.mockResolvedValue({
+      status: 'indexing',
+      progress: { phase: 'embedding', tables_total: 100, tables_done: 42 },
+    });
+    mountHideWhenReady();
+    await waitFor(() => expect(screen.getByText(/Schema index:/)).toBeInTheDocument());
+    // Cancel button is the in-flight action; presence confirms the
+    // panel rendered the full banner, not just empty space.
+    expect(screen.getByRole('button', { name: /Cancel indexing/i })).toBeInTheDocument();
+  });
+
+  it('hideWhenReady=true + status=needs_reindex still renders so the operator can re-index', async () => {
+    mockedApi.getSchemaIndexStatus.mockResolvedValue({ status: 'needs_reindex' });
+    mountHideWhenReady();
+    await waitFor(() => expect(screen.getByText(/Schema index:/)).toBeInTheDocument());
+    expect(screen.getByText(/Cache cleared/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Re-index now/i })).toBeInTheDocument();
+  });
+
+  it('hideWhenReady=false (default) still renders the Ready banner — preserves the wizard contract', async () => {
+    // The wizard's last step keeps the default behaviour so
+    // operators see the explicit "Ready" affordance before
+    // clicking Generate pack. This test pins that contract — a
+    // bug that flipped the default to true would silently break
+    // the wizard's pre-flight indicator.
+    mockedApi.getSchemaIndexStatus.mockResolvedValue({
+      status: 'ready',
+      updated_at: '2026-05-22T18:00:00Z',
+    });
+    mount(); // no hideWhenReady — default false
+    await waitFor(() => expect(screen.getByText(/Schema index:/)).toBeInTheDocument());
+    expect(screen.getByText(/Ready/)).toBeInTheDocument();
   });
 });

--- a/ui/dashboard/src/app/projects/[id]/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/page.tsx
@@ -275,9 +275,15 @@ export default function ProjectPage() {
 
   return (
     <Shell breadcrumb={breadcrumb} actions={topBarActions}>
-      {/* Schema-index status banner — polls every 2s while indexing. */}
+      {/* Schema-index status banner — polls every 2s while indexing.
+          hideWhenReady keeps the banner invisible on the discovery
+          steady state (status=ready), since the panel only adds value
+          when there's something to act on (indexing in flight,
+          needs_reindex after Settings → Clear cache, failed /
+          cancelled recovery). The Re-index entry point on the panel
+          re-appears the moment status flips back to non-ready. */}
       <div style={{ marginBottom: 16 }}>
-        <SchemaIndexPanel projectId={id} onStatusChange={setSchemaIndexStatus} />
+        <SchemaIndexPanel projectId={id} onStatusChange={setSchemaIndexStatus} hideWhenReady />
       </div>
 
       {/* Aggregate Stats Row */}

--- a/ui/dashboard/src/components/SchemaIndexPanel.tsx
+++ b/ui/dashboard/src/components/SchemaIndexPanel.tsx
@@ -33,6 +33,18 @@ interface Props {
    * "Step 1 of 2 — Indexing schema".
    */
   title?: string;
+  /**
+   * When true, the panel renders nothing while `status === 'ready'`.
+   * Polling continues internally so the panel re-appears the moment
+   * the status flips to anything actionable (`needs_reindex`,
+   * `indexing`, `failed`, `cancelled`). Used by surfaces where the
+   * "Ready" steady state is visual noise (the project home + the
+   * pack-gen panel — the badge / helper copy already convey the
+   * "ready" signal). The wizard's last step keeps the default
+   * (false) so operators see the explicit "Ready" affordance
+   * before clicking Generate pack.
+   */
+  hideWhenReady?: boolean;
 }
 
 const POLL_MS = 2000;
@@ -45,7 +57,7 @@ const PHASE_LABELS: Record<string, string> = {
   embedding: 'Building vector index',
 };
 
-export function SchemaIndexPanel({ projectId, onStatusChange, title }: Props) {
+export function SchemaIndexPanel({ projectId, onStatusChange, title, hideWhenReady = false }: Props) {
   const [status, setStatus] = useState<SchemaIndexStatus | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -224,7 +236,29 @@ export function SchemaIndexPanel({ projectId, onStatusChange, title }: Props) {
             : <IconRotateClockwise size={16} />;
 
   if (!status) {
-    return <Text size="sm" c="dimmed">Loading schema index status...</Text>;
+    return hideWhenReady
+      // When the caller opts in to hide-when-ready, also suppress
+      // the brief "Loading schema index status..." flash on the
+      // initial mount — for the project-home steady state the
+      // panel is supposed to be invisible whenever there's
+      // nothing actionable to surface, and the pre-poll moment
+      // counts. Polling still kicks off the moment the component
+      // mounts, so the panel re-appears the instant the first
+      // poll returns a non-ready status.
+      ? null
+      : <Text size="sm" c="dimmed">Loading schema index status...</Text>;
+  }
+
+  // hideWhenReady is the project-home / pack-gen-panel opt-in:
+  // those surfaces convey "ready" through their own badge / helper
+  // copy, so the verbose "Schema index: Ready · last built X · Re-index"
+  // banner is redundant visual noise in steady state. Polling
+  // continues (the useEffect above still runs), so the panel
+  // re-appears the moment status changes to anything else
+  // (`needs_reindex` after Settings → Clear cache, `indexing`
+  // after a re-index kick-off, `failed` / `cancelled` recovery).
+  if (hideWhenReady && status.status === 'ready') {
+    return null;
   }
 
   const updatedDate = status.updated_at ? new Date(status.updated_at).toLocaleString() : null;

--- a/ui/dashboard/src/components/projects/PackGenStatusPanel.tsx
+++ b/ui/dashboard/src/components/projects/PackGenStatusPanel.tsx
@@ -206,7 +206,19 @@ export default function PackGenStatusPanel({ project, onProjectChanged }: PackGe
           )}
           <Text size="sm" c="dimmed">{helperCopy}</Text>
           {showIndexPanel && (
-            <SchemaIndexPanel projectId={project.id} onStatusChange={setIndexStatus} />
+            // hideWhenReady on the pack-gen-pending surface: the badge
+            // ("Schema indexed — step 1 of 2") and the helper copy
+            // already convey "ready", so the verbose
+            // "Schema index: Ready · last built X" banner is
+            // duplicative noise in steady state. The panel still polls
+            // and re-appears the moment status changes
+            // (needs_reindex / indexing / failed / cancelled) so the
+            // operator never loses sight of in-flight or recovery
+            // states. The pack_generation two-step view below keeps
+            // the default (panel always visible) — there "Ready"
+            // means "Step 1 done, Step 2 running" and the panel IS
+            // the step-1 progress display.
+            <SchemaIndexPanel projectId={project.id} onStatusChange={setIndexStatus} hideWhenReady />
           )}
           <Group justify="flex-end">
             <Button onClick={() => router.push(`/projects/${project.id}/generate`)}>


### PR DESCRIPTION
Adds `hideWhenReady` opt-in. Project home + pack-gen-pending pass it (Ready state is duplicative noise there). Wizard last step keeps default false so the operator still sees the explicit Ready affordance before clicking Generate pack. Polling continues internally so the panel reappears the moment status flips to anything actionable (needs_reindex / indexing / failed / cancelled).

Four new tests + tsc + eslint + jest (252/252) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)