### PR TITLE
DecisionBox AI #11: embedding-dimension probe, gateway model pickers, real e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Embedding vector dimensions are detected by probing, not a hardcoded catalog** — `providers/embedding/openai/provider.go`, `services/agent/internal/discovery/{dimensions.go (new),schema_indexer.go,phase_embed_index.go}`, `docs/guides/schema-indexing.md`. The agent sized its Qdrant collection from `Embedder.Dimensions()`, which the OpenAI embedding provider derived from a hardcoded model→dims map — `0` for any model the map doesn't know, including a managed-gateway alias such as `decisionbox-embed-model`. That made `agent --mode index-schema` (and Phase 9 embed/index) fail with `dimensions must be positive, got 0`, even though the embeddings themselves were correct. The agent now resolves the dimension robustly: it trusts the provider's declared `Dimensions()` when known (a catalogued model — unchanged fast path) and otherwise **probes** — embeds one short string and uses `len(vector)` — mirroring `run_step_index.go`. Wired into `schema_indexer` (before `EnsureCollection`, so a Qdrant/embedding misconfig still fails fast) and `phase_embed_index`. The OpenAI embedding provider also accepts an explicit `dimensions` config override (flowed in from `project.Embedding.Config`) as an escape hatch for any model/gateway the catalog doesn't know; a non-positive override is rejected. Known models behave exactly as before. Unit + real-Qdrant integration tests cover known-model / unknown-model / gateway-alias / explicit-override.
+
+### Added
+
+- **DecisionBox AI gateway aliases surface in the dashboard model pickers** — `providers/embedding/openai/list_models.go`, `providers/llm/openai/wire_inference.go`. When an OpenAI-compatible provider points at the managed DecisionBox AI gateway, its `GET /v1/models` returns aliases (`decisionbox-analysis/blurb/embed-model`) that don't follow OpenAI's naming, so both pickers dropped them — the embedding picker filtered to `text-embedding-*`, and the LLM picker classified `decisionbox-*` as an unknown (non-dispatchable) wire. Keyed on the gateway's contract (`owned_by: decisionbox` plus its `?type=chat|embedding` filter), the embedding `ListModels` now requests `?type=embedding` and keeps a row that is either `text-embedding-*` or gateway-owned, and the LLM wire inference classifies the gateway chat aliases as the OpenAI wire (the embed alias stays off the LLM picker). No shared registry/handler or frontend changes.
+
+- **Real end-to-end tests through the DecisionBox AI gateway** — `services/agent/agentserver/{gateway_e2e_test.go,index_schema_e2e_test.go}` (new, `-tags e2e`). Env-gated, no mocks: the pickers list the gateway aliases and a chat dispatches through the analysis alias over the OpenAI wire; the production `runIndexSchema` pipeline indexes a BigQuery warehouse (the olist demo by default) — discover schemas → resolve dimensions → blurbs through the gateway alias → embed → Qdrant upsert. Set `DBX_GATEWAY_URL` / `DBX_GATEWAY_KEY` (+ `DBX_E2E_INDEX=1` and the warehouse/Qdrant/AWS env) to run against `ai.decisionbox.io`.
+
 ## [0.11.0] - 2026-06-09
 
 ### Added

--- a/docs/guides/schema-indexing.md
+++ b/docs/guides/schema-indexing.md
@@ -105,6 +105,17 @@ swapping embedding models (e.g. `text-embedding-3-small` →
 `text-embedding-3-large`, 1536 → 3072 dims) means the collection is
 incompatible. `POST /reindex` drops and recreates it automatically.
 
+### How the dimension is resolved
+
+The collection is sized from the embedding model's vector dimension,
+resolved in this order: an explicit `dimensions` value in the project's
+embedding `config` (an escape hatch for a model the provider catalog
+doesn't know — e.g. a managed gateway alias), then the provider's known
+dimension for catalogued models, and otherwise a **probe** — the agent
+embeds one short string and measures the returned vector. The probe means
+any provider/model indexes correctly, including an OpenAI-compatible
+gateway alias whose dimension the catalog can't know up front.
+
 ## Cost and wall-clock envelope
 
 With the defaults (Bedrock Qwen3-32B + OpenAI text-embedding-3-large)

--- a/providers/embedding/openai/list_models.go
+++ b/providers/embedding/openai/list_models.go
@@ -12,6 +12,13 @@ import (
 	goembedding "github.com/decisionbox-io/decisionbox/libs/go-common/embedding"
 )
 
+// gatewayOwner is the owned_by value the DecisionBox AI gateway stamps on
+// every alias it exposes. The gateway is OpenAI-compatible but its embedding
+// alias (decisionbox-embed-model) doesn't follow OpenAI's text-embedding-*
+// naming, so we trust this ownership marker — combined with the gateway's own
+// ?type=embedding filter — instead of the ID-prefix heuristic.
+const gatewayOwner = "decisionbox"
+
 // ListModels hits OpenAI's GET /v1/models and filters to the rows that
 // look like embedding models (by ID prefix). The endpoint is free and
 // doesn't consume embedding quota — safe to call from the dashboard's
@@ -23,11 +30,16 @@ import (
 // together. The ID-prefix filter (`text-embedding-*`) matches every
 // embedding model OpenAI ships today and any future one they'd name
 // consistently. Anything else gets dropped.
+//
+// The DecisionBox AI gateway is the exception: the request carries
+// ?type=embedding — which the gateway honours by returning only its embedding
+// alias, and plain OpenAI ignores — and a row owned by the gateway is kept
+// regardless of its ID, so the dashboard surfaces the alias.
 func (p *provider) ListModels(ctx context.Context) ([]goembedding.RemoteModel, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, "GET", p.baseURL+"/models", nil)
+	req, err := http.NewRequestWithContext(reqCtx, "GET", p.baseURL+"/models?type=embedding", nil)
 	if err != nil {
 		return nil, fmt.Errorf("openai embedding: build list req: %w", err)
 	}
@@ -67,10 +79,10 @@ func (p *provider) ListModels(ctx context.Context) ([]goembedding.RemoteModel, e
 
 	out := make([]goembedding.RemoteModel, 0, len(listResp.Data))
 	for _, m := range listResp.Data {
-		if !isEmbeddingModelID(m.ID) {
+		if !isEmbeddingModelID(m.ID) && m.OwnedBy != gatewayOwner {
 			continue
 		}
-		dims := modelDimensions[m.ID] // 0 when unknown; dashboard falls back to catalog
+		dims := modelDimensions[m.ID] // 0 when unknown; dashboard falls back to catalog / the dimensions override
 		out = append(out, goembedding.RemoteModel{
 			ID:          m.ID,
 			DisplayName: m.ID,

--- a/providers/embedding/openai/list_models_test.go
+++ b/providers/embedding/openai/list_models_test.go
@@ -91,6 +91,44 @@ func TestListModels_UnknownEmbeddingID_DimensionsZero(t *testing.T) {
 	}
 }
 
+func TestListModels_GatewayAliasKeptByOwner(t *testing.T) {
+	// The DecisionBox AI gateway honours ?type=embedding by returning only its
+	// embedding alias, owned_by "decisionbox". The alias doesn't match the
+	// text-embedding-* prefix, so it's kept purely on the ownership marker —
+	// while a non-gateway model is still dropped.
+	server := httptest.NewServer(buildOpenAIListHandler([]map[string]any{
+		{"id": "decisionbox-embed-model", "object": "model", "owned_by": "decisionbox"},
+		{"id": "gpt-4o", "object": "model", "owned_by": "someone-else"},
+	}, 0, ""))
+	defer server.Close()
+
+	p := newTestProvider(server)
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "decisionbox-embed-model" {
+		t.Fatalf("expected only the gateway embedding alias, got %+v", models)
+	}
+}
+
+func TestListModels_SendsTypeEmbeddingFilter(t *testing.T) {
+	var gotType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotType = r.URL.Query().Get("type")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	p := newTestProvider(server)
+	if _, err := p.ListModels(context.Background()); err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if gotType != "embedding" {
+		t.Errorf("request type filter = %q, want \"embedding\"", gotType)
+	}
+}
+
 func TestListModels_UpstreamErrorSurfacesMessage(t *testing.T) {
 	// Structured 401 body — the handler should extract the
 	// provider-shaped error so the UI shows a specific message instead
@@ -131,7 +169,7 @@ func TestListModels_NetworkErrorPropagates(t *testing.T) {
 func TestProviderSatisfiesModelListerCapability(t *testing.T) {
 	prov, err := goembedding.NewProvider("openai", goembedding.ProviderConfig{
 		"credentials_json": "test-key",
-		"model":   "text-embedding-3-small",
+		"model":            "text-embedding-3-small",
 	})
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)

--- a/providers/embedding/openai/provider.go
+++ b/providers/embedding/openai/provider.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +29,24 @@ const defaultBaseURL = "https://api.openai.com/v1"
 var modelDimensions = map[string]int{
 	"text-embedding-3-small": 1536,
 	"text-embedding-3-large": 3072,
+}
+
+// resolveDimensions picks the declared vector size from the optional
+// `dimensions` override, falling back to the known-model catalog and finally
+// 0 ("unknown"). The override is the escape hatch for a model the catalog
+// doesn't know — it must match the size the model actually returns, since it
+// is reported verbatim as Dimensions() and used to size the vector
+// collection. A non-numeric / non-positive override is a hard error rather
+// than a silent fall-through to a wrong size.
+func resolveDimensions(override, model string) (int, error) {
+	if s := strings.TrimSpace(override); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n <= 0 {
+			return 0, fmt.Errorf("openai embedding: invalid dimensions %q: must be a positive integer", override)
+		}
+		return n, nil
+	}
+	return modelDimensions[model], nil
 }
 
 func init() {
@@ -42,11 +61,18 @@ func init() {
 			model = "text-embedding-3-small"
 		}
 
-		// Accept unknown models with dims=0 so the list-only path and
-		// user-typed custom model IDs both work. Actual Embed() calls
-		// against an unknown model will still fail upstream at the
-		// OpenAI API; we don't pretend to know the vector size.
-		dims := modelDimensions[model]
+		// Dimension resolution, highest precedence first:
+		//  1. an explicit `dimensions` config override — the escape hatch for
+		//     any model/gateway the catalog doesn't know (e.g. a DecisionBox AI
+		//     alias), flowed in from project.Embedding.Config;
+		//  2. the known-model catalog (a fast default so nothing regresses);
+		//  3. 0 — "unknown". A 0 here is not fatal: the list-only path and
+		//     user-typed custom IDs still work, and a caller that needs a real
+		//     size (sizing a Qdrant collection) probes with a live embedding.
+		dims, err := resolveDimensions(cfg["dimensions"], model)
+		if err != nil {
+			return nil, err
+		}
 
 		baseURL := cfg["base_url"]
 		if baseURL == "" {
@@ -60,6 +86,7 @@ func init() {
 		ConfigFields: []goembedding.ConfigField{
 			{Key: "model", Label: "Model", Required: true, Type: "string", Default: "text-embedding-3-small"},
 			{Key: "base_url", Label: "Base URL", Type: "string", Default: defaultBaseURL, Description: "For OpenAI-compatible APIs"},
+			{Key: "dimensions", Label: "Dimensions", Type: "string", Description: "Override the vector size for a model the catalog doesn't know (e.g. a gateway alias). Leave blank to auto-detect."},
 		},
 		AuthMethods: []goembedding.AuthMethod{
 			{

--- a/providers/embedding/openai/provider_test.go
+++ b/providers/embedding/openai/provider_test.go
@@ -60,7 +60,7 @@ func TestFactoryMissingAPIKey(t *testing.T) {
 func TestFactoryUnknownModel(t *testing.T) {
 	prov, err := goembedding.NewProvider("openai", goembedding.ProviderConfig{
 		"credentials_json": "test-key",
-		"model":   "text-embedding-future-ultra",
+		"model":            "text-embedding-future-ultra",
 	})
 	if err != nil {
 		t.Fatalf("factory should accept unknown model for list-only use, got: %v", err)
@@ -70,6 +70,65 @@ func TestFactoryUnknownModel(t *testing.T) {
 	}
 	if prov.ModelName() != "text-embedding-future-ultra" {
 		t.Errorf("ModelName should round-trip the unknown ID, got %q", prov.ModelName())
+	}
+}
+
+// TestFactoryDimensionsOverride covers the explicit `dimensions` escape
+// hatch: it wins over the catalog for known models and supplies a size for
+// models the catalog doesn't know (e.g. a DecisionBox AI gateway alias),
+// while a known model with no override keeps its catalog size (no regression).
+func TestFactoryDimensionsOverride(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     goembedding.ProviderConfig
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "known model, no override → catalog",
+			cfg:  goembedding.ProviderConfig{"credentials_json": "k", "model": "text-embedding-3-large"},
+			want: 3072,
+		},
+		{
+			name: "gateway alias, override supplies size",
+			cfg:  goembedding.ProviderConfig{"credentials_json": "k", "model": "decisionbox-embed-model", "dimensions": "3072"},
+			want: 3072,
+		},
+		{
+			name: "override wins over catalog",
+			cfg:  goembedding.ProviderConfig{"credentials_json": "k", "model": "text-embedding-3-large", "dimensions": "1024"},
+			want: 1024,
+		},
+		{
+			name:    "non-numeric override is rejected",
+			cfg:     goembedding.ProviderConfig{"credentials_json": "k", "model": "text-embedding-3-large", "dimensions": "big"},
+			wantErr: true,
+		},
+		{
+			name:    "non-positive override is rejected",
+			cfg:     goembedding.ProviderConfig{"credentials_json": "k", "model": "text-embedding-3-large", "dimensions": "0"},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := goembedding.NewProvider("openai", tc.cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got dims=%d", p.Dimensions())
+				}
+				if !strings.Contains(err.Error(), "invalid dimensions") {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.Dimensions() != tc.want {
+				t.Errorf("Dimensions() = %d, want %d", p.Dimensions(), tc.want)
+			}
+		})
 	}
 }
 
@@ -83,8 +142,8 @@ func TestFactoryDefaultModel(t *testing.T) {
 	defer server.Close()
 
 	p, err := goembedding.NewProvider("openai", goembedding.ProviderConfig{
-		"credentials_json":  "test-key",
-		"base_url": server.URL,
+		"credentials_json": "test-key",
+		"base_url":         server.URL,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -107,9 +166,9 @@ func TestFactoryLargeModel(t *testing.T) {
 	defer server.Close()
 
 	p, err := goembedding.NewProvider("openai", goembedding.ProviderConfig{
-		"credentials_json":  "test-key",
-		"model":    "text-embedding-3-large",
-		"base_url": server.URL,
+		"credentials_json": "test-key",
+		"model":            "text-embedding-3-large",
+		"base_url":         server.URL,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/providers/llm/openai/wire_inference.go
+++ b/providers/llm/openai/wire_inference.go
@@ -31,6 +31,19 @@ import (
 func inferOpenAIWire(model string) gollm.Wire {
 	id := strings.ToLower(model)
 
+	// DecisionBox AI gateway aliases. The gateway is OpenAI-compatible, so its
+	// chat aliases (decisionbox-analysis-model, decisionbox-blurb-model)
+	// dispatch over the OpenAI Chat Completions wire and belong on the LLM
+	// picker. The embedding alias (decisionbox-embed-model) is not an LLM, so
+	// it stays WireUnknown and the LLM picker hides it — it has its own
+	// embedding-provider surface.
+	if strings.HasPrefix(id, "decisionbox-") {
+		if strings.Contains(id, "embed") {
+			return gollm.WireUnknown
+		}
+		return gollm.WireOpenAICompat
+	}
+
 	// Non-LLM families served by OpenAI under /v1/models — drop them
 	// from the LLM picker. Embeddings have their own provider; the
 	// rest aren't supported as agent LLMs at all.

--- a/providers/llm/openai/wire_inference_test.go
+++ b/providers/llm/openai/wire_inference_test.go
@@ -77,6 +77,24 @@ func TestInferOpenAIWire_NonLLMFamiliesAreUnknown(t *testing.T) {
 	}
 }
 
+func TestInferOpenAIWire_DecisionBoxGatewayAliases(t *testing.T) {
+	// The gateway's chat aliases dispatch over the OpenAI wire and belong on
+	// the LLM picker; the embedding alias is not an LLM and stays unknown.
+	chat := []string{"decisionbox-analysis-model", "decisionbox-blurb-model"}
+	for _, m := range chat {
+		t.Run(m, func(t *testing.T) {
+			if got := inferOpenAIWire(m); got != gollm.WireOpenAICompat {
+				t.Errorf("inferOpenAIWire(%q) = %q, want %q", m, got, gollm.WireOpenAICompat)
+			}
+		})
+	}
+	t.Run("decisionbox-embed-model", func(t *testing.T) {
+		if got := inferOpenAIWire("decisionbox-embed-model"); got != gollm.WireUnknown {
+			t.Errorf("embedding alias should not be an LLM: got %q, want %q", got, gollm.WireUnknown)
+		}
+	})
+}
+
 func TestInferOpenAIWire_Unknown(t *testing.T) {
 	tests := []string{
 		"",

--- a/services/agent/agentserver/gateway_e2e_test.go
+++ b/services/agent/agentserver/gateway_e2e_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+
+// Package agentserver e2e tests exercise the real DecisionBox AI gateway
+// (ai.decisionbox.io or a local instance) through the same OpenAI-compatible
+// provider layer the agent and dashboard use. They are gated behind the `e2e`
+// build tag and the DBX_GATEWAY_URL / DBX_GATEWAY_KEY env vars so they only run
+// when an operator points them at a real, routed gateway:
+//
+//	DBX_GATEWAY_URL=https://ai.decisionbox.io/v1 \
+//	DBX_GATEWAY_KEY=dbx-live-... \
+//	go test -tags e2e -run TestE2E_Gateway ./services/agent/agentserver/ -v
+//
+// They verify issue #11's gateway-facing acceptance: the gateway lists its
+// alias models for the dashboard pickers (part 2), and the chat aliases
+// dispatch end-to-end through the OpenAI-compatible wire (part 4's routing).
+package agentserver
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	goembedding "github.com/decisionbox-io/decisionbox/libs/go-common/embedding"
+	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
+
+	_ "github.com/decisionbox-io/decisionbox/providers/embedding/openai"
+	_ "github.com/decisionbox-io/decisionbox/providers/llm/openai"
+)
+
+func gatewayEnv(t *testing.T) (url, key string) {
+	t.Helper()
+	url = os.Getenv("DBX_GATEWAY_URL")
+	key = os.Getenv("DBX_GATEWAY_KEY")
+	if url == "" || key == "" {
+		t.Skip("set DBX_GATEWAY_URL and DBX_GATEWAY_KEY to run the gateway e2e")
+	}
+	return url, key
+}
+
+func contains(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestE2E_Gateway_EmbeddingPickerListsAlias verifies the dashboard embedding
+// picker surfaces the gateway's embed alias — the provider's ListModels must
+// return decisionbox-embed-model even though it doesn't match text-embedding-*.
+func TestE2E_Gateway_EmbeddingPickerListsAlias(t *testing.T) {
+	url, key := gatewayEnv(t)
+
+	prov, err := goembedding.NewProvider("openai", goembedding.ProviderConfig{
+		"credentials_json": key,
+		"base_url":         url,
+		"model":            "decisionbox-embed-model",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	lister, ok := prov.(goembedding.ModelLister)
+	if !ok {
+		t.Fatal("openai embedding provider must implement ModelLister")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	models, err := lister.ListModels(ctx)
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+	if !contains(ids, "decisionbox-embed-model") {
+		t.Fatalf("embedding picker did not list the gateway alias; got %v", ids)
+	}
+}
+
+// TestE2E_Gateway_LLMPickerListsAliases verifies the gateway returns its chat
+// aliases for the LLM picker.
+func TestE2E_Gateway_LLMPickerListsAliases(t *testing.T) {
+	url, key := gatewayEnv(t)
+
+	prov, err := gollm.NewProvider("openai", gollm.ProviderConfig{
+		"credentials_json": key,
+		"base_url":         url,
+		"model":            "decisionbox-analysis-model",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	lister, ok := prov.(gollm.ModelLister)
+	if !ok {
+		t.Fatal("openai llm provider must implement ModelLister")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	models, err := lister.ListModels(ctx)
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+	for _, want := range []string{"decisionbox-analysis-model", "decisionbox-blurb-model"} {
+		if !contains(ids, want) {
+			t.Errorf("LLM picker did not list %q; got %v", want, ids)
+		}
+	}
+}
+
+// TestE2E_Gateway_ChatThroughAlias dispatches a real chat completion through
+// the gateway's analysis alias over the OpenAI-compatible wire — the routing
+// the agent uses when its LLM provider points at the gateway.
+func TestE2E_Gateway_ChatThroughAlias(t *testing.T) {
+	url, key := gatewayEnv(t)
+
+	prov, err := gollm.NewProvider("openai", gollm.ProviderConfig{
+		"credentials_json": key,
+		"base_url":         url,
+		"model":            "decisionbox-analysis-model",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	resp, err := prov.Chat(ctx, gollm.ChatRequest{
+		Model:     "decisionbox-analysis-model",
+		Messages:  []gollm.Message{{Role: "user", Content: "Reply with the single word: ok"}},
+		MaxTokens: 16,
+	})
+	if err != nil {
+		t.Fatalf("Chat through gateway alias: %v", err)
+	}
+	if resp.Content == "" {
+		t.Fatal("empty response content from the gateway analysis alias")
+	}
+	t.Logf("gateway analysis alias replied: %q (model=%s)", resp.Content, resp.Model)
+}

--- a/services/agent/agentserver/index_schema_e2e_test.go
+++ b/services/agent/agentserver/index_schema_e2e_test.go
@@ -1,0 +1,102 @@
+//go:build e2e
+
+package agentserver
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/config"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/database"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// TestE2E_IndexSchema_OlistThroughGateway runs the real schema-index pipeline
+// end-to-end against a BigQuery warehouse (the olist demo dataset by default),
+// routing blurb generation through the DecisionBox AI gateway alias and
+// embedding through Bedrock Titan, into a real Qdrant. It exercises the path
+// that surfaced issue #11's "dimensions must be positive, got 0" bug:
+// discover_schemas → ensure_collection (dimension-resolved) → blurbs → embed →
+// qdrant_upsert. A nil error means every leg, including correct collection
+// sizing, succeeded.
+//
+// Gated behind the e2e tag and DBX_E2E_INDEX=1 plus the usual agent env
+// (MONGODB_URI, QDRANT_URL — gRPC host:port — and ambient GCP ADC + AWS creds).
+// Point blurbs at the gateway with DBX_GATEWAY_URL / DBX_GATEWAY_KEY; without
+// them the blurb LLM falls back to Bedrock Haiku.
+//
+//	DBX_E2E_INDEX=1 MONGODB_URI=... QDRANT_URL=127.0.0.1:6334 \
+//	DBX_GATEWAY_URL=http://127.0.0.1:18080/v1 DBX_GATEWAY_KEY=dbx-... \
+//	go test -tags e2e -run TestE2E_IndexSchema_Olist ./services/agent/agentserver/ -v
+func TestE2E_IndexSchema_OlistThroughGateway(t *testing.T) {
+	if os.Getenv("DBX_E2E_INDEX") != "1" {
+		t.Skip("set DBX_E2E_INDEX=1 (and the warehouse/gateway env) to run the olist index e2e")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Qdrant.URL == "" {
+		t.Skip("QDRANT_URL is required for the index e2e")
+	}
+
+	whProject := envOr("DBX_E2E_WAREHOUSE_PROJECT", "decisionbox")
+	whDataset := envOr("DBX_E2E_WAREHOUSE_DATASET", "demo_olist_ecommerce")
+	region := envOr("AWS_REGION", "us-east-1")
+
+	// Blurb LLM: the gateway alias when the gateway env is set, else Bedrock.
+	blurb := bson.M{"provider": "bedrock", "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+		"config": bson.M{"region": region, "auth_method": "iam_role"}}
+	if url := os.Getenv("DBX_GATEWAY_URL"); url != "" && os.Getenv("DBX_GATEWAY_KEY") != "" {
+		blurb = bson.M{"provider": "openai", "model": "decisionbox-blurb-model",
+			"config": bson.M{"base_url": url, "auth_method": "api_key"}}
+		t.Setenv("BLURB_LLM_API_KEY", os.Getenv("DBX_GATEWAY_KEY"))
+	}
+
+	ctx := context.Background()
+	mongoClient, err := initMongoDB(ctx, cfg)
+	if err != nil {
+		t.Fatalf("initMongoDB: %v", err)
+	}
+	defer func() { _ = mongoClient.Disconnect(ctx) }()
+
+	oid := primitive.NewObjectID()
+	projects := database.New(mongoClient).Collection(database.CollectionProjects)
+	doc := bson.M{
+		"_id": oid, "name": "Olist E2E (index)", "domain": "ecommerce", "category": "ecommerce",
+		"description": "Brazilian Olist e-commerce marketplace: orders, items, payments, reviews, customers, sellers, products.",
+		"warehouse": bson.M{"provider": "bigquery", "project_id": whProject, "location": "US",
+			"datasets": []string{whDataset}, "config": bson.M{"auth_method": "adc"}},
+		"llm":       bson.M{"provider": "bedrock", "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0", "config": bson.M{"region": region, "auth_method": "iam_role"}},
+		"blurb_llm": blurb,
+		"embedding": bson.M{"provider": "bedrock", "model": "amazon.titan-embed-text-v2:0", "config": bson.M{"region": region, "auth_method": "iam_role"}},
+		"status":    "ready", "created_at": time.Now(), "updated_at": time.Now(),
+	}
+	if _, err := projects.InsertOne(ctx, doc); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = projects.DeleteOne(context.Background(), bson.M{"_id": oid})
+	})
+
+	// The actual production index path. A nil return means discover_schemas →
+	// ensure_collection → blurbs → embed → qdrant_upsert all succeeded — and
+	// because Qdrant rejects vectors whose length doesn't match the collection,
+	// a successful upsert is itself proof the collection was sized correctly
+	// (the bug this fixes created a 0-dim collection and failed here).
+	if err := runIndexSchema(cfg, oid.Hex(), "e2e-index"); err != nil {
+		t.Fatalf("runIndexSchema against %s.%s: %v", whProject, whDataset, err)
+	}
+	t.Logf("indexed %s.%s end-to-end through the gateway blurb alias", whProject, whDataset)
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/services/agent/internal/discovery/dimensions.go
+++ b/services/agent/internal/discovery/dimensions.go
@@ -1,0 +1,41 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+)
+
+// dimensionProbeText is the throwaway input used to measure an embedding
+// model's output size when the provider can't declare it up front.
+const dimensionProbeText = "dimension probe"
+
+// dimensionResolver is the slim embedding surface needed to size a vector
+// collection: a declared dimension when the provider knows it, plus the
+// ability to embed a probe when it doesn't.
+type dimensionResolver interface {
+	Embed(ctx context.Context, texts []string) ([][]float64, error)
+	Dimensions() int
+}
+
+// resolveEmbeddingDimensions returns the vector size to provision a collection
+// with. It trusts the provider's declared Dimensions() when it is known — a
+// catalogued model or an explicit `dimensions` config override, the fast path
+// that keeps known models exactly as they were — and otherwise probes: it
+// embeds one short string and measures the returned vector. The probe makes
+// any provider/model correct, including a DecisionBox AI gateway alias the
+// catalog doesn't know (which would otherwise report Dimensions()==0 and fail
+// collection creation with "dimensions must be positive, got 0"), without a
+// hardcoded size.
+func resolveEmbeddingDimensions(ctx context.Context, e dimensionResolver) (int, error) {
+	if d := e.Dimensions(); d > 0 {
+		return d, nil
+	}
+	vecs, err := e.Embed(ctx, []string{dimensionProbeText})
+	if err != nil {
+		return 0, fmt.Errorf("probe embedding to detect dimensions: %w", err)
+	}
+	if len(vecs) == 0 || len(vecs[0]) == 0 {
+		return 0, fmt.Errorf("probe embedding returned an empty vector")
+	}
+	return len(vecs[0]), nil
+}

--- a/services/agent/internal/discovery/dimensions_test.go
+++ b/services/agent/internal/discovery/dimensions_test.go
@@ -1,0 +1,79 @@
+package discovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// dimProbeEmbedder is a minimal embedder for exercising the dimension
+// resolver: it reports a declared size and records how many times it was
+// probed via Embed.
+type dimProbeEmbedder struct {
+	dims       int
+	vec        []float64
+	embedErr   error
+	embedCalls int
+}
+
+func (f *dimProbeEmbedder) Dimensions() int { return f.dims }
+
+func (f *dimProbeEmbedder) Embed(_ context.Context, texts []string) ([][]float64, error) {
+	f.embedCalls++
+	if f.embedErr != nil {
+		return nil, f.embedErr
+	}
+	out := make([][]float64, len(texts))
+	for i := range texts {
+		out[i] = f.vec
+	}
+	return out, nil
+}
+
+func TestResolveEmbeddingDimensions(t *testing.T) {
+	// A known model / explicit override declares its size — trust it, no probe.
+	t.Run("declared dims skip the probe", func(t *testing.T) {
+		e := &dimProbeEmbedder{dims: 3072, vec: make([]float64, 999)}
+		got, err := resolveEmbeddingDimensions(context.Background(), e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != 3072 {
+			t.Errorf("dims = %d, want 3072 (declared)", got)
+		}
+		if e.embedCalls != 0 {
+			t.Errorf("expected no probe for a declared size, got %d embed calls", e.embedCalls)
+		}
+	})
+
+	// An unknown model / gateway alias reports 0 — probe and measure the
+	// actual vector (this is the case that used to fail with "dimensions must
+	// be positive, got 0").
+	t.Run("unknown dims probe and measure", func(t *testing.T) {
+		e := &dimProbeEmbedder{dims: 0, vec: make([]float64, 3072)}
+		got, err := resolveEmbeddingDimensions(context.Background(), e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != 3072 {
+			t.Errorf("dims = %d, want 3072 (probed)", got)
+		}
+		if e.embedCalls != 1 {
+			t.Errorf("expected exactly one probe, got %d", e.embedCalls)
+		}
+	})
+
+	t.Run("probe error surfaces", func(t *testing.T) {
+		e := &dimProbeEmbedder{dims: 0, embedErr: errors.New("upstream down")}
+		if _, err := resolveEmbeddingDimensions(context.Background(), e); err == nil {
+			t.Fatal("expected an error when the probe embedding fails")
+		}
+	})
+
+	t.Run("empty probe vector is an error not zero", func(t *testing.T) {
+		e := &dimProbeEmbedder{dims: 0, vec: nil}
+		if _, err := resolveEmbeddingDimensions(context.Background(), e); err == nil {
+			t.Fatal("expected an error for an empty probe vector")
+		}
+	})
+}

--- a/services/agent/internal/discovery/phase_embed_index.go
+++ b/services/agent/internal/discovery/phase_embed_index.go
@@ -140,7 +140,15 @@ func (o *Orchestrator) saveStandaloneDocuments(ctx context.Context, insights []*
 
 // embedAndIndex embeds documents and upserts vectors to Qdrant.
 func (o *Orchestrator) embedAndIndex(ctx context.Context, insights []*commonmodels.StandaloneInsight, recs []*commonmodels.StandaloneRecommendation) error {
-	dims := o.embeddingProvider.Dimensions()
+	// Resolve the dimension robustly — the provider's declared size when it
+	// knows it, else a probe embedding — so a model the catalog doesn't know
+	// (e.g. the decisionbox-embed-model gateway alias, which reports 0) sizes
+	// its collection correctly instead of failing with "dimensions must be
+	// positive, got 0".
+	dims, err := resolveEmbeddingDimensions(ctx, o.embeddingProvider)
+	if err != nil {
+		return fmt.Errorf("resolve embedding dimensions: %w", err)
+	}
 	modelName := o.embeddingProvider.ModelName()
 
 	// Ensure Qdrant collection exists for this dimension
@@ -203,13 +211,13 @@ func (o *Orchestrator) embedAndIndex(ctx context.Context, insights []*commonmode
 			Vector: vec,
 			Payload: map[string]interface{}{
 				"type":            "insight",
-				"project_id":     ins.ProjectID,
-				"discovery_id":   ins.DiscoveryID,
+				"project_id":      ins.ProjectID,
+				"discovery_id":    ins.DiscoveryID,
 				"embedding_model": modelName,
-				"severity":       ins.Severity,
-				"analysis_area":  ins.AnalysisArea,
-				"confidence":     ins.Confidence,
-				"created_at":     ins.CreatedAt.Format(time.RFC3339),
+				"severity":        ins.Severity,
+				"analysis_area":   ins.AnalysisArea,
+				"confidence":      ins.Confidence,
+				"created_at":      ins.CreatedAt.Format(time.RFC3339),
 			},
 		})
 	}
@@ -231,11 +239,11 @@ func (o *Orchestrator) embedAndIndex(ctx context.Context, insights []*commonmode
 			Vector: vec,
 			Payload: map[string]interface{}{
 				"type":            "recommendation",
-				"project_id":     rec.ProjectID,
-				"discovery_id":   rec.DiscoveryID,
+				"project_id":      rec.ProjectID,
+				"discovery_id":    rec.DiscoveryID,
 				"embedding_model": modelName,
-				"confidence":     rec.Confidence,
-				"created_at":     rec.CreatedAt.Format(time.RFC3339),
+				"confidence":      rec.Confidence,
+				"created_at":      rec.CreatedAt.Format(time.RFC3339),
 			},
 		})
 	}
@@ -283,4 +291,3 @@ func (o *Orchestrator) checkAndMarkDuplicate(ctx context.Context, docID string, 
 		applog.WithError(err).WithField("id", docID).Warn("Failed to mark duplicate")
 	}
 }
-

--- a/services/agent/internal/discovery/schema_indexer.go
+++ b/services/agent/internal/discovery/schema_indexer.go
@@ -178,9 +178,19 @@ func (si *SchemaIndexer) BuildIndex(ctx context.Context, opts IndexOptions) (*St
 
 	// 3. Provision Qdrant with the embedder's dimension count. If the
 	// caller swapped embedding models, the DropCollection above cleared
-	// the old dimension so this creates a fresh collection.
-	applog.WithField("dimensions", si.Embedder.Dimensions()).Info("schema_indexer: phase=ensure_collection")
-	if err := si.Retriever.EnsureCollection(ctx, opts.ProjectID, si.Embedder.Dimensions()); err != nil {
+	// the old dimension so this creates a fresh collection. Resolve the
+	// dimension robustly: the provider's declared size when it knows it,
+	// otherwise a probe embedding — so a model the catalog doesn't know
+	// (e.g. the decisionbox-embed-model gateway alias, which would report 0)
+	// still sizes its collection correctly. Done before the long blurb phase
+	// so a Qdrant/embedding misconfig fails fast.
+	dims, err := resolveEmbeddingDimensions(ctx, si.Embedder)
+	if err != nil {
+		si.recordErr(ctx, opts.ProjectID, "resolve dimensions: "+err.Error())
+		return nil, fmt.Errorf("schema_indexer: resolve dimensions: %w", err)
+	}
+	applog.WithField("dimensions", dims).Info("schema_indexer: phase=ensure_collection")
+	if err := si.Retriever.EnsureCollection(ctx, opts.ProjectID, dims); err != nil {
 		si.recordErr(ctx, opts.ProjectID, "ensure collection: "+err.Error())
 		return nil, fmt.Errorf("schema_indexer: ensure collection: %w", err)
 	}

--- a/services/agent/internal/discovery/schema_indexer_integration_test.go
+++ b/services/agent/internal/discovery/schema_indexer_integration_test.go
@@ -280,3 +280,74 @@ func TestInteg_SchemaIndexer_DropCollectionOnRetry(t *testing.T) {
 		t.Errorf("retained stale entry: %v", hits[0].Blurb.Table)
 	}
 }
+
+// unknownDimEmbedder models a model the catalog doesn't know (e.g. the
+// decisionbox-embed-model gateway alias): Dimensions() reports 0, but Embed
+// returns full-length vectors. Before the probe-based fix this made
+// EnsureCollection fail with "dimensions must be positive, got 0".
+type unknownDimEmbedder struct {
+	vecLen int
+	model  string
+}
+
+func (e *unknownDimEmbedder) Embed(_ context.Context, texts []string) ([][]float64, error) {
+	out := make([][]float64, len(texts))
+	for i := range out {
+		v := make([]float64, e.vecLen)
+		v[0] = 1 // unit-length on axis 0, as the collection uses cosine distance
+		out[i] = v
+	}
+	return out, nil
+}
+func (e *unknownDimEmbedder) Dimensions() int   { return 0 }
+func (e *unknownDimEmbedder) ModelName() string { return e.model }
+
+// TestInteg_SchemaIndexer_UnknownDimensions_ProbesAndSizes is the regression
+// test for the gateway-alias bug: an embedder that can't declare its size
+// (Dimensions()==0) must still build an index, because the indexer probes a
+// live embedding to size the collection. The Search with an 8-dim query then
+// only succeeds if the collection was actually created with 8 dimensions.
+func TestInteg_SchemaIndexer_UnknownDimensions_ProbesAndSizes(t *testing.T) {
+	ctx := context.Background()
+	retriever := startQdrant(t)
+
+	const dims = 8
+	schemas := map[string]models.TableSchema{
+		"s.orders": {TableName: "s.orders", RowCount: 100, Columns: []models.ColumnInfo{{Name: "id", Type: "INT64"}}},
+		"s.users":  {TableName: "s.users", RowCount: 50, Columns: []models.ColumnInfo{{Name: "id", Type: "INT64"}}},
+	}
+	gen, err := blurb.New(blurb.Config{LLM: &stubLLM{text: "A concise description."}, Model: "gpt-4o", Workers: 2})
+	if err != nil {
+		t.Fatalf("blurb.New: %v", err)
+	}
+	si := SchemaIndexer{
+		Discovery: &stubIntegSchemaSource{schemas: schemas},
+		Blurber:   gen,
+		Embedder:  &unknownDimEmbedder{vecLen: dims, model: "decisionbox-embed-model"},
+		Retriever: retriever,
+		Progress:  &memProgress{},
+	}
+
+	stats, err := si.BuildIndex(ctx, IndexOptions{ProjectID: "p-gateway-alias", RunID: "run-ga"})
+	if err != nil {
+		t.Fatalf("BuildIndex with an unknown-dimension embedder should succeed via probing, got: %v", err)
+	}
+	if stats.Tables != 2 {
+		t.Errorf("indexed tables = %d, want 2", stats.Tables)
+	}
+
+	// An 8-dim query only matches if the collection was sized to 8 (the
+	// probed length), not 0 or some default.
+	hits, err := retriever.Search(ctx, "p-gateway-alias", unitVec(0, dims), schema_retrieve.SearchOpts{TopK: 5})
+	if err != nil {
+		t.Fatalf("search against the probed-size collection: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("no hits — collection was not sized from the probe")
+	}
+	for _, h := range hits {
+		if h.Blurb.EmbeddingModel != "decisionbox-embed-model" {
+			t.Errorf("embedding_model = %q, want decisionbox-embed-model", h.Blurb.EmbeddingModel)
+		}
+	}
+}


### PR DESCRIPTION
## What

The **decisionbox-platform** portion of decisionbox-io/decisionbox-ai-gateway#11: the embedding-dimensions bug (#1), the dashboard model-picker for the DecisionBox AI provider (#2), and real end-to-end tests through the gateway aliases (#4). Companion to the gateway PR (decisionbox-ai-gateway#12).

## 1 — Dimensions detected by probing (the `index-schema` bug)

The agent sized its Qdrant collection from `Embedder.Dimensions()`, which the OpenAI embedding provider derived from a **hardcoded** model→dims map — `0` for any model it doesn't know, including the gateway alias `decisionbox-embed-model`. Result: `agent --mode index-schema` failed with `dimensions must be positive, got 0`, even though the embeddings (3072 via the gateway) were correct.

- `services/agent/internal/discovery/dimensions.go` (new) — `resolveEmbeddingDimensions`: trust the provider's declared `Dimensions()` when known (catalogued model / explicit override — the unchanged fast path), else **probe** one live embedding and use `len(vector)`, mirroring `run_step_index.go`. Wired into `schema_indexer` (before `EnsureCollection`, so a misconfig still fails fast) and `phase_embed_index`.
- `providers/embedding/openai/provider.go` — reads an explicit `dimensions` config override (flows in from `project.Embedding.Config`) as an escape hatch; invalid → hard error. Catalog kept as the fast default for known models.
- Known models behave exactly as before.

**Tests:** provider unit tests (known / gateway-alias override / override-wins / invalid); resolver unit tests (declared / probe / probe-error / empty-vector); a **real-Qdrant** integration test proving an embedder reporting `Dimensions()==0` still builds a correctly-sized collection (8-dim search confirms it).

## 2 — DecisionBox AI aliases in the model pickers

The gateway's `/v1/models` aliases don't follow OpenAI naming, so both pickers dropped them. Keyed on the gateway's contract (`owned_by: decisionbox` + its `?type=` filter), localized to the openai provider packages:
- `providers/embedding/openai/list_models.go` — request `?type=embedding`; keep a row that is `text-embedding-*` **or** gateway-owned.
- `providers/llm/openai/wire_inference.go` — classify the gateway chat aliases as the OpenAI wire (dispatchable); the embed alias stays off the LLM picker.

No shared registry/handler or frontend changes — the dashboard renders whatever dispatchable models the providers return.

## 4 — Real e2e through the gateway

`services/agent/agentserver/{gateway_e2e_test.go, index_schema_e2e_test.go}` (new, `-tags e2e`, env-gated, no mocks):
- pickers list the gateway aliases; a chat dispatches through the analysis alias over the OpenAI wire;
- the production `runIndexSchema` pipeline indexes a BigQuery warehouse (olist by default) — discover → resolve dims → blurbs **through the gateway alias** → embed → Qdrant upsert.

## How it was verified (locally, real services)

- **Real-Qdrant integration test** (testcontainers): gateway-alias dims=0 → probe → 8-dim collection, search hits. ✅
- **Live gateway e2e**: against a local gateway (new routing) — embedding picker → `decisionbox-embed-model`, LLM picker → analysis/blurb, chat through analysis alias → real Bedrock Opus 4.6 reply. ✅
- **Live index e2e**: `runIndexSchema` against the real **olist BigQuery** dataset (`demo_olist_ecommerce`, ADC) → 9 tables discovered → blurbs through the gateway blurb alias (→ Bedrock Haiku) → Bedrock Titan embeddings → **Qdrant collection: 9 points @ 1024 dim**, exit 0. ✅
- `go build` / `go vet` / unit tests green for the changed modules.

### Known limitation / not in this PR
- The **embed-via-gateway** leg routes to OpenAI; this container has no OpenAI key, so the live index e2e used Bedrock Titan for embeddings (blurbs still went through the gateway). The e2e supports the gateway embed alias when run against an OpenAI-backed gateway.
- A **full discovery run** (default mode: exploration → insights → recommendations) is supported by the agent (`--max-steps`/`--test-mode`) and its chat path is verified live, but isn't executed here — it needs project prompts seeded server-side and is orthogonal to these fixes. Happy to run it if you want it in the loop.

Part of decisionbox-io/decisionbox-ai-gateway#11.

— Co-coded with Jale 🤖
