### PR TITLE
fix(askserve): drive the Ask data agent with native tool-calling

### DIFF
--- a/services/agent/internal/ai/client.go
+++ b/services/agent/internal/ai/client.go
@@ -84,6 +84,17 @@ func (c *Client) Chat(ctx context.Context, userPrompt string, systemPrompt strin
 
 // CreateMessage sends a message to the LLM and returns the full response.
 func (c *Client) CreateMessage(ctx context.Context, messages []gollm.Message, systemPrompt string, maxTokens int) (*gollm.ChatResponse, error) {
+	return c.CreateMessageWithTools(ctx, messages, systemPrompt, maxTokens, nil, "")
+}
+
+// CreateMessageWithTools is CreateMessage with native tool-calling: tools is the
+// set of tools the model may call and toolChoice forces the decision ("" / "auto"
+// = model decides, "any" / "required" = must call a tool, "none" = must not, or a
+// specific tool name). The returned ChatResponse carries ToolCalls when the model
+// invoked tools (StopReason "tool_use"). Providers whose ProviderMeta.SupportsTools
+// is false reject a non-empty tools slice with gollm.ErrToolsNotSupported, so
+// callers must gate on tool support before passing tools.
+func (c *Client) CreateMessageWithTools(ctx context.Context, messages []gollm.Message, systemPrompt string, maxTokens int, tools []gollm.ToolDefinition, toolChoice string) (*gollm.ChatResponse, error) {
 	startTime := time.Now()
 
 	if c.testMode {
@@ -99,6 +110,8 @@ func (c *Client) CreateMessage(ctx context.Context, messages []gollm.Message, sy
 		SystemPrompt: systemPrompt,
 		Messages:     messages,
 		MaxTokens:    maxTokens,
+		Tools:        tools,
+		ToolChoice:   toolChoice,
 	}
 
 	logger.WithFields(logger.Fields{

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -80,7 +80,7 @@ func (r *runner) run(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
 		r.runWithTools(ctx, rt, req)
 		return
 	}
-	r.runText(ctx, rt, req)
+	r.runText(ctx, rt, req, 0, 0)
 }
 
 // toolsSupported reports whether the runtime's LLM provider honours native tool
@@ -100,8 +100,8 @@ func toolsSupported(rt *ProjectRuntime) bool {
 // terminates, preserving whatever transcript was gathered. This is the fallback
 // for providers without native tool-calling; its grounding guard (re-nudge then
 // decline rather than emit an ungrounded answer) is the safety net there.
-func (r *runner) runText(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
-	st := &turnState{req: req, client: rt.AIClient, model: rt.Model}
+func (r *runner) runText(ctx context.Context, rt *ProjectRuntime, req TurnRequest, tokensIn, tokensOut int) {
+	st := &turnState{req: req, client: rt.AIClient, model: rt.Model, tokensIn: tokensIn, tokensOut: tokensOut}
 
 	conv := ai.NewConversation(ai.ConversationOptions{
 		SystemPrompt: buildSystemPrompt(rt, r.cfg),
@@ -269,7 +269,9 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 			// openai provider, or a backend that 400s on tools). Fall back to the
 			// JSON-text loop rather than failing the turn.
 			if st.round == 1 {
-				r.runText(ctx, rt, req)
+				// Carry any tokens already spent on the (ignored) native call so
+				// the turn's usage accounting stays accurate.
+				r.runText(ctx, rt, req, st.tokensIn, st.tokensOut)
 				return
 			}
 			r.finishFailed(ctx, st, fmt.Sprintf("model call failed: %v", err))
@@ -291,7 +293,9 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 			// first round (no work yet) fall back to the JSON-text loop, which
 			// carries the action contract; otherwise nudge.
 			if st.round == 1 {
-				r.runText(ctx, rt, req)
+				// Carry any tokens already spent on the (ignored) native call so
+				// the turn's usage accounting stays accurate.
+				r.runText(ctx, rt, req, st.tokensIn, st.tokensOut)
 				return
 			}
 			messages = append(messages, gollm.Message{Role: "user", Content: groundingNudge})

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
 	commonmodels "github.com/decisionbox-io/decisionbox/libs/go-common/models"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/ai"
 	applog "github.com/decisionbox-io/decisionbox/services/agent/internal/log"
@@ -64,10 +65,37 @@ const groundingNudge = "Do NOT answer yet — you have run no query, so you have
 	"If you don't know the tables or columns, discover them with a query against INFORMATION_SCHEMA (e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES`) or use search_tables / lookup_schema. " +
 	"Only use clarify or decline if the question genuinely cannot be turned into any query."
 
-// run drives the bounded ReAct loop for one turn. It always finalizes the turn
-// (done/declined/timeout/failed) so the reader's poll terminates, preserving
-// whatever transcript was gathered.
+// run drives one turn to a finalized outcome. It dispatches on whether the
+// project's LLM provider supports native tool-calling: tool-wired providers
+// (bedrock / claude / openai) take the native-tools loop, where the model is
+// forced to call an evidence tool before it can answer; everyone else takes the
+// JSON-in-text loop, which coaxes the same vocabulary through prose + nudges.
 func (r *runner) run(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
+	if toolsSupported(rt) {
+		r.runWithTools(ctx, rt, req)
+		return
+	}
+	r.runText(ctx, rt, req)
+}
+
+// toolsSupported reports whether the runtime's LLM provider honours native tool
+// definitions. The provider name is set on the AI client at build time
+// (SetProvenance with project.LLM.Provider). When it's unknown or tools are
+// unsupported, the caller falls back to the JSON-text loop.
+func toolsSupported(rt *ProjectRuntime) bool {
+	if rt == nil || rt.AIClient == nil {
+		return false
+	}
+	meta, ok := gollm.GetProviderMeta(rt.AIClient.ProviderName())
+	return ok && meta.SupportsTools
+}
+
+// runText drives the bounded ReAct loop on the JSON-in-text path. It always
+// finalizes the turn (done/declined/timeout/failed) so the reader's poll
+// terminates, preserving whatever transcript was gathered. This is the fallback
+// for providers without native tool-calling; its grounding guard (re-nudge then
+// decline rather than emit an ungrounded answer) is the safety net there.
+func (r *runner) runText(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
 	st := &turnState{req: req, client: rt.AIClient, model: rt.Model}
 
 	conv := ai.NewConversation(ai.ConversationOptions{
@@ -196,6 +224,150 @@ func (st *turnState) callModel(ctx context.Context, conv *ai.Conversation, r *ru
 	st.tokensIn += resp.Usage.InputTokens
 	st.tokensOut += resp.Usage.OutputTokens
 	return resp.Content, nil
+}
+
+// runWithTools drives the bounded loop using native tool-calling. The model is
+// given the Q&A tools and forced (ToolChoice="any") to call one until the turn
+// is grounded — the `answer` tool is withheld until at least one query/lookup/
+// search has produced a result, so the model literally cannot finish with an
+// ungrounded answer. Once grounded it may keep querying or answer (ToolChoice=
+// "auto"). It always finalizes the turn. Conversation state is held as a raw
+// []gollm.Message because ai.Conversation cannot carry tool_use / tool_result
+// blocks.
+func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
+	st := &turnState{req: req, client: rt.AIClient, model: rt.Model}
+	system := buildSystemPromptForTools(rt, r.cfg)
+	hasSchema := rt.SchemaProvider != nil
+
+	var messages []gollm.Message
+	for _, m := range trimHistory(req.History, r.cfg.HistoryCharBudget) {
+		messages = append(messages, gollm.Message{Role: m.Role, Content: m.Content})
+	}
+	messages = append(messages, gollm.Message{Role: "user", Content: req.Question})
+
+	for st.round = 1; st.round <= r.cfg.MaxRounds; st.round++ {
+		if err := ctx.Err(); err != nil {
+			r.finishTimeout(ctx, st)
+			return
+		}
+
+		grounded := len(st.events) > 0
+		resp, err := st.callModelTools(ctx, messages, system, toolsForPhase(grounded, hasSchema), toolChoiceForPhase(grounded))
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				r.finishTimeout(ctx, st)
+				return
+			}
+			r.finishFailed(ctx, st, fmt.Sprintf("model call failed: %v", err))
+			return
+		}
+
+		// Record the assistant turn (text + any tool_use blocks) so the next
+		// request carries the tool_use the provider correlates tool_result to.
+		messages = append(messages, gollm.Message{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls})
+
+		if len(resp.ToolCalls) == 0 {
+			// No tool call. A grounded free-text reply is the answer; otherwise
+			// the model answered without evidence — nudge and retry. With
+			// ToolChoice="any" while ungrounded this branch should be rare.
+			if grounded && strings.TrimSpace(resp.Content) != "" {
+				r.finishTerminal(ctx, st, &turnAction{Kind: actAnswer, Text: strings.TrimSpace(resp.Content)})
+				return
+			}
+			messages = append(messages, gollm.Message{Role: "user", Content: groundingNudge})
+			continue
+		}
+
+		// A terminal tool (answer/clarify/decline) ends the turn. `answer` is in
+		// the tool set only once grounded, so an ungrounded answer can't reach
+		// here; the guard below is defensive.
+		if term := firstTerminalCall(resp.ToolCalls); term != nil {
+			act := toolCallToAction(*term)
+			if act.Kind == actAnswer && len(st.events) == 0 {
+				messages = append(messages, gollm.Message{Role: "user", ToolResults: []gollm.ToolResult{{CallID: term.ID, Content: groundingNudge, IsError: true}}})
+				continue
+			}
+			r.finishTerminal(ctx, st, act)
+			return
+		}
+
+		// Execute every data/schema tool call and feed all results back in one
+		// user message so the provider correlates each tool_result to its
+		// tool_use by id.
+		results := make([]gollm.ToolResult, 0, len(resp.ToolCalls))
+		for _, tc := range resp.ToolCalls {
+			act := toolCallToAction(tc)
+			if act == nil {
+				results = append(results, gollm.ToolResult{CallID: tc.ID, Content: fmt.Sprintf("Unknown tool %q.", tc.Name), IsError: true})
+				continue
+			}
+			obs := r.execute(ctx, rt, st, act)
+			if ctx.Err() != nil {
+				r.finishTimeout(ctx, st)
+				return
+			}
+			results = append(results, gollm.ToolResult{CallID: tc.ID, Content: obs})
+		}
+		messages = append(messages, gollm.Message{Role: "user", ToolResults: results})
+	}
+
+	// Round budget exhausted. One final, forced synthesis from gathered evidence.
+	if act := r.synthesizeFinalTools(ctx, messages, system, st); act != nil {
+		if act.Kind == actAnswer && len(st.events) == 0 {
+			r.finishUngrounded(ctx, st)
+			return
+		}
+		r.finishTerminal(ctx, st, act)
+		return
+	}
+	if ctx.Err() != nil {
+		r.finishTimeout(ctx, st)
+		return
+	}
+	r.finishFailed(ctx, st, fmt.Sprintf("reached the step budget (%d) without producing an answer", r.cfg.MaxRounds))
+}
+
+// callModelTools issues one tool-enabled LLM call and accumulates token usage.
+func (st *turnState) callModelTools(ctx context.Context, messages []gollm.Message, system string, tools []gollm.ToolDefinition, choice string) (*gollm.ChatResponse, error) {
+	resp, err := st.client.CreateMessageWithTools(ctx, messages, system, llmMaxOutputTokens, tools, choice)
+	if err != nil {
+		return nil, err
+	}
+	st.tokensIn += resp.Usage.InputTokens
+	st.tokensOut += resp.Usage.OutputTokens
+	return resp, nil
+}
+
+// synthesizeFinalTools makes one last tool-enabled call after the round budget
+// is spent, offering only answer/decline and forcing a choice. Returns a
+// terminal action, or nil if the model produced neither.
+func (r *runner) synthesizeFinalTools(ctx context.Context, messages []gollm.Message, system string, st *turnState) *turnAction {
+	if ctx.Err() != nil {
+		return nil
+	}
+	messages = append(messages, gollm.Message{Role: "user", Content: "You have reached the step budget. Answer the original question now using only the results already gathered in this conversation, or decline if they are insufficient."})
+	resp, err := st.callModelTools(ctx, messages, system, []gollm.ToolDefinition{toolAnswer(), toolDecline()}, "any")
+	if err != nil {
+		return nil
+	}
+	if term := firstTerminalCall(resp.ToolCalls); term != nil {
+		return toolCallToAction(*term)
+	}
+	if strings.TrimSpace(resp.Content) != "" {
+		return &turnAction{Kind: actAnswer, Text: strings.TrimSpace(resp.Content)}
+	}
+	return nil
+}
+
+// firstTerminalCall returns the first answer/clarify/decline tool call in the
+// response, or nil if there is none.
+func firstTerminalCall(calls []gollm.ToolCall) *gollm.ToolCall {
+	for i := range calls {
+		if actionKind(calls[i].Name).terminal() {
+			return &calls[i]
+		}
+	}
+	return nil
 }
 
 // execute runs a tool action and returns the observation to feed back to the

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -49,6 +49,11 @@ type turnState struct {
 	tokensIn        int
 	tokensOut       int
 	groundingNudges int
+	// groundedEvents counts evidence tool events that SUCCEEDED (no error). The
+	// native-tools loop grounds on this, not on len(events): a failed query /
+	// rejected tenant filter / unavailable schema search records an event but
+	// observed no data, so it must not unlock the answer tool.
+	groundedEvents int
 }
 
 // maxGroundingNudges bounds how many times the loop re-prompts a model that
@@ -251,19 +256,19 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 			return
 		}
 
-		grounded := len(st.events) > 0
+		grounded := st.groundedEvents > 0
 		resp, err := st.callModelTools(ctx, messages, system, toolsForPhase(grounded, hasSchema), toolChoiceForPhase(grounded))
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				r.finishTimeout(ctx, st)
 				return
 			}
-			// The first tool-enabled call failed before any evidence was
-			// gathered. SupportsTools is provider-wide, so a specific model can
-			// still reject tools (e.g. an OpenAI reasoning model under the
-			// tool-capable openai provider, or a backend that 400s on tools).
-			// Fall back to the JSON-text loop rather than failing the turn.
-			if st.round == 1 && len(st.events) == 0 {
+			// The first tool-enabled call failed before any work was done.
+			// SupportsTools is provider-wide, so a specific model can still
+			// reject tools (e.g. an OpenAI reasoning model under the tool-capable
+			// openai provider, or a backend that 400s on tools). Fall back to the
+			// JSON-text loop rather than failing the turn.
+			if st.round == 1 {
 				r.runText(ctx, rt, req)
 				return
 			}
@@ -276,11 +281,17 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 		messages = append(messages, gollm.Message{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls})
 
 		if len(resp.ToolCalls) == 0 {
-			// No tool call. A grounded free-text reply is the answer; otherwise
-			// the model answered without evidence — nudge and retry. With
-			// ToolChoice="any" while ungrounded this branch should be rare.
+			// No tool call. A grounded free-text reply is the answer.
 			if grounded && strings.TrimSpace(resp.Content) != "" {
 				r.finishTerminal(ctx, st, &turnAction{Kind: actAnswer, Text: strings.TrimSpace(resp.Content)})
+				return
+			}
+			// Ungrounded with no tool call means ToolChoice="any" was not honoured
+			// (a backend that accepts `tools` but ignores `tool_choice`). On the
+			// first round (no work yet) fall back to the JSON-text loop, which
+			// carries the action contract; otherwise nudge.
+			if st.round == 1 {
+				r.runText(ctx, rt, req)
 				return
 			}
 			messages = append(messages, gollm.Message{Role: "user", Content: groundingNudge})
@@ -300,7 +311,7 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 				messages = append(messages, gollm.Message{Role: "user", ToolResults: []gollm.ToolResult{{CallID: tc.ID, Content: aerr.Error(), IsError: true}}})
 				continue
 			}
-			if act.Kind == actAnswer && len(st.events) == 0 {
+			if act.Kind == actAnswer && st.groundedEvents == 0 {
 				messages = append(messages, gollm.Message{Role: "user", ToolResults: []gollm.ToolResult{{CallID: tc.ID, Content: groundingNudge, IsError: true}}})
 				continue
 			}
@@ -336,7 +347,7 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 
 	// Round budget exhausted. One final, forced synthesis from gathered evidence.
 	if act := r.synthesizeFinalTools(ctx, messages, system, st); act != nil {
-		if act.Kind == actAnswer && len(st.events) == 0 {
+		if act.Kind == actAnswer && st.groundedEvents == 0 {
 			r.finishUngrounded(ctx, st)
 			return
 		}
@@ -509,6 +520,10 @@ func (r *runner) execSearch(ctx context.Context, rt *ProjectRuntime, st *turnSta
 // emit appends a tool event to the in-memory transcript and persists it.
 func (r *runner) emit(ctx context.Context, st *turnState, ev commonmodels.ToolEvent) {
 	st.events = append(st.events, ev)
+	if ev.Error == "" {
+		// A successful evidence event — the model actually observed data.
+		st.groundedEvents++
+	}
 	// Persist under a short, detached deadline so a turn ctx already past its
 	// wall-clock can still durably record the event it just produced.
 	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -258,6 +258,15 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 				r.finishTimeout(ctx, st)
 				return
 			}
+			// The first tool-enabled call failed before any evidence was
+			// gathered. SupportsTools is provider-wide, so a specific model can
+			// still reject tools (e.g. an OpenAI reasoning model under the
+			// tool-capable openai provider, or a backend that 400s on tools).
+			// Fall back to the JSON-text loop rather than failing the turn.
+			if st.round == 1 && len(st.events) == 0 {
+				r.runText(ctx, rt, req)
+				return
+			}
 			r.finishFailed(ctx, st, fmt.Sprintf("model call failed: %v", err))
 			return
 		}
@@ -278,27 +287,41 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 			continue
 		}
 
-		// A terminal tool (answer/clarify/decline) ends the turn. `answer` is in
-		// the tool set only once grounded, so an ungrounded answer can't reach
-		// here; the guard below is defensive.
-		if term := firstTerminalCall(resp.ToolCalls); term != nil {
-			act := toolCallToAction(*term)
+		// A LONE terminal tool call (answer/clarify/decline) ends the turn.
+		// `answer` is in the tool set only once grounded, so an ungrounded answer
+		// can't reach here; the guard below is defensive. A terminal call that
+		// arrives ALONGSIDE data calls is NOT finalized — the answer could
+		// reference a query we have not run — it is refused in the batch loop
+		// below so the model re-issues it after seeing the results.
+		if len(resp.ToolCalls) == 1 && actionKind(resp.ToolCalls[0].Name).terminal() {
+			tc := resp.ToolCalls[0]
+			act, aerr := toolCallToAction(tc)
+			if aerr != nil {
+				messages = append(messages, gollm.Message{Role: "user", ToolResults: []gollm.ToolResult{{CallID: tc.ID, Content: aerr.Error(), IsError: true}}})
+				continue
+			}
 			if act.Kind == actAnswer && len(st.events) == 0 {
-				messages = append(messages, gollm.Message{Role: "user", ToolResults: []gollm.ToolResult{{CallID: term.ID, Content: groundingNudge, IsError: true}}})
+				messages = append(messages, gollm.Message{Role: "user", ToolResults: []gollm.ToolResult{{CallID: tc.ID, Content: groundingNudge, IsError: true}}})
 				continue
 			}
 			r.finishTerminal(ctx, st, act)
 			return
 		}
 
-		// Execute every data/schema tool call and feed all results back in one
-		// user message so the provider correlates each tool_result to its
-		// tool_use by id.
+		// Execute every call and feed all results back in one user message so the
+		// provider correlates each tool_result to its tool_use by id. A malformed
+		// call yields an error result without running (so it never emits a
+		// spuriously grounding event); a terminal call mixed into the batch is
+		// refused so the model reviews the data before finishing.
 		results := make([]gollm.ToolResult, 0, len(resp.ToolCalls))
 		for _, tc := range resp.ToolCalls {
-			act := toolCallToAction(tc)
-			if act == nil {
-				results = append(results, gollm.ToolResult{CallID: tc.ID, Content: fmt.Sprintf("Unknown tool %q.", tc.Name), IsError: true})
+			if actionKind(tc.Name).terminal() {
+				results = append(results, gollm.ToolResult{CallID: tc.ID, Content: "Do not finish in the same step as a data tool. Review the query results first, then call answer/clarify/decline on its own.", IsError: true})
+				continue
+			}
+			act, aerr := toolCallToAction(tc)
+			if aerr != nil {
+				results = append(results, gollm.ToolResult{CallID: tc.ID, Content: aerr.Error(), IsError: true})
 				continue
 			}
 			obs := r.execute(ctx, rt, st, act)
@@ -351,7 +374,9 @@ func (r *runner) synthesizeFinalTools(ctx context.Context, messages []gollm.Mess
 		return nil
 	}
 	if term := firstTerminalCall(resp.ToolCalls); term != nil {
-		return toolCallToAction(*term)
+		if act, err := toolCallToAction(*term); err == nil {
+			return act
+		}
 	}
 	if strings.TrimSpace(resp.Content) != "" {
 		return &turnAction{Kind: actAnswer, Text: strings.TrimSpace(resp.Content)}

--- a/services/agent/internal/askserve/loop_tools_test.go
+++ b/services/agent/internal/askserve/loop_tools_test.go
@@ -155,25 +155,49 @@ func TestLoopTools_AnswerWithheldUntilGrounded(t *testing.T) {
 	}
 }
 
-func TestLoopTools_UngroundedFreeTextNudged(t *testing.T) {
-	// If the model replies with free text (no tool call) while ungrounded, the
-	// loop must NOT accept it as an answer — it nudges and continues until a real
-	// query backs the answer.
+func TestLoopTools_NoToolCallRound1FallsBack(t *testing.T) {
+	// A backend that accepts `tools` but ignores `tool_choice=any` returns
+	// ordinary content with no tool calls on the forced first round. Treat that
+	// as "tools not honoured" and fall back to the JSON-text loop, which carries
+	// the action contract and still answers.
 	wh := testutil.NewMockWarehouseProvider("ds")
 	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
-		{Content: "There are 5 tables.", StopReason: "end_turn", Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5}},
-		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.t"}),
-		toolCall(string(actAnswer), map[string]any{"text": "grounded answer"}),
+		{Content: "Sure, let me look into that.", StopReason: "end_turn", Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5}}, // no tool calls → forced tools ignored
+		{Content: `{"query":"SELECT 1 FROM ds.t"}`, Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5}},                        // JSON-text path
+		{Content: `{"answer":"text-path answer"}`, Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5}},
 	}}
 	store := runOnceTools(t, Config{}, p, wh, nil, "")
-	if store.final.Status != commonmodels.AskTurnStatusDone {
-		t.Fatalf("status = %q, want done", store.final.Status)
-	}
-	if store.final.Answer != "grounded answer" {
-		t.Fatalf("ungrounded free text must not win; answer = %q", store.final.Answer)
+	if store.final.Status != commonmodels.AskTurnStatusDone || store.final.Answer != "text-path answer" {
+		t.Fatalf("expected fallback to the text loop; status=%q answer=%q", store.final.Status, store.final.Answer)
 	}
 	if len(store.events) != 1 {
-		t.Fatalf("events = %d, want 1", len(store.events))
+		t.Fatalf("events = %d, want 1 from the fallback query", len(store.events))
+	}
+}
+
+func TestLoopTools_FailedEvidenceNotGrounding(t *testing.T) {
+	// A failed query records an event but observed no data — it must NOT mark the
+	// turn grounded, so the answer tool stays withheld and the model can only
+	// (legitimately) decline.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	wh.QueryError = errors.New("table not found")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.t"}), // fails → error event, not grounded
+		toolCall(string(actDecline), map[string]any{"reason": "could not get data"}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDeclined {
+		t.Fatalf("status = %q, want declined", store.final.Status)
+	}
+	if len(store.events) != 1 || store.events[0].Error == "" {
+		t.Fatalf("expected one failed query event, got %+v", store.events)
+	}
+	// The failed query must not have unlocked the answer tool on the next round.
+	if hasTool(p.reqs[1].Tools, string(actAnswer)) {
+		t.Fatal("answer offered after a FAILED query — failed evidence wrongly grounded the turn")
+	}
+	if p.reqs[1].ToolChoice != "any" {
+		t.Fatalf("ToolChoice = %q after a failed query, want any (still ungrounded)", p.reqs[1].ToolChoice)
 	}
 }
 

--- a/services/agent/internal/askserve/loop_tools_test.go
+++ b/services/agent/internal/askserve/loop_tools_test.go
@@ -2,6 +2,7 @@ package askserve
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -252,6 +253,119 @@ func TestLoopTools_RoundCapThenSynthesizes(t *testing.T) {
 	}
 	if store.final.Answer != "synthesized from gathered data" {
 		t.Fatalf("answer = %q", store.final.Answer)
+	}
+}
+
+func TestLoopTools_EmptyQueryNotGrounding(t *testing.T) {
+	// A query_data call missing its required "query" arg must be rejected without
+	// running — it must NOT emit a (spuriously grounding) event, so the `answer`
+	// tool stays withheld until a real query has run.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{}),                              // missing query → rejected
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.t"}), // real query → grounds
+		toolCall(string(actAnswer), map[string]any{"text": "grounded"}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q, want done", store.final.Status)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("events = %d, want 1 (empty query must not emit a grounding event)", len(store.events))
+	}
+	if len(wh.Calls) != 1 {
+		t.Fatalf("warehouse calls = %d, want 1 (empty query must not reach the warehouse)", len(wh.Calls))
+	}
+	// After the rejected empty query the turn is still ungrounded, so answer must
+	// not yet be offered.
+	if hasTool(p.reqs[1].Tools, string(actAnswer)) {
+		t.Fatal("answer offered after a rejected empty query — turn wrongly considered grounded")
+	}
+}
+
+func TestLoopTools_MixedTerminalDefersToData(t *testing.T) {
+	// A response carrying a data call AND a terminal answer in parallel must NOT
+	// finalize on the answer (it could reference a query that never ran) — the
+	// data call runs and the answer is deferred to a later round.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.a"}),
+		{
+			StopReason: "tool_use",
+			ToolCalls: []gollm.ToolCall{
+				{ID: "q2", Name: string(actQuery), Input: map[string]any{"query": "SELECT 2 FROM ds.b"}},
+				{ID: "a1", Name: string(actAnswer), Input: map[string]any{"text": "premature answer"}},
+			},
+			Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5},
+		},
+		toolCall(string(actAnswer), map[string]any{"text": "final grounded answer"}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q", store.final.Status)
+	}
+	if store.final.Answer != "final grounded answer" {
+		t.Fatalf("mixed-batch answer must be deferred; got %q", store.final.Answer)
+	}
+	if len(store.events) != 2 {
+		t.Fatalf("events = %d, want 2 (both data queries ran)", len(store.events))
+	}
+	// The deferred answer call must have received an error tool_result.
+	round2Results := p.reqs[2].Messages[len(p.reqs[2].Messages)-1].ToolResults
+	var sawAnswerRefusal bool
+	for _, tr := range round2Results {
+		if tr.CallID == "a1" && tr.IsError {
+			sawAnswerRefusal = true
+		}
+	}
+	if !sawAnswerRefusal {
+		t.Fatal("the deferred answer call should receive an error tool_result")
+	}
+}
+
+// errThenTextProvider errors on its first Chat (simulating a model that rejects
+// tools) then returns scripted JSON-text responses for the fallback loop.
+type errThenTextProvider struct {
+	calls int
+	text  []string
+}
+
+func (p *errThenTextProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*gollm.ChatResponse, error) {
+	p.calls++
+	if p.calls == 1 {
+		return nil, errors.New("tools not supported by this model")
+	}
+	content := `{"decline":"out of script"}`
+	if i := p.calls - 2; i < len(p.text) {
+		content = p.text[i]
+	}
+	return &gollm.ChatResponse{Content: content, Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5}}, nil
+}
+func (p *errThenTextProvider) Validate(ctx context.Context) error { return nil }
+
+func TestLoopTools_FallbackOnToolErrorUsesTextLoop(t *testing.T) {
+	// SupportsTools is provider-wide; if the specific model rejects tools the
+	// first call errors before any evidence — the turn must fall back to the
+	// JSON-text loop and still answer rather than failing.
+	ensureToolProvider()
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &errThenTextProvider{text: []string{
+		`{"query":"SELECT count(*) AS c FROM ds.t"}`,
+		`{"answer":"text-path answer"}`,
+	}}
+	store := &fakeStore{}
+	r := &runner{cfg: Config{MaxRounds: 8, MaxQueriesPerTurn: 6, MaxFetchRows: 1000, PreviewRows: 50}, store: store}
+	rt := testRuntime(p, wh, nil, "")
+	rt.AIClient.SetProvenance("p1", "", "test-tools") // tool-capable provider → native path tried first
+	r.run(context.Background(), rt, TurnRequest{TurnID: "t1", SessionID: "s1", ProjectID: "p1", Question: "how many?"})
+	if store.final == nil {
+		t.Fatal("turn did not finalize")
+	}
+	if store.final.Status != commonmodels.AskTurnStatusDone || store.final.Answer != "text-path answer" {
+		t.Fatalf("expected fallback text path to answer; got status=%q answer=%q", store.final.Status, store.final.Answer)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("events = %d, want 1 from the fallback query", len(store.events))
 	}
 }
 

--- a/services/agent/internal/askserve/loop_tools_test.go
+++ b/services/agent/internal/askserve/loop_tools_test.go
@@ -1,0 +1,283 @@
+package askserve
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
+	commonmodels "github.com/decisionbox-io/decisionbox/libs/go-common/models"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/ai"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/testutil"
+)
+
+// toolProviderOnce registers a synthetic tool-capable provider ("test-tools")
+// exactly once per test binary so toolsSupported() returns true for runtimes
+// whose AI client is given that provenance. The factory is never invoked (tests
+// inject the provider directly via ai.New); only the meta's SupportsTools flag
+// matters.
+var toolProviderOnce sync.Once
+
+func ensureToolProvider() {
+	toolProviderOnce.Do(func() {
+		gollm.RegisterWithMeta(
+			"test-tools",
+			func(gollm.ProviderConfig) (gollm.Provider, error) { return nil, nil },
+			gollm.ProviderMeta{SupportsTools: true},
+		)
+	})
+}
+
+// scriptedToolProvider returns canned tool-calling responses by call order and
+// records every request it received (so tests can assert which tools were
+// offered and the tool_result round-trip).
+type scriptedToolProvider struct {
+	responses []gollm.ChatResponse
+	reqs      []gollm.ChatRequest
+	idx       int
+}
+
+func (p *scriptedToolProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*gollm.ChatResponse, error) {
+	p.reqs = append(p.reqs, req)
+	i := p.idx
+	p.idx++
+	if i < len(p.responses) {
+		resp := p.responses[i]
+		return &resp, nil
+	}
+	return &gollm.ChatResponse{
+		StopReason: "tool_use",
+		ToolCalls:  []gollm.ToolCall{{ID: "end", Name: string(actDecline), Input: map[string]any{"reason": "out of script"}}},
+		Usage:      gollm.Usage{InputTokens: 10, OutputTokens: 5},
+	}, nil
+}
+func (p *scriptedToolProvider) Validate(ctx context.Context) error { return nil }
+
+// toolCall builds a ChatResponse carrying one tool call.
+func toolCall(name string, input map[string]any) gollm.ChatResponse {
+	return gollm.ChatResponse{
+		StopReason: "tool_use",
+		ToolCalls:  []gollm.ToolCall{{ID: name + "-1", Name: name, Input: input}},
+		Usage:      gollm.Usage{InputTokens: 10, OutputTokens: 5},
+	}
+}
+
+func toolRuntime(provider gollm.Provider, wh *testutil.MockWarehouseProvider, sp ai.SchemaProvider, filterField string) *ProjectRuntime {
+	ensureToolProvider()
+	rt := testRuntime(provider, wh, sp, filterField)
+	// Mark the client as a tool-capable provider so run() takes the native path.
+	rt.AIClient.SetProvenance("p1", "", "test-tools")
+	return rt
+}
+
+func runOnceTools(t *testing.T, cfg Config, p *scriptedToolProvider, wh *testutil.MockWarehouseProvider, sp ai.SchemaProvider, filterField string) *fakeStore {
+	t.Helper()
+	if cfg.MaxRounds == 0 {
+		cfg = Config{MaxRounds: 8, MaxQueriesPerTurn: 6, MaxFetchRows: 1000, PreviewRows: 50}
+	}
+	store := &fakeStore{}
+	r := &runner{cfg: cfg, store: store}
+	rt := toolRuntime(p, wh, sp, filterField)
+	r.run(context.Background(), rt, TurnRequest{TurnID: "t1", SessionID: "s1", ProjectID: "p1", Question: "how many?"})
+	if store.final == nil {
+		t.Fatal("turn did not finalize")
+	}
+	return store
+}
+
+func hasTool(tools []gollm.ToolDefinition, name string) bool {
+	for _, td := range tools {
+		if td.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestToolsSupported_DetectsProvider(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("ds")
+	// Default test runtime has no provenance → unknown provider → fallback.
+	if toolsSupported(testRuntime(&scriptedProvider{}, wh, nil, "")) {
+		t.Fatal("unknown provider must not be treated as tool-capable")
+	}
+	// A runtime marked with the tool-capable provider → native path.
+	if !toolsSupported(toolRuntime(&scriptedToolProvider{}, wh, nil, "")) {
+		t.Fatal("test-tools provider should be tool-capable")
+	}
+}
+
+func TestLoopTools_HappyPath(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT count(*) AS c FROM ds.t"}),
+		toolCall(string(actAnswer), map[string]any{"text": "There are 100 rows."}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q, want done", store.final.Status)
+	}
+	if store.final.Answer != "There are 100 rows." {
+		t.Fatalf("answer = %q", store.final.Answer)
+	}
+	if len(store.events) != 1 || store.events[0].Name != "query_data" {
+		t.Fatalf("events = %+v, want 1 query event", store.events)
+	}
+	if store.events[0].Output == nil {
+		t.Fatal("query event missing summary output")
+	}
+}
+
+func TestLoopTools_AnswerWithheldUntilGrounded(t *testing.T) {
+	// The structural guarantee: while ungrounded the model is FORCED to call a
+	// tool ("any") and the `answer` tool is not even offered — fabrication is
+	// impossible. Once a query has run, `answer` appears and the choice relaxes.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.t"}),
+		toolCall(string(actAnswer), map[string]any{"text": "grounded"}),
+	}}
+	runOnceTools(t, Config{}, p, wh, nil, "")
+	if len(p.reqs) < 2 {
+		t.Fatalf("expected at least 2 model calls, got %d", len(p.reqs))
+	}
+	if hasTool(p.reqs[0].Tools, string(actAnswer)) {
+		t.Fatal("answer tool must NOT be offered before any evidence is gathered")
+	}
+	if p.reqs[0].ToolChoice != "any" {
+		t.Fatalf("ungrounded ToolChoice = %q, want any", p.reqs[0].ToolChoice)
+	}
+	if !hasTool(p.reqs[1].Tools, string(actAnswer)) {
+		t.Fatal("answer tool must be offered once grounded")
+	}
+	if p.reqs[1].ToolChoice != "auto" {
+		t.Fatalf("grounded ToolChoice = %q, want auto", p.reqs[1].ToolChoice)
+	}
+}
+
+func TestLoopTools_UngroundedFreeTextNudged(t *testing.T) {
+	// If the model replies with free text (no tool call) while ungrounded, the
+	// loop must NOT accept it as an answer — it nudges and continues until a real
+	// query backs the answer.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		{Content: "There are 5 tables.", StopReason: "end_turn", Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5}},
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.t"}),
+		toolCall(string(actAnswer), map[string]any{"text": "grounded answer"}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q, want done", store.final.Status)
+	}
+	if store.final.Answer != "grounded answer" {
+		t.Fatalf("ungrounded free text must not win; answer = %q", store.final.Answer)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(store.events))
+	}
+}
+
+func TestLoopTools_DeclineToolBeforeQuery(t *testing.T) {
+	// decline is available even while ungrounded — a genuinely unanswerable
+	// question terminates cleanly with no query.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actDecline), map[string]any{"reason": "not in the data"}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDeclined {
+		t.Fatalf("status = %q, want declined", store.final.Status)
+	}
+	if len(store.events) != 0 || len(wh.Calls) != 0 {
+		t.Fatalf("decline must run no query; events=%d calls=%d", len(store.events), len(wh.Calls))
+	}
+}
+
+func TestLoopTools_ClarifyToolBeforeQuery(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actClarify), map[string]any{"question": "which region?"}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Disposition != commonmodels.AskTurnDispositionClarify {
+		t.Fatalf("disposition = %q, want clarify", store.final.Disposition)
+	}
+	if len(store.events) != 0 {
+		t.Fatalf("clarify must run no query; events=%d", len(store.events))
+	}
+}
+
+func TestLoopTools_ParallelToolCalls(t *testing.T) {
+	// A single response with two tool calls: both execute, and both results are
+	// fed back in one user message correlated by call id.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		{
+			StopReason: "tool_use",
+			ToolCalls: []gollm.ToolCall{
+				{ID: "q1", Name: string(actQuery), Input: map[string]any{"query": "SELECT 1 FROM ds.a"}},
+				{ID: "q2", Name: string(actQuery), Input: map[string]any{"query": "SELECT 2 FROM ds.b"}},
+			},
+			Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5},
+		},
+		toolCall(string(actAnswer), map[string]any{"text": "both ran"}),
+	}}
+	store := runOnceTools(t, Config{}, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q", store.final.Status)
+	}
+	if len(store.events) != 2 {
+		t.Fatalf("events = %d, want 2 (both parallel calls executed)", len(store.events))
+	}
+	// The second request must carry a user message with two tool results.
+	last := p.reqs[1].Messages[len(p.reqs[1].Messages)-1]
+	if last.Role != "user" || len(last.ToolResults) != 2 {
+		t.Fatalf("expected a user message with 2 tool results, got role=%q results=%d", last.Role, len(last.ToolResults))
+	}
+	if last.ToolResults[0].CallID != "q1" || last.ToolResults[1].CallID != "q2" {
+		t.Fatalf("tool results not correlated by call id: %+v", last.ToolResults)
+	}
+}
+
+func TestLoopTools_RoundCapThenSynthesizes(t *testing.T) {
+	cfg := Config{MaxRounds: 2, MaxQueriesPerTurn: 6, MaxFetchRows: 1000, PreviewRows: 50}
+	wh := testutil.NewMockWarehouseProvider("ds")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.a"}),
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 2 FROM ds.b"}),
+		toolCall(string(actAnswer), map[string]any{"text": "synthesized from gathered data"}),
+	}}
+	store := runOnceTools(t, cfg, p, wh, nil, "")
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q, want done via synthesis", store.final.Status)
+	}
+	if store.final.Answer != "synthesized from gathered data" {
+		t.Fatalf("answer = %q", store.final.Answer)
+	}
+}
+
+func TestLoopTools_SchemaToolsOfferedOnlyWithProvider(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("ds")
+	// No schema provider → search/lookup tools must not be offered.
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.t"}),
+		toolCall(string(actAnswer), map[string]any{"text": "ok"}),
+	}}
+	runOnceTools(t, Config{}, p, wh, nil, "")
+	if hasTool(p.reqs[0].Tools, string(actSearch)) || hasTool(p.reqs[0].Tools, string(actLookup)) {
+		t.Fatal("schema tools must not be offered when SchemaProvider is nil")
+	}
+
+	// With a schema provider → both are offered.
+	sp := &fakeSchema{hits: []ai.SearchHit{{Table: "ds.users", Blurb: "u", RowCount: 1, Score: 0.5}}}
+	p2 := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actSearch), map[string]any{"query": "users"}),
+		toolCall(string(actAnswer), map[string]any{"text": "found"}),
+	}}
+	store := runOnceTools(t, Config{}, p2, testutil.NewMockWarehouseProvider("ds"), sp, "")
+	if !hasTool(p2.reqs[0].Tools, string(actSearch)) || !hasTool(p2.reqs[0].Tools, string(actLookup)) {
+		t.Fatal("schema tools should be offered when SchemaProvider is set")
+	}
+	if len(store.events) != 1 || store.events[0].Name != "search_tables" {
+		t.Fatalf("events = %+v, want a search_tables event", store.events)
+	}
+}

--- a/services/agent/internal/askserve/loop_tools_test.go
+++ b/services/agent/internal/askserve/loop_tools_test.go
@@ -173,6 +173,11 @@ func TestLoopTools_NoToolCallRound1FallsBack(t *testing.T) {
 	if len(store.events) != 1 {
 		t.Fatalf("events = %d, want 1 from the fallback query", len(store.events))
 	}
+	// Tokens from the ignored native call (10/5) must carry into the text loop,
+	// which then spends 2 more calls (10/5 each): 30 in / 15 out total.
+	if store.final.InputTokens != 30 || store.final.OutputTokens != 15 {
+		t.Fatalf("token accounting lost the ignored native call: in=%d out=%d, want 30/15", store.final.InputTokens, store.final.OutputTokens)
+	}
 }
 
 func TestLoopTools_FailedEvidenceNotGrounding(t *testing.T) {

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -5,34 +5,18 @@ import (
 	"strings"
 )
 
-// buildSystemPrompt renders the Q&A system prompt for one turn. It is
-// deliberately generic — an analyst data-question agent over a read-only
-// warehouse — and describes the JSON action vocabulary the loop parses, the
-// hard safety rules, and the result-summarization behaviour so the model
-// reaches for aggregate SQL instead of expecting full result sets.
+// buildSystemPrompt renders the Q&A system prompt for one turn on the JSON-text
+// path (providers without native tool-calling). It is deliberately generic — an
+// analyst data-question agent over a read-only warehouse — and describes the
+// JSON action vocabulary the loop parses, the hard safety rules, and the
+// result-summarization behaviour so the model reaches for aggregate SQL instead
+// of expecting full result sets.
 func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
 	var b strings.Builder
 
 	b.WriteString("You are a data analyst agent. Answer the user's natural-language question about their data by reasoning step by step and running read-only SQL against their data warehouse. Ground every claim in query results — never invent numbers.\n\n")
 
-	b.WriteString("WAREHOUSE\n")
-	if rt.Dialect != "" {
-		fmt.Fprintf(&b, "- SQL dialect: %s\n", rt.Dialect)
-	}
-	if len(rt.Datasets) > 0 {
-		fmt.Fprintf(&b, "- Datasets available: %s\n", strings.Join(rt.Datasets, ", "))
-	}
-	b.WriteString("- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n")
-	if strings.TrimSpace(rt.FilterField) != "" {
-		if strings.TrimSpace(rt.FilterValue) != "" {
-			// Inject the exact tenant predicate so the model scopes every query
-			// correctly. (Presence of the column is enforced server-side; do not
-			// negate or broaden it.)
-			fmt.Fprintf(&b, "- SECURITY: this is a multi-tenant dataset. Every query MUST be scoped to this tenant with the predicate `%s = '%s'` (in the WHERE clause, or preserved through every join/CTE). Never negate, broaden, or omit it. A query missing the %q column is rejected.\n", rt.FilterField, rt.FilterValue, rt.FilterField)
-		} else {
-			fmt.Fprintf(&b, "- SECURITY: every query MUST filter by %q (the tenant scope). A query missing this filter is rejected.\n", rt.FilterField)
-		}
-	}
+	writeWarehouseSection(&b, rt)
 
 	b.WriteString("\nHOW TO RESPOND\n")
 	b.WriteString("Respond with EXACTLY ONE JSON object and nothing else — no prose, no markdown fences. Pick one action per step:\n")
@@ -43,14 +27,71 @@ func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
 	b.WriteString(`  {"thinking":"...","clarify":"a single clarifying question"}` + "  — when the question is too ambiguous to answer\n")
 	b.WriteString(`  {"thinking":"...","decline":"why this cannot be answered from the data"}` + "  — when it is unanswerable\n")
 
-	b.WriteString("\nRESULT HANDLING\n")
-	fmt.Fprintf(&b, "- Query results are returned summary-only: row count, columns, and a preview of up to %d rows. Large result sets are truncated.\n", cfg.PreviewRows)
-	b.WriteString("- For totals, counts, distributions, or \"how many\" questions, write aggregate SQL (COUNT, SUM, AVG, GROUP BY) — do NOT page through raw rows.\n")
-	fmt.Fprintf(&b, "- You may run at most %d queries and take at most %d steps this turn. Be economical; reuse results already in this conversation instead of re-querying.\n", cfg.MaxQueriesPerTurn, cfg.MaxRounds)
+	writeResultHandling(&b, cfg)
 
 	b.WriteString("\nGROUNDING (required): you MUST run at least one query_data action and observe its result before you give an `answer`. Never state a table name, count, total, or specific value you have not seen in a query result in this conversation — do not answer from prior knowledge or guesses. If you don't yet know the tables or columns, your FIRST action must be a discovery query — e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES` — or a search_tables / lookup_schema; do not invent table or column names. An answer with no query behind it will be rejected; only use clarify or decline if the question genuinely cannot be turned into any query.\n")
 
 	b.WriteString("\nFinish with an \"answer\", \"clarify\", or \"decline\" action. The answer should be concise, analyst-style prose that directly addresses the question and references the figures you found.")
 
 	return b.String()
+}
+
+// buildSystemPromptForTools renders the Q&A system prompt for the native
+// tool-calling path. It reuses the warehouse, security, and result-handling
+// guidance but omits the JSON action contract — the tools ARE the contract, and
+// the loop withholds the `answer` tool until at least one query/lookup/search
+// has run, so grounding is enforced structurally rather than by prose. The
+// prose here is guidance, not a hard gate.
+func buildSystemPromptForTools(rt *ProjectRuntime, cfg Config) string {
+	var b strings.Builder
+
+	b.WriteString("You are a data analyst agent. Answer the user's natural-language question about their data by reasoning step by step and using the provided tools to run read-only SQL against their data warehouse. Ground every claim in query results — never invent numbers, table names, or column names.\n\n")
+
+	writeWarehouseSection(&b, rt)
+
+	b.WriteString("\nTOOLS\n")
+	b.WriteString("- query_data: run one read-only SQL query and observe a summary of the result.\n")
+	b.WriteString("- search_tables / lookup_schema: discover which tables exist and what columns they have.\n")
+	b.WriteString("- answer / clarify / decline: finish the turn.\n")
+
+	writeResultHandling(&b, cfg)
+
+	b.WriteString("\nGROUNDING (required): you MUST run at least one query_data, search_tables, or lookup_schema call and observe its result before you answer. Never state a table name, count, total, or value you have not seen in a result this turn — do not answer from prior knowledge or guesses. If you don't know the tables or columns, start with search_tables or a discovery query (e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES`); do not invent names. Only clarify when the request is genuinely too ambiguous to query, and prefer a discovery query before you decline.\n")
+
+	b.WriteString("\nFinish by calling answer (concise, analyst-style prose referencing the figures you found), clarify, or decline.")
+
+	return b.String()
+}
+
+// writeWarehouseSection renders the shared WAREHOUSE block (dialect, datasets,
+// read-only rule, and the tenant-scope predicate when the dataset is
+// multi-tenant). Shared verbatim by both prompt builders.
+func writeWarehouseSection(b *strings.Builder, rt *ProjectRuntime) {
+	b.WriteString("WAREHOUSE\n")
+	if rt.Dialect != "" {
+		fmt.Fprintf(b, "- SQL dialect: %s\n", rt.Dialect)
+	}
+	if len(rt.Datasets) > 0 {
+		fmt.Fprintf(b, "- Datasets available: %s\n", strings.Join(rt.Datasets, ", "))
+	}
+	b.WriteString("- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n")
+	if strings.TrimSpace(rt.FilterField) != "" {
+		if strings.TrimSpace(rt.FilterValue) != "" {
+			// Inject the exact tenant predicate so the model scopes every query
+			// correctly. (Presence of the column is enforced server-side; do not
+			// negate or broaden it.)
+			fmt.Fprintf(b, "- SECURITY: this is a multi-tenant dataset. Every query MUST be scoped to this tenant with the predicate `%s = '%s'` (in the WHERE clause, or preserved through every join/CTE). Never negate, broaden, or omit it. A query missing the %q column is rejected.\n", rt.FilterField, rt.FilterValue, rt.FilterField)
+		} else {
+			fmt.Fprintf(b, "- SECURITY: every query MUST filter by %q (the tenant scope). A query missing this filter is rejected.\n", rt.FilterField)
+		}
+	}
+}
+
+// writeResultHandling renders the shared RESULT HANDLING block. Shared verbatim
+// by both prompt builders.
+func writeResultHandling(b *strings.Builder, cfg Config) {
+	b.WriteString("\nRESULT HANDLING\n")
+	fmt.Fprintf(b, "- Query results are returned summary-only: row count, columns, and a preview of up to %d rows. Large result sets are truncated.\n", cfg.PreviewRows)
+	b.WriteString("- For totals, counts, distributions, or \"how many\" questions, write aggregate SQL (COUNT, SUM, AVG, GROUP BY) — do NOT page through raw rows.\n")
+	fmt.Fprintf(b, "- You may run at most %d queries and take at most %d steps this turn. Be economical; reuse results already in this conversation instead of re-querying.\n", cfg.MaxQueriesPerTurn, cfg.MaxRounds)
 }

--- a/services/agent/internal/askserve/tools.go
+++ b/services/agent/internal/askserve/tools.go
@@ -1,6 +1,7 @@
 package askserve
 
 import (
+	"fmt"
 	"strings"
 
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
@@ -138,42 +139,59 @@ func toolChoiceForPhase(grounded bool) string {
 
 // toolCallToAction maps a native tool call to the loop's internal turnAction so
 // the existing execQuery / execLookup / execSearch handlers (and their ToolEvent
-// emission) are reused unchanged. Returns nil for an unrecognised tool name.
-func toolCallToAction(tc gollm.ToolCall) *turnAction {
+// emission) are reused unchanged. It validates required arguments and returns an
+// error for an unknown tool or a missing/empty required field — the caller feeds
+// that back as an error tool_result WITHOUT running the tool, so a malformed call
+// never emits a (spuriously grounding) event. Mirrors the text parser, which
+// likewise rejects an empty query.
+func toolCallToAction(tc gollm.ToolCall) (*turnAction, error) {
 	getStr := func(k string) string {
 		if v, ok := tc.Input[k].(string); ok {
 			return strings.TrimSpace(v)
 		}
 		return ""
 	}
-	act := &turnAction{}
 	switch actionKind(tc.Name) {
 	case actQuery:
-		act.Kind = actQuery
+		q := ""
 		if v, ok := tc.Input["query"].(string); ok {
-			act.Query = v // do not trim SQL
+			q = v // do not trim SQL
 		}
-		act.Purpose = getStr("purpose")
+		if strings.TrimSpace(q) == "" {
+			return nil, fmt.Errorf("query_data requires a non-empty %q argument", "query")
+		}
+		return &turnAction{Kind: actQuery, Query: q, Purpose: getStr("purpose")}, nil
 	case actLookup:
-		act.Kind = actLookup
-		act.LookupSchema = toStringSlice(tc.Input["tables"])
+		tables := toStringSlice(tc.Input["tables"])
+		if len(tables) == 0 {
+			return nil, fmt.Errorf("lookup_schema requires a non-empty %q array", "tables")
+		}
+		return &turnAction{Kind: actLookup, LookupSchema: tables}, nil
 	case actSearch:
-		act.Kind = actSearch
-		act.SearchTables = getStr("query")
-		act.SearchTopK = toInt(tc.Input["top_k"])
+		q := getStr("query")
+		if q == "" {
+			return nil, fmt.Errorf("search_tables requires a non-empty %q argument", "query")
+		}
+		return &turnAction{Kind: actSearch, SearchTables: q, SearchTopK: toInt(tc.Input["top_k"])}, nil
 	case actAnswer:
-		act.Kind = actAnswer
-		act.Text = getStr("text")
+		txt := getStr("text")
+		if txt == "" {
+			return nil, fmt.Errorf("answer requires a non-empty %q argument", "text")
+		}
+		return &turnAction{Kind: actAnswer, Text: txt}, nil
 	case actClarify:
-		act.Kind = actClarify
-		act.Text = getStr("question")
+		txt := getStr("question")
+		if txt == "" {
+			return nil, fmt.Errorf("clarify requires a non-empty %q argument", "question")
+		}
+		return &turnAction{Kind: actClarify, Text: txt}, nil
 	case actDecline:
-		act.Kind = actDecline
-		act.Text = getStr("reason")
+		// A reason is helpful but not strictly required — decline is a valid
+		// terminal even with an empty body.
+		return &turnAction{Kind: actDecline, Text: getStr("reason")}, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unknown tool %q", tc.Name)
 	}
-	return act
 }
 
 func toStringSlice(v interface{}) []string {

--- a/services/agent/internal/askserve/tools.go
+++ b/services/agent/internal/askserve/tools.go
@@ -1,0 +1,203 @@
+package askserve
+
+import (
+	"strings"
+
+	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
+)
+
+// This file defines the native tool-calling vocabulary for the Q&A loop. The
+// tool names match the actionKind wire strings so the tool path, the JSON-text
+// fallback, and the persisted ToolEvents all share one vocabulary. On providers
+// whose ProviderMeta.SupportsTools is true (bedrock / claude / openai) the loop
+// drives the model with these definitions instead of asking it to emit JSON in
+// free text — the provider then *guarantees* the model either calls a tool or
+// finishes, which is what makes grounding structural rather than coaxed.
+
+func toolQueryData() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name: string(actQuery),
+		Description: "Run one read-only SQL query (SELECT / CTE only) against the data warehouse and observe a summary of the result " +
+			"(row count, columns, and a small row preview). This is how you gather evidence. For totals, counts, or distributions write " +
+			"aggregate SQL (COUNT/SUM/AVG/GROUP BY) rather than paging raw rows. If you don't yet know the tables, start with a discovery " +
+			"query against INFORMATION_SCHEMA.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"query":   map[string]interface{}{"type": "string", "description": "The read-only SQL to execute."},
+				"purpose": map[string]interface{}{"type": "string", "description": "Short note on what this query answers (optional)."},
+			},
+			"required": []string{"query"},
+		},
+	}
+}
+
+func toolLookupSchema() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name:        string(actLookup),
+		Description: "Fetch the columns (and types) for one or more known tables. Use this when you know which tables you need but not their exact columns.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"tables": map[string]interface{}{
+					"type":        "array",
+					"items":       map[string]interface{}{"type": "string"},
+					"description": "Fully-qualified table names (e.g. dataset.table).",
+				},
+			},
+			"required": []string{"tables"},
+		},
+	}
+}
+
+func toolSearchTables() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name:        string(actSearch),
+		Description: "Semantically search the indexed schema for tables relevant to a description. Use this first when you don't know which tables hold what you need.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"query": map[string]interface{}{"type": "string", "description": "Keywords describing the data you're looking for."},
+				"top_k": map[string]interface{}{"type": "integer", "description": "Max number of tables to return (optional)."},
+			},
+			"required": []string{"query"},
+		},
+	}
+}
+
+func toolAnswer() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name:        string(actAnswer),
+		Description: "Give the final, grounded answer to the user. Only available after you have run at least one query or schema lookup — every figure must come from a result you observed this turn.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"text": map[string]interface{}{"type": "string", "description": "The final answer, concise analyst-style prose referencing the figures you found."},
+			},
+			"required": []string{"text"},
+		},
+	}
+}
+
+func toolClarify() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name:        string(actClarify),
+		Description: "Ask the user a single clarifying question when the request is too ambiguous to turn into a query.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"question": map[string]interface{}{"type": "string", "description": "One clarifying question."},
+			},
+			"required": []string{"question"},
+		},
+	}
+}
+
+func toolDecline() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name:        string(actDecline),
+		Description: "Decline when the question genuinely cannot be answered from this warehouse. Prefer a discovery query before declining.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"reason": map[string]interface{}{"type": "string", "description": "Why this cannot be answered from the data."},
+			},
+			"required": []string{"reason"},
+		},
+	}
+}
+
+// toolsForPhase returns the tool set offered for the current step. Until the
+// turn is grounded (no tool event has run yet) the `answer` tool is deliberately
+// withheld so the model cannot finish with an ungrounded answer — paired with
+// toolChoiceForPhase("any") this makes fabrication impossible by construction.
+// clarify / decline stay available so a genuinely ambiguous or unanswerable
+// question can still terminate without inventing data. Schema tools are offered
+// only when a schema provider is wired.
+func toolsForPhase(grounded, hasSchema bool) []gollm.ToolDefinition {
+	tools := []gollm.ToolDefinition{toolQueryData()}
+	if hasSchema {
+		tools = append(tools, toolLookupSchema(), toolSearchTables())
+	}
+	if grounded {
+		tools = append(tools, toolAnswer())
+	}
+	tools = append(tools, toolClarify(), toolDecline())
+	return tools
+}
+
+// toolChoiceForPhase forces a tool call while ungrounded ("any") so the model
+// must gather evidence (or explicitly clarify/decline) before it can answer;
+// once grounded it relaxes to "auto" so the model may keep querying or finish.
+func toolChoiceForPhase(grounded bool) string {
+	if grounded {
+		return "auto"
+	}
+	return "any"
+}
+
+// toolCallToAction maps a native tool call to the loop's internal turnAction so
+// the existing execQuery / execLookup / execSearch handlers (and their ToolEvent
+// emission) are reused unchanged. Returns nil for an unrecognised tool name.
+func toolCallToAction(tc gollm.ToolCall) *turnAction {
+	getStr := func(k string) string {
+		if v, ok := tc.Input[k].(string); ok {
+			return strings.TrimSpace(v)
+		}
+		return ""
+	}
+	act := &turnAction{}
+	switch actionKind(tc.Name) {
+	case actQuery:
+		act.Kind = actQuery
+		if v, ok := tc.Input["query"].(string); ok {
+			act.Query = v // do not trim SQL
+		}
+		act.Purpose = getStr("purpose")
+	case actLookup:
+		act.Kind = actLookup
+		act.LookupSchema = toStringSlice(tc.Input["tables"])
+	case actSearch:
+		act.Kind = actSearch
+		act.SearchTables = getStr("query")
+		act.SearchTopK = toInt(tc.Input["top_k"])
+	case actAnswer:
+		act.Kind = actAnswer
+		act.Text = getStr("text")
+	case actClarify:
+		act.Kind = actClarify
+		act.Text = getStr("question")
+	case actDecline:
+		act.Kind = actDecline
+		act.Text = getStr("reason")
+	default:
+		return nil
+	}
+	return act
+}
+
+func toStringSlice(v interface{}) []string {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func toInt(v interface{}) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	}
+	return 0
+}


### PR DESCRIPTION
## What

The agentic Ask data agent now drives the model with **native tool-calling** on providers that support it, instead of describing the tools in prose and parsing a JSON "action" out of free text.

## Why

Live-testing the merged Conversational Data Q&A feature (#287 / enterprise #115) on the Novo Nordisk BigQuery project surfaced a real defect: the agent sometimes answered **without ever querying the warehouse**.

- **Root cause:** the loop called `CreateMessage` and parsed `resp.Content` as a JSON action. Nothing *forced* a tool call, so the model could answer straight from its priors. Pre-hotfix that produced **fabricated** answers (invented tables/numbers); after the ground-or-decline guard (#288) it produced **spurious declines** of answerable questions (~1 in 3). Same root cause, two symptoms.
- The schema index was never the problem — the project's Qdrant schema collection has rich per-table blurbs; the model simply never *searched* it.

## How

gollm already had full native tool-calling (`Tools` / `ToolChoice` / `ToolCalls`, `tool_result` round-trip), wired + integration-tested for **Bedrock / Claude / OpenAI**. The Ask loop just never used it.

- **`ai.Client.CreateMessageWithTools`** — threads `Tools`/`ToolChoice` through; `CreateMessage` delegates to it (same retry + observability).
- **`askserve/tools.go`** — the six tools (`query_data`, `lookup_schema`, `search_tables`, `answer`, `clarify`, `decline`) as `ToolDefinition`s mirroring the existing action vocabulary, plus `toolsForPhase` / `toolChoiceForPhase` / `toolCallToAction`.
- **Two-phase exposure** (the core mechanism): while **ungrounded**, the `answer` tool is withheld and `ToolChoice="any"` forces the model to gather evidence (or explicitly clarify/decline) — **fabrication is impossible by construction**. Once a query/lookup/search has run, `answer` is offered and `ToolChoice` relaxes to `"auto"`.
- **Fallback:** providers where `ProviderMeta.SupportsTools == false` (vertex-ai / azure-foundry / ollama) keep the **existing JSON-in-text loop verbatim**, including #288's ground-or-decline guard. `run()` dispatches on `toolsSupported(rt)`.
- The existing `execQuery`/`execLookup`/`execSearch` handlers and `ToolEvent` emission are **reused**, so the streamed transcript and the dashboard are unchanged. The native path manages `[]gollm.Message` directly because `ai.Conversation` is text-only.

**Out of scope** (possible fast-follows): an insights/knowledge-base `search_insights` tool; enabling Vertex/Azure native tools.

## Verification

- **New unit tests** (`loop_tools_test.go`): native happy path; `answer` withheld + `ToolChoice="any"` until grounded; ungrounded free-text nudged not accepted; decline/clarify before any query; parallel tool calls with correlated `tool_result`s; round-budget synthesis; schema tools offered only when a provider is wired; provider detection / fallback routing. Existing `loop_test.go` (unchanged) proves the fallback path.
- `go test ./...` (agent module) green; `golangci-lint` clean on the changed packages; `go build ./...` ok.
- **Live E2E** against the Novo Nordisk BigQuery project: the question that previously declined ~1/3 of the time ("How many prescribers are in the Medicare Part D data?") now runs a discovery query + a count and returns the **same grounded answer** (1,380,665 distinct prescribers from `part_d_provider_2023`) on **every** run. A Vertex/Gemini project still answers via the fallback path.

## Note

Stacks on #288 (the ground-or-decline guard, which becomes the retained fallback behaviour). Until #288 merges to `beta`, this PR's diff includes its commit; it narrows automatically once #288 lands.

— Co-coded with Jale 🤖