### PR TITLE
feat(providers/llm): Vertex AI MaaS catalog — add DeepSeek V3.2 + Llama 4 Scout, fix Maverick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **DeepSeek V3.2 added to the Vertex AI MaaS model catalog** — `providers/llm/vertex-ai/catalog.go`. Adds `deepseek-ai/deepseek-v3.2-maas` (alias `deepseek-ai/deepseek-v3.2`) as an OpenAI-compat MaaS entry: 128K context (`deepseekMaaSInputWindow`), 32768 max output, Vertex list price $0.56 / $1.68 per 1M input/output tokens. Previously the model was only usable as free-text, so `GetMaxOutputTokens` fell back to the vertex-ai provider default (16384) and the model never appeared in the dashboard model picker.
+
 ## [0.10.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Llama 4 Maverick catalog entry corrected** — `providers/llm/vertex-ai/catalog.go`. The model ID was `meta/llama-4-maverick-17b-instruct-maas`, which does not exist on Vertex (404 in every region); corrected to the real ID `meta/llama-4-maverick-17b-128e-instruct-maas`. Also fixes the output price ($1.40 → $1.15 per 1M). Max output stays 8192 (Vertex's enforced cap).
 
+- **DeepSeek R1 marked as a reasoning model** — `providers/llm/vertex-ai/catalog.go`. The `deepseek-ai/deepseek-r1-0528-maas` entry now sets `Reasoning: true` so `IsReasoningModel` reports correctly (R1 emits hidden chain-of-thought). All other values verified against the live endpoint and unchanged: 32768 max output (Vertex caps higher requests at 32768), ~128K context, $1.35 / $5.40 per 1M; served from `us-central1`.
+
 ## [0.10.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **DeepSeek V3.2 added to the Vertex AI MaaS model catalog** — `providers/llm/vertex-ai/catalog.go`. Adds `deepseek-ai/deepseek-v3.2-maas` (alias `deepseek-ai/deepseek-v3.2`) as an OpenAI-compat MaaS entry: 128K context (`deepseekMaaSInputWindow`), 32768 max output, Vertex list price $0.56 / $1.68 per 1M input/output tokens. Previously the model was only usable as free-text, so `GetMaxOutputTokens` fell back to the vertex-ai provider default (16384) and the model never appeared in the dashboard model picker.
 
+- **Llama 4 Scout added to the Vertex AI MaaS model catalog** — `providers/llm/vertex-ai/catalog.go`. Adds `meta/llama-4-scout-17b-16e-instruct-maas` as an OpenAI-compat MaaS entry: 10M context, 8192 max output, Vertex list price $0.25 / $0.70 per 1M input/output tokens. Both Llama 4 models are served only from `us-east5`, and Vertex caps their max output at 8192 (verified against the live endpoint — a higher `maxOutputTokens` returns a 400).
+
+### Fixed
+
+- **Llama 4 Maverick catalog entry corrected** — `providers/llm/vertex-ai/catalog.go`. The model ID was `meta/llama-4-maverick-17b-instruct-maas`, which does not exist on Vertex (404 in every region); corrected to the real ID `meta/llama-4-maverick-17b-128e-instruct-maas`. Also fixes the output price ($1.40 → $1.15 per 1M). Max output stays 8192 (Vertex's enforced cap).
+
 ## [0.10.0] - 2026-05-28
 
 ### Added

--- a/providers/llm/vertex-ai/catalog.go
+++ b/providers/llm/vertex-ai/catalog.go
@@ -240,6 +240,17 @@ func buildVertexCatalog() []gollm.ModelEntry {
 			MaxInputTokens:  deepseekMaaSInputWindow,
 			Pricing:         gollm.TokenPricing{InputPerMillion: 1.35, OutputPerMillion: 5.40},
 		},
+		{
+			// Same: DeepSeek V3.2's chat-capable MaaS endpoint is the
+			// "-maas"-suffixed ID. 128K context, 32K max output.
+			ID:              "deepseek-ai/deepseek-v3.2-maas",
+			Aliases:         []string{"deepseek-ai/deepseek-v3.2"},
+			DisplayName:     "DeepSeek V3.2 (Vertex MaaS)",
+			Wire:            gollm.WireOpenAICompat,
+			MaxOutputTokens: 32768,
+			MaxInputTokens:  deepseekMaaSInputWindow,
+			Pricing:         gollm.TokenPricing{InputPerMillion: 0.56, OutputPerMillion: 1.68},
+		},
 	}
 	// Claude 4.x on Vertex shares the 200K standard context window —
 	// fill once rather than duplicate the value on every entry.

--- a/providers/llm/vertex-ai/catalog.go
+++ b/providers/llm/vertex-ai/catalog.go
@@ -40,13 +40,14 @@ const (
 // as well (Google publishes 1M for the entire 1.5 / 2.x line). MaaS
 // models vary — set per-entry below.
 const (
-	claude4InputWindow      = 200000
-	gemini1MInputWindow     = 1000000
-	llama3MaaSInputWindow   = 128000
-	llama4MaaSInputWindow   = 1000000
-	qwenMaaSInputWindow     = 256000
-	mistralMaaSInputWindow  = 128000
-	deepseekMaaSInputWindow = 128000
+	claude4InputWindow            = 200000
+	gemini1MInputWindow           = 1000000
+	llama3MaaSInputWindow         = 128000
+	llama4MaverickMaaSInputWindow = 1000000
+	llama4ScoutMaaSInputWindow    = 10000000
+	qwenMaaSInputWindow           = 256000
+	mistralMaaSInputWindow        = 128000
+	deepseekMaaSInputWindow       = 128000
 )
 
 // buildVertexCatalog returns every Vertex AI model DecisionBox ships
@@ -201,12 +202,25 @@ func buildVertexCatalog() []gollm.ModelEntry {
 			Pricing:         gollm.TokenPricing{InputPerMillion: 0.72, OutputPerMillion: 0.72},
 		},
 		{
-			ID:              "meta/llama-4-maverick-17b-instruct-maas",
-			DisplayName:     "Llama 4 Maverick 17B (Vertex MaaS)",
+			// Llama 4 Maverick + Scout MaaS endpoints use the
+			// "-maas"-suffixed publisher IDs and are served only from
+			// us-east5 (global / us-central1 return 404). Vertex caps
+			// max output at 8192 for both — a higher maxOutputTokens
+			// 400s with "supported range ... to 8193 (exclusive)".
+			ID:              "meta/llama-4-maverick-17b-128e-instruct-maas",
+			DisplayName:     "Llama 4 Maverick 17B 128E (Vertex MaaS)",
 			Wire:            gollm.WireOpenAICompat,
 			MaxOutputTokens: 8192,
-			MaxInputTokens:  llama4MaaSInputWindow,
-			Pricing:         gollm.TokenPricing{InputPerMillion: 0.35, OutputPerMillion: 1.40},
+			MaxInputTokens:  llama4MaverickMaaSInputWindow,
+			Pricing:         gollm.TokenPricing{InputPerMillion: 0.35, OutputPerMillion: 1.15},
+		},
+		{
+			ID:              "meta/llama-4-scout-17b-16e-instruct-maas",
+			DisplayName:     "Llama 4 Scout 17B 16E (Vertex MaaS)",
+			Wire:            gollm.WireOpenAICompat,
+			MaxOutputTokens: 8192,
+			MaxInputTokens:  llama4ScoutMaaSInputWindow,
+			Pricing:         gollm.TokenPricing{InputPerMillion: 0.25, OutputPerMillion: 0.70},
 		},
 		{
 			ID:              "qwen/qwen3-coder-480b-a35b-instruct-maas",

--- a/providers/llm/vertex-ai/catalog.go
+++ b/providers/llm/vertex-ai/catalog.go
@@ -253,6 +253,7 @@ func buildVertexCatalog() []gollm.ModelEntry {
 			MaxOutputTokens: 32768,
 			MaxInputTokens:  deepseekMaaSInputWindow,
 			Pricing:         gollm.TokenPricing{InputPerMillion: 1.35, OutputPerMillion: 5.40},
+			Reasoning:       true,
 		},
 		{
 			// Same: DeepSeek V3.2's chat-capable MaaS endpoint is the


### PR DESCRIPTION
## Summary

Vertex AI MaaS model catalog updates in `providers/llm/vertex-ai/catalog.go`:

- **Add `deepseek-ai/deepseek-v3.2-maas`** (alias `deepseek-ai/deepseek-v3.2`) — OpenAI-compat, 128K context, 32768 max output, $0.56 / $1.68 per 1M. Served from `global`.
- **Add `meta/llama-4-scout-17b-16e-instruct-maas`** — OpenAI-compat, 10M context, 8192 max output, $0.25 / $0.70 per 1M. Served from `us-east5`.
- **Fix `meta/llama-4-maverick-17b-128e-instruct-maas`** — the previous catalogued ID `meta/llama-4-maverick-17b-instruct-maas` does not exist on Vertex (404 in every region). Also corrects the output price $1.40 → $1.15. Served from `us-east5`.
- **Mark `deepseek-ai/deepseek-r1-0528-maas` as a reasoning model** (`Reasoning: true`) — all other R1 values verified correct and unchanged (32768 max output, ~128K context, $1.35 / $5.40). Served from `us-central1`.
- Split `llama4MaaSInputWindow` into `llama4MaverickMaaSInputWindow` (1M) and `llama4ScoutMaaSInputWindow` (10M).

## Why

These models were missing or mis-defined, surfaced while debugging real projects: DeepSeek V3.2 was free-text only (so `GetMaxOutputTokens` fell back to the provider default 16384 and it never showed in the picker); the Llama 4 Maverick entry shipped a non-existent model ID that always 404'd.

## Verification (live against Vertex)

- **Model IDs + region** (all live-tested): Maverick + Scout → 200 in `us-east5` only (404 in global/us-central1); DeepSeek R1 → 200 in `us-central1` only (404 in global); DeepSeek V3.2 → 200 in `global`.
- **Max-output caps** (probed `max_tokens` until 400): Llama 4 Maverick/Scout cap at **8192** (`"supported range ... to 8193"`); DeepSeek R1 caps at **32768**. Catalog values match.
- **Pricing/context** from the Vertex Model Garden / CloudPrice Vertex listings.

> Note: per-model **region availability** is not representable in the catalog today (Llama 4 = `us-east5`, R1 = `us-central1`, V3.2 = `global`), so the dashboard can still offer an unusable model/region combo. Tracking that as a separate follow-up.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` for the `providers/llm/vertex-ai` module (pass)
- [x] `gofmt`
- [ ] Optional: confirm the models appear in the dashboard LLM picker for Vertex AI