### PR TITLE
fix(agent): preserve an explicit endpoint model in blurb resolution

### DIFF
--- a/services/agent/agentserver/index_schema.go
+++ b/services/agent/agentserver/index_schema.go
@@ -237,29 +237,28 @@ func runIndexSchema(cfg *config.Config, projectID, runID string) error {
 func resolveBlurbLLM(ctx context.Context, _ *config.Config, project *models.Project, secretProvider gosecrets.Provider, projectID string) (providerName, model, credential string, err error) {
 	providerName = project.LLM.Provider
 	model = project.LLM.Model
+	blurbConfig := project.LLM.Config
 	if project.BlurbLLM != nil && project.BlurbLLM.Provider != "" {
 		providerName = project.BlurbLLM.Provider
-		if project.BlurbLLM.Model != "" {
-			model = project.BlurbLLM.Model
+		blurbConfig = project.BlurbLLM.Config
+		// Use the blurb override's own model — empty or explicit. Don't
+		// inherit the analysis model into an endpoint override: that would
+		// send an unrelated model the endpoint doesn't serve. The legacy
+		// convenience (a non-endpoint override reusing the analysis model
+		// when its own model is blank) is preserved.
+		model = project.BlurbLLM.Model
+		if model == "" && strings.TrimSpace(blurbConfig["endpoint_id"]) == "" {
+			model = project.LLM.Model
 		}
 	}
 	if providerName == "" {
 		return "", "", "", fmt.Errorf("no LLM provider configured (project.blurb_llm or project.llm)")
 	}
-	// A user-deployed endpoint identifies its own model, so an empty model
-	// is expected when the effective blurb provider config carries an
-	// endpoint_id. Mirror the caller's config selection to detect it.
-	blurbConfig := project.LLM.Config
-	if project.BlurbLLM != nil && project.BlurbLLM.Provider != "" {
-		blurbConfig = project.BlurbLLM.Config
-	}
-	if strings.TrimSpace(blurbConfig["endpoint_id"]) != "" {
-		// A user-deployed endpoint identifies its own model. Force an
-		// empty model so the endpoint resolves it — and so a blurb
-		// endpoint override never inherits the (unrelated) analysis
-		// model left in `model` when BlurbLLM.Model is blank.
-		model = ""
-	} else if model == "" {
+	// An endpoint-backed config may legitimately run with no model (the
+	// endpoint serves its own) or with an explicit one (strict serving
+	// containers that validate the OpenAI model field) — either is passed
+	// through verbatim. Only a non-endpoint config must supply a model.
+	if model == "" && strings.TrimSpace(blurbConfig["endpoint_id"]) == "" {
 		return "", "", "", fmt.Errorf("no model configured for blurb LLM")
 	}
 

--- a/services/agent/agentserver/resolve_blurb_llm_test.go
+++ b/services/agent/agentserver/resolve_blurb_llm_test.go
@@ -53,6 +53,25 @@ func TestResolveBlurbLLM_EmptyModel(t *testing.T) {
 			wantModel:    "",
 			wantProvider: "vertex-ai",
 		},
+		{
+			// An endpoint config with an explicit model (strict serving
+			// container) keeps it — blurb must not blank it out.
+			name: "endpoint_with_explicit_model_is_preserved",
+			project: &models.Project{
+				LLM: models.LLMConfig{Provider: "vertex-ai", Model: "served-name", Config: map[string]string{"endpoint_id": "mg-endpoint-strict"}},
+			},
+			wantModel: "served-name",
+		},
+		{
+			// A blurb endpoint override with an explicit model keeps it too.
+			name: "blurb_endpoint_override_explicit_model_is_preserved",
+			project: &models.Project{
+				LLM:      models.LLMConfig{Provider: "openai", Model: "gpt-4o"},
+				BlurbLLM: &models.BlurbLLMConfig{Provider: "vertex-ai", Model: "served-name", Config: map[string]string{"endpoint_id": "mg-endpoint-strict"}},
+			},
+			wantModel:    "served-name",
+			wantProvider: "vertex-ai",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #260 (user-deployed Vertex endpoints). That PR made schema-index blurb resolution force an **empty** model for any endpoint-backed config, to stop a separate blurb override from inheriting the unrelated analysis model. But forcing empty also discards an **explicitly-set** endpoint model — which a strict OpenAI-compat serving container (one started with `--served-model-name`) validates. The result: `/ask` and discovery send the explicit model, but blurb generation sends an empty one, so blurb could fail on a strict endpoint while analysis works.

## Fix

`resolveBlurbLLM` now resolves the model from the config's **own** value instead of force-emptying it:

- A separate blurb override (`project.blurb_llm`) uses its own `Model` — empty or explicit — and never inherits the analysis model into an endpoint override.
- The legacy convenience (a non-endpoint override with a blank model reuses the analysis model) is preserved.
- A model is required only for a non-endpoint config; an endpoint config may run with an empty model (endpoint serves its own) or an explicit one (passed through verbatim).

This makes blurb model handling consistent with the analysis path for every combination of analysis-LLM / separate-blurb-LLM × empty / explicit / inherited × endpoint / non-endpoint.

## Reachability

Low: the dashboard hides the model field for endpoint configs (always saves an empty model), so this only affects configs created programmatically with `endpoint_id` **and** an explicit model on a **strict** serving container. It also resolves a latent inconsistency introduced in #260.

## Tests

`resolve_blurb_llm_test.go` adds cases for an explicit endpoint model via both the analysis-LLM and the separate-blurb-LLM paths, alongside the existing empty-model / no-inheritance / non-endpoint cases. `go test`, `golangci-lint`, and `go build` all pass.