### PR TITLE
refactor(api): expose ValidateDomainPack via models package

### DIFF
--- a/services/api/internal/handler/domain_packs.go
+++ b/services/api/internal/handler/domain_packs.go
@@ -61,7 +61,7 @@ func (h *DomainPacksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := ValidateDomainPack(&pack); err != nil {
+	if err := models.ValidateDomainPack(&pack); err != nil {
 		writeError(w, http.StatusBadRequest, "validation error: "+err.Error())
 		return
 	}
@@ -104,7 +104,7 @@ func (h *DomainPacksHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// Preserve slug from URL
 	pack.Slug = slug
 
-	if err := ValidateDomainPack(&pack); err != nil {
+	if err := models.ValidateDomainPack(&pack); err != nil {
 		writeError(w, http.StatusBadRequest, "validation error: "+err.Error())
 		return
 	}
@@ -157,7 +157,7 @@ func (h *DomainPacksHandler) Import(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pack := &portable.Pack
-	if err := ValidateDomainPack(pack); err != nil {
+	if err := models.ValidateDomainPack(pack); err != nil {
 		writeError(w, http.StatusBadRequest, "validation error: "+err.Error())
 		return
 	}

--- a/services/api/internal/handler/domain_packs_test.go
+++ b/services/api/internal/handler/domain_packs_test.go
@@ -565,45 +565,8 @@ func TestProjectsHandler_Create_DomainPackNotFound(t *testing.T) {
 	}
 }
 
-// --- Seed validation edge cases ---
-
-func TestValidateDomainPack_CategoryAreaValidation(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.AnalysisAreas.Categories["match3"] = []models.PackAnalysisArea{
-		{ID: "", Name: "Bad", Keywords: []string{"x"}, Prompt: "x"},
-	}
-	err := models.ValidateDomainPack(pack)
-	if err == nil {
-		t.Error("should reject category area with empty ID")
-	}
-}
-
-func TestValidateDomainPack_ExplorationMissingSchemaInfo(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.Prompts.Base.Exploration = "Explore {{DATASET}} with {{ANALYSIS_AREAS}}"
-	err := models.ValidateDomainPack(pack)
-	if err == nil {
-		t.Error("should require {{SCHEMA_INFO}} in exploration")
-	}
-}
-
-func TestValidateDomainPack_RecommendationsMissingInsightsData(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.Prompts.Base.Recommendations = "Generate recommendations"
-	err := models.ValidateDomainPack(pack)
-	if err == nil {
-		t.Error("should require {{INSIGHTS_DATA}} in recommendations")
-	}
-}
-
-func TestValidateDomainPack_CategoryMissingName(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.Categories[0].Name = ""
-	err := models.ValidateDomainPack(pack)
-	if err == nil {
-		t.Error("should require category name")
-	}
-}
+// Validator tests live in services/api/models/domainpack_validator_test.go
+// alongside the function under test.
 
 func TestMergeProfileSchema_NilBase(t *testing.T) {
 	pack := &models.DomainPack{

--- a/services/api/internal/handler/domain_packs_test.go
+++ b/services/api/internal/handler/domain_packs_test.go
@@ -572,7 +572,7 @@ func TestValidateDomainPack_CategoryAreaValidation(t *testing.T) {
 	pack.AnalysisAreas.Categories["match3"] = []models.PackAnalysisArea{
 		{ID: "", Name: "Bad", Keywords: []string{"x"}, Prompt: "x"},
 	}
-	err := ValidateDomainPack(pack)
+	err := models.ValidateDomainPack(pack)
 	if err == nil {
 		t.Error("should reject category area with empty ID")
 	}
@@ -581,7 +581,7 @@ func TestValidateDomainPack_CategoryAreaValidation(t *testing.T) {
 func TestValidateDomainPack_ExplorationMissingSchemaInfo(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.Prompts.Base.Exploration = "Explore {{DATASET}} with {{ANALYSIS_AREAS}}"
-	err := ValidateDomainPack(pack)
+	err := models.ValidateDomainPack(pack)
 	if err == nil {
 		t.Error("should require {{SCHEMA_INFO}} in exploration")
 	}
@@ -590,7 +590,7 @@ func TestValidateDomainPack_ExplorationMissingSchemaInfo(t *testing.T) {
 func TestValidateDomainPack_RecommendationsMissingInsightsData(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.Prompts.Base.Recommendations = "Generate recommendations"
-	err := ValidateDomainPack(pack)
+	err := models.ValidateDomainPack(pack)
 	if err == nil {
 		t.Error("should require {{INSIGHTS_DATA}} in recommendations")
 	}
@@ -599,7 +599,7 @@ func TestValidateDomainPack_RecommendationsMissingInsightsData(t *testing.T) {
 func TestValidateDomainPack_CategoryMissingName(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.Categories[0].Name = ""
-	err := ValidateDomainPack(pack)
+	err := models.ValidateDomainPack(pack)
 	if err == nil {
 		t.Error("should require category name")
 	}

--- a/services/api/internal/handler/handler_test.go
+++ b/services/api/internal/handler/handler_test.go
@@ -10,7 +10,6 @@ import (
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
 	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/runner"
-	"github.com/decisionbox-io/decisionbox/services/api/models"
 
 	_ "github.com/decisionbox-io/decisionbox/providers/llm/claude"
 	_ "github.com/decisionbox-io/decisionbox/providers/llm/openai"
@@ -95,70 +94,8 @@ func TestDecodeJSON_Invalid(t *testing.T) {
 	}
 }
 
-// --- Validate Domain Pack ---
-
-func TestValidateDomainPack_Valid(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	if err := models.ValidateDomainPack(pack); err != nil {
-		t.Errorf("valid pack should pass: %v", err)
-	}
-}
-
-func TestValidateDomainPack_MissingSlug(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.Slug = ""
-	if err := models.ValidateDomainPack(pack); err == nil {
-		t.Error("should require slug")
-	}
-}
-
-func TestValidateDomainPack_MissingCategories(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.Categories = nil
-	if err := models.ValidateDomainPack(pack); err == nil {
-		t.Error("should require at least one category")
-	}
-}
-
-func TestValidateDomainPack_MissingBaseContext(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.Prompts.Base.BaseContext = ""
-	if err := models.ValidateDomainPack(pack); err == nil {
-		t.Error("should require base_context")
-	}
-}
-
-func TestValidateDomainPack_MissingProfileTemplate(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.Prompts.Base.BaseContext = "no profile variable"
-	if err := models.ValidateDomainPack(pack); err == nil {
-		t.Error("should require {{PROFILE}} in base_context")
-	}
-}
-
-func TestValidateDomainPack_MissingAnalysisAreas(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.AnalysisAreas.Base = nil
-	if err := models.ValidateDomainPack(pack); err == nil {
-		t.Error("should require at least one base analysis area")
-	}
-}
-
-func TestValidateDomainPack_AreaMissingPrompt(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.AnalysisAreas.Base[0].Prompt = ""
-	if err := models.ValidateDomainPack(pack); err == nil {
-		t.Error("should require prompt in analysis area")
-	}
-}
-
-func TestValidateDomainPack_AreaMissingKeywords(t *testing.T) {
-	pack := testDomainPack("gaming", "match3")
-	pack.AnalysisAreas.Base[0].Keywords = nil
-	if err := models.ValidateDomainPack(pack); err == nil {
-		t.Error("should require keywords in analysis area")
-	}
-}
+// Validator tests live in services/api/models/domainpack_validator_test.go
+// alongside the function under test.
 
 // --- Provider Endpoints ---
 

--- a/services/api/internal/handler/handler_test.go
+++ b/services/api/internal/handler/handler_test.go
@@ -10,6 +10,7 @@ import (
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
 	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/runner"
+	"github.com/decisionbox-io/decisionbox/services/api/models"
 
 	_ "github.com/decisionbox-io/decisionbox/providers/llm/claude"
 	_ "github.com/decisionbox-io/decisionbox/providers/llm/openai"
@@ -98,7 +99,7 @@ func TestDecodeJSON_Invalid(t *testing.T) {
 
 func TestValidateDomainPack_Valid(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
-	if err := ValidateDomainPack(pack); err != nil {
+	if err := models.ValidateDomainPack(pack); err != nil {
 		t.Errorf("valid pack should pass: %v", err)
 	}
 }
@@ -106,7 +107,7 @@ func TestValidateDomainPack_Valid(t *testing.T) {
 func TestValidateDomainPack_MissingSlug(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.Slug = ""
-	if err := ValidateDomainPack(pack); err == nil {
+	if err := models.ValidateDomainPack(pack); err == nil {
 		t.Error("should require slug")
 	}
 }
@@ -114,7 +115,7 @@ func TestValidateDomainPack_MissingSlug(t *testing.T) {
 func TestValidateDomainPack_MissingCategories(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.Categories = nil
-	if err := ValidateDomainPack(pack); err == nil {
+	if err := models.ValidateDomainPack(pack); err == nil {
 		t.Error("should require at least one category")
 	}
 }
@@ -122,7 +123,7 @@ func TestValidateDomainPack_MissingCategories(t *testing.T) {
 func TestValidateDomainPack_MissingBaseContext(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.Prompts.Base.BaseContext = ""
-	if err := ValidateDomainPack(pack); err == nil {
+	if err := models.ValidateDomainPack(pack); err == nil {
 		t.Error("should require base_context")
 	}
 }
@@ -130,7 +131,7 @@ func TestValidateDomainPack_MissingBaseContext(t *testing.T) {
 func TestValidateDomainPack_MissingProfileTemplate(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.Prompts.Base.BaseContext = "no profile variable"
-	if err := ValidateDomainPack(pack); err == nil {
+	if err := models.ValidateDomainPack(pack); err == nil {
 		t.Error("should require {{PROFILE}} in base_context")
 	}
 }
@@ -138,7 +139,7 @@ func TestValidateDomainPack_MissingProfileTemplate(t *testing.T) {
 func TestValidateDomainPack_MissingAnalysisAreas(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.AnalysisAreas.Base = nil
-	if err := ValidateDomainPack(pack); err == nil {
+	if err := models.ValidateDomainPack(pack); err == nil {
 		t.Error("should require at least one base analysis area")
 	}
 }
@@ -146,7 +147,7 @@ func TestValidateDomainPack_MissingAnalysisAreas(t *testing.T) {
 func TestValidateDomainPack_AreaMissingPrompt(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.AnalysisAreas.Base[0].Prompt = ""
-	if err := ValidateDomainPack(pack); err == nil {
+	if err := models.ValidateDomainPack(pack); err == nil {
 		t.Error("should require prompt in analysis area")
 	}
 }
@@ -154,7 +155,7 @@ func TestValidateDomainPack_AreaMissingPrompt(t *testing.T) {
 func TestValidateDomainPack_AreaMissingKeywords(t *testing.T) {
 	pack := testDomainPack("gaming", "match3")
 	pack.AnalysisAreas.Base[0].Keywords = nil
-	if err := ValidateDomainPack(pack); err == nil {
+	if err := models.ValidateDomainPack(pack); err == nil {
 		t.Error("should require keywords in analysis area")
 	}
 }

--- a/services/api/internal/handler/seed_packs.go
+++ b/services/api/internal/handler/seed_packs.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
-	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -13,8 +11,6 @@ import (
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	"github.com/decisionbox-io/decisionbox/services/api/models"
 )
-
-var slugRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 
 //go:embed seed/*.json
 var seedFS embed.FS
@@ -82,93 +78,3 @@ func SeedBuiltInPacks(ctx context.Context, repo database.DomainPackRepo) {
 	}
 }
 
-// ValidateDomainPack checks that a domain pack has all required fields and prompts.
-func ValidateDomainPack(pack *models.DomainPack) error {
-	if pack.Slug == "" {
-		return fmt.Errorf("slug is required")
-	}
-	if len(pack.Slug) < 2 || !slugRegexp.MatchString(pack.Slug) {
-		return fmt.Errorf("slug must be lowercase alphanumeric with hyphens (e.g. 'gaming', 'e-commerce')")
-	}
-	if pack.Name == "" {
-		return fmt.Errorf("name is required")
-	}
-	if len(pack.Categories) == 0 {
-		return fmt.Errorf("at least one category is required")
-	}
-
-	// Validate categories have IDs
-	for i, cat := range pack.Categories {
-		if cat.ID == "" {
-			return fmt.Errorf("category %d: id is required", i)
-		}
-		if cat.Name == "" {
-			return fmt.Errorf("category %q: name is required", cat.ID)
-		}
-	}
-
-	// Validate base prompts
-	if pack.Prompts.Base.BaseContext == "" {
-		return fmt.Errorf("base_context prompt is required")
-	}
-	if pack.Prompts.Base.Exploration == "" {
-		return fmt.Errorf("exploration prompt is required")
-	}
-	if pack.Prompts.Base.Recommendations == "" {
-		return fmt.Errorf("recommendations prompt is required")
-	}
-
-	// Validate template variables in prompts
-	if !strings.Contains(pack.Prompts.Base.BaseContext, "{{PROFILE}}") {
-		return fmt.Errorf("base_context must contain {{PROFILE}} template variable")
-	}
-	if !strings.Contains(pack.Prompts.Base.Exploration, "{{DATASET}}") {
-		return fmt.Errorf("exploration must contain {{DATASET}} template variable")
-	}
-	if !strings.Contains(pack.Prompts.Base.Exploration, "{{SCHEMA_INFO}}") {
-		return fmt.Errorf("exploration must contain {{SCHEMA_INFO}} template variable")
-	}
-	if !strings.Contains(pack.Prompts.Base.Exploration, "{{ANALYSIS_AREAS}}") {
-		return fmt.Errorf("exploration must contain {{ANALYSIS_AREAS}} template variable")
-	}
-	if !strings.Contains(pack.Prompts.Base.Recommendations, "{{INSIGHTS_DATA}}") {
-		return fmt.Errorf("recommendations must contain {{INSIGHTS_DATA}} template variable")
-	}
-
-	// Validate base analysis areas
-	if len(pack.AnalysisAreas.Base) == 0 {
-		return fmt.Errorf("at least one base analysis area is required")
-	}
-	for i, area := range pack.AnalysisAreas.Base {
-		if err := validateAnalysisArea(area, fmt.Sprintf("base area %d", i)); err != nil {
-			return err
-		}
-	}
-
-	// Validate category analysis areas
-	for catID, areas := range pack.AnalysisAreas.Categories {
-		for i, area := range areas {
-			if err := validateAnalysisArea(area, fmt.Sprintf("category %q area %d", catID, i)); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func validateAnalysisArea(area models.PackAnalysisArea, label string) error {
-	if area.ID == "" {
-		return fmt.Errorf("%s: id is required", label)
-	}
-	if area.Name == "" {
-		return fmt.Errorf("%s (%s): name is required", label, area.ID)
-	}
-	if area.Prompt == "" {
-		return fmt.Errorf("%s (%s): prompt is required", label, area.ID)
-	}
-	if len(area.Keywords) == 0 {
-		return fmt.Errorf("%s (%s): at least one keyword is required", label, area.ID)
-	}
-	return nil
-}

--- a/services/api/models/domainpack_validator.go
+++ b/services/api/models/domainpack_validator.go
@@ -1,0 +1,120 @@
+package models
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// DomainPackSlugRegex is the canonical slug shape for a saved domain
+// pack. Mirrors the regex enforced by the API on pack creation and
+// import; exported so the enterprise packgen plugin can validate
+// generated slugs against the same contract before persistence.
+var DomainPackSlugRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+
+// ValidateDomainPack returns nil if the pack passes every check the
+// API's save / import flow runs, or an error describing the first
+// failure.
+//
+// This is the single source of truth for "is this pack persistable"
+// — the dashboard's PUT /api/v1/domain-packs/{slug} handler runs
+// it, the seed-loading flow runs it, and the enterprise packgen
+// plugin's auto-fix loop runs it (via its own import) so a
+// generated pack that would later be rejected at save time is
+// caught at generation time instead.
+//
+// Checks:
+//   - slug shape (DomainPackSlugRegex, min length 2)
+//   - name + at least one category, each with id + name
+//   - base prompts non-empty
+//   - required template placeholders: {{PROFILE}} in base_context;
+//     {{DATASET}}, {{SCHEMA_INFO}}, {{ANALYSIS_AREAS}} in exploration;
+//     {{INSIGHTS_DATA}} in recommendations — substituted by the
+//     discovery agent at run-time and required by the agent's
+//     prompt-rendering pipeline.
+//   - at least one base analysis area; every area (base and
+//     per-category) has id + name + prompt + at least one keyword.
+func ValidateDomainPack(pack *DomainPack) error {
+	if pack.Slug == "" {
+		return fmt.Errorf("slug is required")
+	}
+	if len(pack.Slug) < 2 || !DomainPackSlugRegex.MatchString(pack.Slug) {
+		return fmt.Errorf("slug must be lowercase alphanumeric with hyphens (e.g. 'gaming', 'e-commerce')")
+	}
+	if pack.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(pack.Categories) == 0 {
+		return fmt.Errorf("at least one category is required")
+	}
+
+	for i, cat := range pack.Categories {
+		if cat.ID == "" {
+			return fmt.Errorf("category %d: id is required", i)
+		}
+		if cat.Name == "" {
+			return fmt.Errorf("category %q: name is required", cat.ID)
+		}
+	}
+
+	if pack.Prompts.Base.BaseContext == "" {
+		return fmt.Errorf("base_context prompt is required")
+	}
+	if pack.Prompts.Base.Exploration == "" {
+		return fmt.Errorf("exploration prompt is required")
+	}
+	if pack.Prompts.Base.Recommendations == "" {
+		return fmt.Errorf("recommendations prompt is required")
+	}
+
+	if !strings.Contains(pack.Prompts.Base.BaseContext, "{{PROFILE}}") {
+		return fmt.Errorf("base_context must contain {{PROFILE}} template variable")
+	}
+	if !strings.Contains(pack.Prompts.Base.Exploration, "{{DATASET}}") {
+		return fmt.Errorf("exploration must contain {{DATASET}} template variable")
+	}
+	if !strings.Contains(pack.Prompts.Base.Exploration, "{{SCHEMA_INFO}}") {
+		return fmt.Errorf("exploration must contain {{SCHEMA_INFO}} template variable")
+	}
+	if !strings.Contains(pack.Prompts.Base.Exploration, "{{ANALYSIS_AREAS}}") {
+		return fmt.Errorf("exploration must contain {{ANALYSIS_AREAS}} template variable")
+	}
+	if !strings.Contains(pack.Prompts.Base.Recommendations, "{{INSIGHTS_DATA}}") {
+		return fmt.Errorf("recommendations must contain {{INSIGHTS_DATA}} template variable")
+	}
+
+	if len(pack.AnalysisAreas.Base) == 0 {
+		return fmt.Errorf("at least one base analysis area is required")
+	}
+	for i, area := range pack.AnalysisAreas.Base {
+		if err := validateAnalysisArea(area, fmt.Sprintf("base area %d", i)); err != nil {
+			return err
+		}
+	}
+
+	for catID, areas := range pack.AnalysisAreas.Categories {
+		for i, area := range areas {
+			if err := validateAnalysisArea(area, fmt.Sprintf("category %q area %d", catID, i)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateAnalysisArea(area PackAnalysisArea, label string) error {
+	if area.ID == "" {
+		return fmt.Errorf("%s: id is required", label)
+	}
+	if area.Name == "" {
+		return fmt.Errorf("%s (%s): name is required", label, area.ID)
+	}
+	if area.Prompt == "" {
+		return fmt.Errorf("%s (%s): prompt is required", label, area.ID)
+	}
+	if len(area.Keywords) == 0 {
+		return fmt.Errorf("%s (%s): at least one keyword is required", label, area.ID)
+	}
+	return nil
+}

--- a/services/api/models/domainpack_validator_test.go
+++ b/services/api/models/domainpack_validator_test.go
@@ -1,0 +1,240 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+// testDomainPack returns a minimal valid pack. Test cases mutate one
+// field, call ValidateDomainPack, and assert on the result.
+func testDomainPack(slug, category string) *DomainPack {
+	return &DomainPack{
+		Slug:        slug,
+		Name:        slug,
+		IsPublished: true,
+		Categories: []PackCategory{
+			{ID: category, Name: category, Description: "test category"},
+		},
+		Prompts: PackPrompts{
+			Base: BasePrompts{
+				BaseContext:     "Context: {{PROFILE}}\n{{PREVIOUS_CONTEXT}}",
+				Exploration:     "Explore {{DATASET}} using {{SCHEMA_INFO}} areas: {{ANALYSIS_AREAS}}",
+				Recommendations: "Recommend based on {{INSIGHTS_DATA}} summary: {{INSIGHTS_SUMMARY}} date: {{DISCOVERY_DATE}}",
+			},
+			Categories: map[string]CategoryPrompts{
+				category: {ExplorationContext: "Category-specific context for " + category},
+			},
+		},
+		AnalysisAreas: PackAnalysisAreas{
+			Base: []PackAnalysisArea{
+				{
+					ID: "test_area", Name: "Test Area", Description: "Test analysis area",
+					Keywords: []string{"test"}, Priority: 1,
+					Prompt: "Analyze {{DATASET}}: {{QUERY_RESULTS}}",
+				},
+			},
+			Categories: map[string][]PackAnalysisArea{},
+		},
+		ProfileSchema: PackProfileSchema{
+			Base:       map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+			Categories: map[string]map[string]interface{}{},
+		},
+	}
+}
+
+func TestValidateDomainPack_Valid(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	if err := ValidateDomainPack(pack); err != nil {
+		t.Errorf("valid pack should pass: %v", err)
+	}
+}
+
+func TestValidateDomainPack_MissingSlug(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Slug = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require slug")
+	}
+}
+
+func TestValidateDomainPack_SlugRegexShape(t *testing.T) {
+	cases := []struct {
+		name  string
+		slug  string
+		valid bool
+	}{
+		{"valid lowercase", "gaming", true},
+		{"valid with digits", "1stplace", true},
+		{"valid with hyphens", "e-commerce", true},
+		{"valid all digits", "12345", true},
+		{"too short", "a", false},
+		{"trailing hyphen", "gaming-", false},
+		{"leading hyphen", "-gaming", false},
+		{"uppercase", "Gaming", false},
+		{"contains space", "two words", false},
+		{"contains underscore", "snake_case", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pack := testDomainPack(tc.slug, "match3")
+			err := ValidateDomainPack(pack)
+			if tc.valid && err != nil {
+				t.Errorf("%q should be valid, got %v", tc.slug, err)
+			}
+			if !tc.valid && err == nil {
+				t.Errorf("%q should be rejected", tc.slug)
+			}
+		})
+	}
+}
+
+func TestValidateDomainPack_MissingName(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Name = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require name")
+	}
+}
+
+func TestValidateDomainPack_MissingCategories(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Categories = nil
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require at least one category")
+	}
+}
+
+func TestValidateDomainPack_CategoryMissingID(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Categories[0].ID = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require category id")
+	}
+}
+
+func TestValidateDomainPack_CategoryMissingName(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Categories[0].Name = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require category name")
+	}
+}
+
+func TestValidateDomainPack_MissingBaseContext(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.BaseContext = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require base_context")
+	}
+}
+
+func TestValidateDomainPack_MissingExploration(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.Exploration = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require exploration")
+	}
+}
+
+func TestValidateDomainPack_MissingRecommendations(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.Recommendations = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require recommendations")
+	}
+}
+
+func TestValidateDomainPack_MissingProfileTemplate(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.BaseContext = "no profile variable"
+	err := ValidateDomainPack(pack)
+	if err == nil || !strings.Contains(err.Error(), "{{PROFILE}}") {
+		t.Errorf("should require {{PROFILE}} in base_context, got %v", err)
+	}
+}
+
+func TestValidateDomainPack_ExplorationMissingDataset(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.Exploration = "Explore using {{SCHEMA_INFO}} areas: {{ANALYSIS_AREAS}}"
+	err := ValidateDomainPack(pack)
+	if err == nil || !strings.Contains(err.Error(), "{{DATASET}}") {
+		t.Errorf("should require {{DATASET}} in exploration, got %v", err)
+	}
+}
+
+func TestValidateDomainPack_ExplorationMissingSchemaInfo(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.Exploration = "Explore {{DATASET}} with {{ANALYSIS_AREAS}}"
+	err := ValidateDomainPack(pack)
+	if err == nil || !strings.Contains(err.Error(), "{{SCHEMA_INFO}}") {
+		t.Errorf("should require {{SCHEMA_INFO}} in exploration, got %v", err)
+	}
+}
+
+func TestValidateDomainPack_ExplorationMissingAnalysisAreas(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.Exploration = "Explore {{DATASET}} using {{SCHEMA_INFO}}"
+	err := ValidateDomainPack(pack)
+	if err == nil || !strings.Contains(err.Error(), "{{ANALYSIS_AREAS}}") {
+		t.Errorf("should require {{ANALYSIS_AREAS}} in exploration, got %v", err)
+	}
+}
+
+func TestValidateDomainPack_RecommendationsMissingInsightsData(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Prompts.Base.Recommendations = "Generate recommendations"
+	err := ValidateDomainPack(pack)
+	if err == nil || !strings.Contains(err.Error(), "{{INSIGHTS_DATA}}") {
+		t.Errorf("should require {{INSIGHTS_DATA}} in recommendations, got %v", err)
+	}
+}
+
+func TestValidateDomainPack_MissingAnalysisAreas(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.AnalysisAreas.Base = nil
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require at least one base analysis area")
+	}
+}
+
+func TestValidateDomainPack_AreaMissingID(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.AnalysisAreas.Base[0].ID = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require id in analysis area")
+	}
+}
+
+func TestValidateDomainPack_AreaMissingName(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.AnalysisAreas.Base[0].Name = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require name in analysis area")
+	}
+}
+
+func TestValidateDomainPack_AreaMissingPrompt(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.AnalysisAreas.Base[0].Prompt = ""
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require prompt in analysis area")
+	}
+}
+
+func TestValidateDomainPack_AreaMissingKeywords(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.AnalysisAreas.Base[0].Keywords = nil
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should require keywords in analysis area")
+	}
+}
+
+func TestValidateDomainPack_CategoryAreaValidation(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.AnalysisAreas.Categories["match3"] = []PackAnalysisArea{
+		{ID: "", Name: "Bad", Keywords: []string{"x"}, Prompt: "x"},
+	}
+	if err := ValidateDomainPack(pack); err == nil {
+		t.Error("should reject category area with empty ID")
+	}
+}


### PR DESCRIPTION
## Summary

Moves the domain-pack validator out of `services/api/internal/handler/seed_packs.go` (unreachable from outside this Go module) into a public location at `services/api/models/domainpack_validator.go`. The enterprise `packgen` plugin will import + delegate to it in a sibling PR so the auto-fix loop catches packs that would later fail at save.

## Why

The function was duplicated in `decisionbox-enterprise/packgen/validator.go`. The two copies drifted: weaker LLM models produced packs the enterprise validator accepted but the community pack-save handler rejected:
- decisionbox-io/decisionbox-enterprise#64 — Ollama gemma4 dropped `{{INSIGHTS_DATA}}` in recommendations
- decisionbox-io/decisionbox-enterprise#65 — Vertex Gemini dropped `{{ANALYSIS_AREAS}}` in exploration

Go's `internal/` package rule blocked the enterprise plugin from importing the community validator directly. Moving it to a public package (`services/api/models/`, which enterprise already imports) makes one source of truth reachable from both code paths.

## Changes

- New file: `services/api/models/domainpack_validator.go` — `ValidateDomainPack`, `validateAnalysisArea`, and `DomainPackSlugRegex` (exported).
- Removed from: `services/api/internal/handler/seed_packs.go`.
- `services/api/internal/handler/domain_packs.go`: callers now use `models.ValidateDomainPack`.
- Test files (`handler_test.go`, `domain_packs_test.go`): updated to `models.ValidateDomainPack`.

## Behaviour change

None for community. Same regex (`^[a-z0-9][a-z0-9-]*[a-z0-9]$`), same checks, same error messages. The enterprise validator change rides on this in a follow-up PR.

## Test plan

- [ ] CI green (Go build + test + lint).
- [ ] `make test-go` passes locally — confirmed.
- [ ] `make lint-go` passes — confirmed.
- [ ] No grep hits for `internal/handler.ValidateDomainPack` outside the moved file — confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)