### PR TITLE
fix(askserve): never emit an ungrounded data-query answer — decline instead

### DIFF
--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -47,15 +47,22 @@ type turnState struct {
 	queriesUsed     int
 	tokensIn        int
 	tokensOut       int
-	groundingNudged bool
+	groundingNudges int
 }
 
-// groundingNudge is the one-time correction when the model tries to answer a
-// data question without having run any query — it bounds hallucination by
-// forcing the agent to ground a numeric/factual answer in a real result.
-const groundingNudge = "You have not run any query yet, so you have no data to ground an answer in. " +
-	"Run a query_data action to gather the evidence first — never state a count, total, or specific value you have not seen in a query result this turn. " +
-	"If the question genuinely cannot be turned into a query, use clarify or decline instead of answering."
+// maxGroundingNudges bounds how many times the loop re-prompts a model that
+// tries to answer with no tool activity. After this many refusals the turn is
+// DECLINED rather than emitting an ungrounded (fabricated) answer — accepting
+// such an answer is the worst failure mode for a data tool.
+const maxGroundingNudges = 2
+
+// groundingNudge is the correction when the model tries to answer without
+// having run any query — it forbids ungrounded answers and tells it how to
+// start gathering evidence even with no schema catalog in hand.
+const groundingNudge = "Do NOT answer yet — you have run no query, so you have no data to ground an answer in. " +
+	"Run a query_data action first to gather evidence; never state a table, count, total, or value you have not seen in a query result this turn. " +
+	"If you don't know the tables or columns, discover them with a query against INFORMATION_SCHEMA (e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES`) or use search_tables / lookup_schema. " +
+	"Only use clarify or decline if the question genuinely cannot be turned into any query."
 
 // run drives the bounded ReAct loop for one turn. It always finalizes the turn
 // (done/declined/timeout/failed) so the reader's poll terminates, preserving
@@ -92,16 +99,20 @@ func (r *runner) run(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
 		}
 
 		if act.Kind.terminal() {
-			// Grounding guard: refuse a data answer produced with no tool
-			// activity at all (no query / lookup / search). The model sometimes
-			// shortcuts to a plausible-but-fabricated answer on the first round;
-			// nudge it once to gather evidence first. Any tool event (even a
-			// schema lookup) counts as grounding, so schema-only answers are
-			// allowed; clarify / decline need no data and are always accepted.
-			if act.Kind == actAnswer && len(st.events) == 0 && !st.groundingNudged {
-				st.groundingNudged = true
-				conv.AddUserMessage(groundingNudge)
-				continue
+			// Grounding guard: an `answer` produced with no tool activity (no
+			// query / lookup / search) is ungrounded — the model fabricated it.
+			// Re-nudge it to gather evidence; if it still refuses after
+			// maxGroundingNudges, DECLINE rather than emit fabricated content.
+			// Any tool event (even a schema lookup) counts as grounding;
+			// clarify / decline need no data and are always accepted.
+			if act.Kind == actAnswer && len(st.events) == 0 {
+				if st.groundingNudges < maxGroundingNudges {
+					st.groundingNudges++
+					conv.AddUserMessage(groundingNudge)
+					continue
+				}
+				r.finishUngrounded(ctx, st)
+				return
 			}
 			r.finishTerminal(ctx, st, act)
 			return
@@ -118,6 +129,12 @@ func (r *runner) run(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
 	// Round budget exhausted without a terminal action. Give the model one
 	// final, non-tool synthesis chance to answer with what it has gathered.
 	if act := r.synthesizeFinal(ctx, conv, st); act != nil {
+		// Still enforce grounding: a synthesized answer with no tool activity
+		// is fabricated — decline instead of emitting it.
+		if act.Kind == actAnswer && len(st.events) == 0 {
+			r.finishUngrounded(ctx, st)
+			return
+		}
 		r.finishTerminal(ctx, st, act)
 		return
 	}
@@ -318,6 +335,18 @@ func (r *runner) finishTerminal(ctx context.Context, st *turnState, act *turnAct
 		Status:      status,
 		Disposition: disposition,
 		Answer:      act.Text,
+	})
+}
+
+// finishUngrounded declines a turn whose model insisted on answering without
+// running any query — emitting that answer would surface fabricated data, so
+// we decline instead.
+func (r *runner) finishUngrounded(ctx context.Context, st *turnState) {
+	r.finalize(ctx, st, TurnFinal{
+		Status:      commonmodels.AskTurnStatusDeclined,
+		Disposition: commonmodels.AskTurnDispositionDecline,
+		Error:       "model would not gather evidence; declined rather than answer ungrounded",
+		Answer:      "I couldn't answer this from the data — I wasn't able to gather any query results to ground a response. Please rephrase the question, or check that the project's warehouse and schema are available.",
 	})
 }
 

--- a/services/agent/internal/askserve/loop_test.go
+++ b/services/agent/internal/askserve/loop_test.go
@@ -3,6 +3,7 @@ package askserve
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -149,6 +150,30 @@ func TestLoop_RejectsUngroundedAnswer(t *testing.T) {
 	}
 	if store.final.Answer != "There are 100 rows." {
 		t.Fatalf("final answer should come after the query, got %q", store.final.Answer)
+	}
+}
+
+func TestLoop_FabricatedAnswerDeclined(t *testing.T) {
+	// The model keeps answering with no tool activity (fabrication). After the
+	// bounded nudges the turn must DECLINE, never emit the ungrounded answer.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	store := runOnce(t, Config{}, []string{
+		`{"answer":"There are 8 tables; call_activity has 99,990 rows."}`,
+		`{"answer":"There are 8 tables; call_activity has 99,990 rows."}`,
+		`{"answer":"There are 8 tables; call_activity has 99,990 rows."}`,
+		`{"answer":"There are 8 tables; call_activity has 99,990 rows."}`,
+	}, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDeclined {
+		t.Fatalf("status = %q, want declined (ungrounded answer must not be emitted)", store.final.Status)
+	}
+	if store.final.Disposition != commonmodels.AskTurnDispositionDecline {
+		t.Fatalf("disposition = %q, want decline", store.final.Disposition)
+	}
+	if len(store.events) != 0 || len(wh.Calls) != 0 {
+		t.Fatalf("no tool should have run; events=%d calls=%d", len(store.events), len(wh.Calls))
+	}
+	if strings.Contains(store.final.Answer, "call_activity") {
+		t.Fatalf("fabricated content leaked into the declined answer: %q", store.final.Answer)
 	}
 }
 

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -48,7 +48,7 @@ func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
 	b.WriteString("- For totals, counts, distributions, or \"how many\" questions, write aggregate SQL (COUNT, SUM, AVG, GROUP BY) — do NOT page through raw rows.\n")
 	fmt.Fprintf(&b, "- You may run at most %d queries and take at most %d steps this turn. Be economical; reuse results already in this conversation instead of re-querying.\n", cfg.MaxQueriesPerTurn, cfg.MaxRounds)
 
-	b.WriteString("\nGROUNDING (required): you MUST run at least one query_data action and observe its result before you give an `answer`. Never state a count, total, or specific value you have not seen in a query result in this conversation — do not answer from prior knowledge or guesses. If a question genuinely cannot be turned into a query, use clarify or decline instead.\n")
+	b.WriteString("\nGROUNDING (required): you MUST run at least one query_data action and observe its result before you give an `answer`. Never state a table name, count, total, or specific value you have not seen in a query result in this conversation — do not answer from prior knowledge or guesses. If you don't yet know the tables or columns, your FIRST action must be a discovery query — e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES` — or a search_tables / lookup_schema; do not invent table or column names. An answer with no query behind it will be rejected; only use clarify or decline if the question genuinely cannot be turned into any query.\n")
 
 	b.WriteString("\nFinish with an \"answer\", \"clarify\", or \"decline\" action. The answer should be concise, analyst-style prose that directly addresses the question and references the figures you found.")
 


### PR DESCRIPTION
## Hotfix — grounding fabrication found in live testing

Follow-up to #287. Running the merged ask-serve against a real project (Novo Nordisk / BigQuery) surfaced that the data agent could still **fabricate** answers: it answered with no query, took the single grounding nudge, and re-answered with invented table names + row counts, which the guard then **accepted**. The same "how many tables / which has the most rows" question returned **three different answers across runs** with **zero tool events** persisted — the signature of fabrication.

### Root cause
The grounding guard nudged **once**, then accepted the next answer even if it was still ungrounded. The model (Bedrock Opus-4-6) doesn't reliably comply with one nudge.

### Fix — grounding is now a hard invariant
- An `answer` with **zero tool events** is re-nudged up to `maxGroundingNudges` (2). If the model still won't run any query / lookup / search, the turn **declines** ("couldn't gather data to ground a response") instead of emitting the fabricated answer. Same enforcement on the round-cap synthesis path. **An answer reaches the user only if a tool actually ran.**
- Strengthened the nudge + system prompt to tell the model *how* to start when it has no catalog — a discovery query against `INFORMATION_SCHEMA`, or `search_tables` / `lookup_schema` — and never to invent table/column names.
- Adds `TestLoop_FabricatedAnswerDeclined` — the refusal path the prior unit test missed (it only scripted a model that *complied* with the nudge).

### Verified live (post-fix), same question ×3
- two runs → `done` with the **same real answer** (5 tables; `part_d_provider_drug_2023`; 26,794,878 rows) backed by real query events;
- one run → `declined` (model refused to query) — **no fabrication**.

`go build`, `go test ./internal/askserve/...`, and `golangci-lint` all pass.

— Co-coded with Jale 🤖