### PR TITLE
feat(providers/llm): add Gemma 4 26B to Vertex AI MaaS catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Llama 4 Scout added to the Vertex AI MaaS model catalog** — `providers/llm/vertex-ai/catalog.go`. Adds `meta/llama-4-scout-17b-16e-instruct-maas` as an OpenAI-compat MaaS entry: 10M context, 8192 max output, Vertex list price $0.25 / $0.70 per 1M input/output tokens. Both Llama 4 models are served only from `us-east5`, and Vertex caps their max output at 8192 (verified against the live endpoint — a higher `maxOutputTokens` returns a 400).
 
+- **Gemma 4 26B added to the Vertex AI MaaS model catalog** — `providers/llm/vertex-ai/catalog.go`. Adds `google/gemma-4-26b-a4b-it-maas` as an OpenAI-compat MaaS entry: 262K context, 128000 max output, Vertex list price $0.06 / $0.33 per 1M input/output tokens, `Reasoning: true`. Served from `global`. Unlike Llama 4 / R1, Vertex does not enforce a lower output cap for this model (a 200K `maxOutputTokens` request is accepted), so the model-card limit of 128K is used. Previously uncatalogued, so `GetMaxOutputTokens` fell back to the provider default (16384).
+
 ### Fixed
 
 - **Llama 4 Maverick catalog entry corrected** — `providers/llm/vertex-ai/catalog.go`. The model ID was `meta/llama-4-maverick-17b-instruct-maas`, which does not exist on Vertex (404 in every region); corrected to the real ID `meta/llama-4-maverick-17b-128e-instruct-maas`. Also fixes the output price ($1.40 → $1.15 per 1M). Max output stays 8192 (Vertex's enforced cap).

--- a/providers/llm/vertex-ai/catalog.go
+++ b/providers/llm/vertex-ai/catalog.go
@@ -48,6 +48,7 @@ const (
 	qwenMaaSInputWindow           = 256000
 	mistralMaaSInputWindow        = 128000
 	deepseekMaaSInputWindow       = 128000
+	gemma4MaaSInputWindow         = 262144
 )
 
 // buildVertexCatalog returns every Vertex AI model DecisionBox ships
@@ -265,6 +266,19 @@ func buildVertexCatalog() []gollm.ModelEntry {
 			MaxOutputTokens: 32768,
 			MaxInputTokens:  deepseekMaaSInputWindow,
 			Pricing:         gollm.TokenPricing{InputPerMillion: 0.56, OutputPerMillion: 1.68},
+		},
+		{
+			// Gemma 4 on Vertex MaaS speaks the OpenAI-compat wire and
+			// is served from global. Max output 128K; Vertex does not
+			// enforce a lower cap (a 200K maxOutputTokens request is
+			// accepted). Emits a reasoning trace, so Reasoning=true.
+			ID:              "google/gemma-4-26b-a4b-it-maas",
+			DisplayName:     "Gemma 4 26B A4B (Vertex MaaS)",
+			Wire:            gollm.WireOpenAICompat,
+			MaxOutputTokens: 128000,
+			MaxInputTokens:  gemma4MaaSInputWindow,
+			Pricing:         gollm.TokenPricing{InputPerMillion: 0.06, OutputPerMillion: 0.33},
+			Reasoning:       true,
 		},
 	}
 	// Claude 4.x on Vertex shares the 200K standard context window —


### PR DESCRIPTION
## Summary

Adds `google/gemma-4-26b-a4b-it-maas` to the Vertex AI model catalog (`providers/llm/vertex-ai/catalog.go`):

- OpenAI-compat wire, served from `global`
- `MaxOutputTokens: 128000`, `MaxInputTokens: 262144` (new `gemma4MaaSInputWindow` constant)
- Pricing $0.06 / $0.33 per 1M (Vertex listing)
- `Reasoning: true` (the `ModelEntry.Reasoning` doc classifies gemma4 as a reasoning model)

## Why

The model was uncatalogued, so `GetMaxOutputTokens` fell back to the vertex-ai provider default (16384) and it never appeared in the dashboard model picker.

## Verification (live against Vertex)

- Model ID resolves and returns 200 in `global`.
- **Output cap**: unlike Llama 4 (8192) and DeepSeek R1 (32768), this endpoint does **not** reject a high `maxOutputTokens` — `16384 / 65536 / 128000 / 131072 / 200000` all return 200. So there's no probe-enforced cap; the model-card limit of **128000** is used.
- Pricing/context confirmed against the Vertex Model Garden / CloudPrice Vertex listing ($0.06 / $0.33; 262K context).

> Context: surfaced while debugging a packgen failure on a Gemma 4 project. Note the catalog entry does not fix that failure — the synth output was malformed JSON at ~5K tokens (well under any cap), i.e. a model-output-quality issue, not truncation. This PR is purely catalog accuracy.

> Per-model region availability still isn't representable in the catalog (this model is `global`, Llama 4 is `us-east5`, R1 is `us-central1`) — tracked as a separate follow-up.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` for the `providers/llm/vertex-ai` module (pass)
- [x] `gofmt`
- [ ] Optional: confirm the model appears in the dashboard LLM picker for Vertex AI