### PR TITLE
fix(api): raise HTTP WriteTimeout to 5 min for synchronous LLM routes

### DIFF
--- a/services/api/apiserver/apiserver.go
+++ b/services/api/apiserver/apiserver.go
@@ -296,10 +296,23 @@ func Run() {
 		qdrantProvider,
 	)
 	srv := &http.Server{
-		Addr:         ":" + cfg.Server.Port,
-		Handler:      ApplyGlobalMiddlewares(handler),
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		Addr:    ":" + cfg.Server.Port,
+		Handler: ApplyGlobalMiddlewares(handler),
+		// ReadTimeout governs slow-client requests; 15s is generous
+		// for the largest legitimate JSON body the dashboard sends.
+		ReadTimeout: 15 * time.Second,
+		// WriteTimeout must outlive the longest legitimate handler.
+		// Synchronous LLM-driven routes (the enterprise pack-gen
+		// regenerate-section endpoint is the canonical case)
+		// routinely take 30-60s of model time; the previous 30s
+		// budget closed the connection before the handler's
+		// writeJSON could fire, leaving the UI to think the request
+		// had failed even though the Mongo side-effects had
+		// committed. 5 minutes covers every LLM provider we ship
+		// plus margin. Per-route control would be tighter but
+		// requires middleware not yet justified by a second use
+		// case.
+		WriteTimeout: 5 * time.Minute,
 		IdleTimeout:  60 * time.Second,
 	}
 


### PR DESCRIPTION
## Summary
- Bumps the apiserver's `*http.Server.WriteTimeout` from 30s to 5m so synchronous LLM-driven handlers (notably the enterprise pack-gen plugin's `regenerate-section` endpoint) can finish writing their response.

## Why
The 30s ceiling was shorter than any realistic LLM round-trip. A typical Bedrock Opus 4.6 single-section regeneration takes 30–60s of model time. Concretely on the enterprise build today: `POST /api/pack-gen/projects/{id}/regenerate-section` runs synchronously, the handler's goroutine completes the LLM call + Mongo write, but the HTTP connection is already closed → `curl` returns exit 52 ("Empty reply"), the dashboard renders it as a generic fetch failure, and the customer re-fires the request (burning a second round of tokens) for a regen that actually succeeded server-side.

5 minutes covers every LLM provider we ship plus margin. Per-route timeout middleware would be tighter, but a second use case hasn't appeared yet.

## Verification
- `make test-go` clean (`services/api/apiserver/` test suite green).
- `make lint-go` clean.
- Manually exercised the failing case (enterprise build, regen-section against Bedrock): pre-bump → curl exit 52 + Mongo write committed; post-bump → curl 200 + Mongo write committed.

## Test plan
- [ ] CI green on this branch
- [ ] No other synchronous handler is suddenly tying up a connection for longer than 30s — `grep -rnE "time\.(Sleep|After)|http\.NewRequest" services/api/internal/handler` shows the existing slowest synchronous paths are the AI ones; 5min is a safe envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)