### PR TITLE
feat(askserve): add search_insights — unify Ask over insights + SQL

### DIFF
--- a/services/agent/agentserver/ask_serve.go
+++ b/services/agent/agentserver/ask_serve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/config"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/database"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/discovery"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/insightsearch"
 	applog "github.com/decisionbox-io/decisionbox/services/agent/internal/log"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/queryexec"
 )
@@ -50,6 +51,17 @@ func runAskServe(cfg *config.Config) error {
 		sharedRetriever = nil
 	} else {
 		defer func() { _ = sharedRetriever.Close() }()
+	}
+
+	// One shared vector store (Qdrant) for the insight/recommendation index,
+	// reused across projects for the search_insights tool. A missing store
+	// degrades that one tool, not the whole service.
+	vectorStore, vsCleanup, vsErr := initQdrant(ctx, cfg)
+	if vsErr != nil {
+		applog.WithError(vsErr).Warn("ask-serve: vector store unavailable — search_insights disabled")
+		vectorStore = nil
+	} else {
+		defer vsCleanup()
 	}
 
 	builder := func(buildCtx context.Context, projectID string) (*askserve.ProjectRuntime, error) {
@@ -100,6 +112,12 @@ func runAskServe(cfg *config.Config) error {
 			FilterValue: project.Warehouse.FilterValue,
 		})
 
+		// One embedder per project, shared by semantic schema search and the
+		// insight search tool. Nil when the project has no embedding provider
+		// configured — both semantic tools then degrade (schema lookup still
+		// works from the cache; search_insights is simply not offered).
+		embedder, _ := initEmbeddingProvider(buildCtx, project, secretProvider, projectID)
+
 		// Schema provider (optional). Lookup serves from the cached schemas
 		// map; semantic search additionally needs the retriever + embedder.
 		var schemaProvider ai.SchemaProvider
@@ -111,7 +129,6 @@ func runAskServe(cfg *config.Config) error {
 		case len(schemas) == 0:
 			applog.WithField("project_id", projectID).Warn("ask-serve: no cached schema for project — run --mode index-schema to enable schema tools")
 		default:
-			embedder, _ := initEmbeddingProvider(buildCtx, project, secretProvider, projectID)
 			opts := discovery.CacheSchemaProviderOptions{
 				ProjectID: projectID,
 				Datasets:  datasets,
@@ -131,16 +148,26 @@ func runAskServe(cfg *config.Config) error {
 			}
 		}
 
+		// Insights provider (optional). insightsearch.New returns nil unless the
+		// vector store AND an embedder are both present; keep the interface nil
+		// in that case (a typed-nil would defeat the loop's nil check) so the
+		// search_insights tool is simply not offered.
+		var insightsProvider ai.InsightsProvider
+		if is := insightsearch.New(projectID, mongoClient.Database(), vectorStore, embedder); is != nil {
+			insightsProvider = is
+		}
+
 		return &askserve.ProjectRuntime{
-			Executor:       executor,
-			SchemaProvider: schemaProvider,
-			AIClient:       aiClient,
-			Model:          project.LLM.Model,
-			Datasets:       datasets,
-			Dialect:        warehouse.SQLDialect(),
-			FilterField:    project.Warehouse.FilterField,
-			FilterValue:    project.Warehouse.FilterValue,
-			Closers:        closers,
+			Executor:         executor,
+			SchemaProvider:   schemaProvider,
+			InsightsProvider: insightsProvider,
+			AIClient:         aiClient,
+			Model:            project.LLM.Model,
+			Datasets:         datasets,
+			Dialect:          warehouse.SQLDialect(),
+			FilterField:      project.Warehouse.FilterField,
+			FilterValue:      project.Warehouse.FilterValue,
+			Closers:          closers,
 		}, nil
 	}
 

--- a/services/agent/internal/ai/insights_provider.go
+++ b/services/agent/internal/ai/insights_provider.go
@@ -1,0 +1,30 @@
+package ai
+
+import "context"
+
+// InsightsProvider backs the search_insights tool: a semantic search over the
+// project's discovered insights and recommendations. It mirrors SchemaProvider
+// — the ask-serve loop holds at most one per project, and a nil provider simply
+// means the tool is not offered (the project has no embedder or no indexed
+// insights). Implementations rank semantically against the project's insight
+// embedding index.
+type InsightsProvider interface {
+	// SearchInsights returns the top-k insights/recommendations most relevant to
+	// the natural-language query, ranked by semantic similarity.
+	SearchInsights(ctx context.Context, query string, k int) ([]InsightHit, error)
+}
+
+// InsightHit is one insight or recommendation surfaced by SearchInsights. It is
+// the agent-facing projection of a StandaloneInsight / StandaloneRecommendation
+// — enough for the model to ground an answer and for the dashboard to render a
+// citation.
+type InsightHit struct {
+	ID            string
+	Type          string // "insight" or "recommendation"
+	Name          string
+	Description   string
+	Severity      string
+	AnalysisArea  string
+	AffectedCount int
+	Score         float64
+}

--- a/services/agent/internal/ai/insights_provider.go
+++ b/services/agent/internal/ai/insights_provider.go
@@ -27,4 +27,7 @@ type InsightHit struct {
 	AnalysisArea  string
 	AffectedCount int
 	Score         float64
+	// DiscoveryID links the hit back to the discovery run that produced it, so a
+	// persisted citation can resolve the source run on history reload.
+	DiscoveryID string
 }

--- a/services/agent/internal/askserve/action.go
+++ b/services/agent/internal/askserve/action.go
@@ -10,12 +10,13 @@ import (
 type actionKind string
 
 const (
-	actQuery   actionKind = "query_data"
-	actLookup  actionKind = "lookup_schema"
-	actSearch  actionKind = "search_tables"
-	actAnswer  actionKind = "answer"
-	actClarify actionKind = "clarify"
-	actDecline actionKind = "decline"
+	actQuery          actionKind = "query_data"
+	actLookup         actionKind = "lookup_schema"
+	actSearch         actionKind = "search_tables"
+	actSearchInsights actionKind = "search_insights"
+	actAnswer         actionKind = "answer"
+	actClarify        actionKind = "clarify"
+	actDecline        actionKind = "decline"
 )
 
 func (k actionKind) terminal() bool {
@@ -35,6 +36,9 @@ type turnAction struct {
 	SearchTables string   // search_tables
 	SearchTopK   int      // search_tables (optional)
 
+	SearchInsights string // search_insights (query)
+	InsightsLimit  int    // search_insights (optional)
+
 	Text string // answer / clarify / decline body
 }
 
@@ -51,6 +55,9 @@ type rawAction struct {
 	LookupSchema []string `json:"lookup_schema"`
 	SearchTables string   `json:"search_tables"`
 	SearchTopK   int      `json:"search_top_k"`
+
+	SearchInsights string `json:"search_insights"`
+	InsightsLimit  int    `json:"insights_limit"`
 
 	Answer  string `json:"answer"`
 	Clarify string `json:"clarify"`
@@ -99,8 +106,12 @@ func parseTurnAction(response string) (*turnAction, error) {
 		act.Kind = actSearch
 		act.SearchTables = strings.TrimSpace(raw.SearchTables)
 		act.SearchTopK = raw.SearchTopK
+	case strings.TrimSpace(raw.SearchInsights) != "":
+		act.Kind = actSearchInsights
+		act.SearchInsights = strings.TrimSpace(raw.SearchInsights)
+		act.InsightsLimit = raw.InsightsLimit
 	default:
-		return nil, fmt.Errorf("action JSON has no answer, clarify, decline, query, lookup_schema, or search_tables")
+		return nil, fmt.Errorf("action JSON has no answer, clarify, decline, query, lookup_schema, search_tables, or search_insights")
 	}
 	return act, nil
 }
@@ -154,6 +165,20 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			raw.SearchTables = in.Query
 			if raw.SearchTopK == 0 {
 				raw.SearchTopK = in.TopK
+			}
+		}
+	case actSearchInsights:
+		if raw.SearchInsights != "" {
+			return
+		}
+		var in struct {
+			Query string `json:"query"`
+			Limit int    `json:"limit"`
+		}
+		if json.Unmarshal(env.Input, &in) == nil {
+			raw.SearchInsights = in.Query
+			if raw.InsightsLimit == 0 {
+				raw.InsightsLimit = in.Limit
 			}
 		}
 	case actAnswer, actClarify, actDecline:
@@ -278,7 +303,7 @@ func jsonHasActionKey(s string) bool {
 	if json.Unmarshal([]byte(s), &probe) != nil {
 		return false
 	}
-	for _, k := range []string{"answer", "clarify", "decline", "query", "lookup_schema", "search_tables", "name"} {
+	for _, k := range []string{"answer", "clarify", "decline", "query", "lookup_schema", "search_tables", "search_insights", "name"} {
 		if _, ok := probe[k]; ok {
 			return true
 		}

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -54,6 +54,10 @@ type turnState struct {
 	// rejected tenant filter / unavailable schema search records an event but
 	// observed no data, so it must not unlock the answer tool.
 	groundedEvents int
+	// insightHits accumulates the insights/recommendations surfaced by
+	// search_insights across the turn, mapped to the message's Sources at
+	// finalize so the dashboard renders them as citations.
+	insightHits []ai.InsightHit
 }
 
 // maxGroundingNudges bounds how many times the loop re-prompts a model that
@@ -243,6 +247,7 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 	st := &turnState{req: req, client: rt.AIClient, model: rt.Model}
 	system := buildSystemPromptForTools(rt, r.cfg)
 	hasSchema := rt.SchemaProvider != nil
+	hasInsights := rt.InsightsProvider != nil
 
 	var messages []gollm.Message
 	for _, m := range trimHistory(req.History, r.cfg.HistoryCharBudget) {
@@ -257,7 +262,7 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 		}
 
 		grounded := st.groundedEvents > 0
-		resp, err := st.callModelTools(ctx, messages, system, toolsForPhase(grounded, hasSchema), toolChoiceForPhase(grounded))
+		resp, err := st.callModelTools(ctx, messages, system, toolsForPhase(grounded, hasSchema, hasInsights), toolChoiceForPhase(grounded))
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				r.finishTimeout(ctx, st)
@@ -420,6 +425,8 @@ func (r *runner) execute(ctx context.Context, rt *ProjectRuntime, st *turnState,
 		return r.execLookup(ctx, rt, st, act)
 	case actSearch:
 		return r.execSearch(ctx, rt, st, act)
+	case actSearchInsights:
+		return r.execSearchInsights(ctx, rt, st, act)
 	default:
 		return "Unknown action."
 	}
@@ -521,6 +528,33 @@ func (r *runner) execSearch(ctx context.Context, rt *ProjectRuntime, st *turnSta
 	return formatSearch(act.SearchTables, hits)
 }
 
+func (r *runner) execSearchInsights(ctx context.Context, rt *ProjectRuntime, st *turnState, act *turnAction) string {
+	ev := commonmodels.ToolEvent{
+		Round: st.round,
+		Name:  string(actSearchInsights),
+		Args:  map[string]any{"query": act.SearchInsights, "limit": act.InsightsLimit},
+	}
+	if rt.InsightsProvider == nil {
+		ev.Error = "insights provider not configured"
+		r.emit(ctx, st, ev)
+		return "Insight search unavailable. Answer from a query instead, or decline."
+	}
+	start := time.Now()
+	hits, err := rt.InsightsProvider.SearchInsights(ctx, act.SearchInsights, act.InsightsLimit)
+	ev.LatencyMS = time.Since(start).Milliseconds()
+	if err != nil {
+		ev.Error = err.Error()
+		r.emit(ctx, st, ev)
+		return fmt.Sprintf("Insight search failed: %s", err.Error())
+	}
+	ev.Output = insightsSummary(hits)
+	r.emit(ctx, st, ev)
+	// Accumulate for the final message's Sources (deduped at finalize) so the
+	// dashboard renders these as citations.
+	st.insightHits = append(st.insightHits, hits...)
+	return formatInsights(act.SearchInsights, hits)
+}
+
 // emit appends a tool event to the in-memory transcript and persists it.
 func (r *runner) emit(ctx context.Context, st *turnState, ev commonmodels.ToolEvent) {
 	st.events = append(st.events, ev)
@@ -592,12 +626,40 @@ func (r *runner) finalize(ctx context.Context, st *turnState, fin TurnFinal) {
 	fin.ToolEvents = st.events
 	fin.InputTokens = st.tokensIn
 	fin.OutputTokens = st.tokensOut
+	fin.Sources = st.insightSources()
 
 	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 	if err := r.store.Finalize(pctx, fin); err != nil {
 		applog.WithError(err).WithField("turn_id", fin.TurnID).Error("ask-serve: failed to finalize turn")
 	}
+}
+
+// insightSources maps the insights/recommendations surfaced this turn to the
+// dashboard's citation shape, deduped by id and preserving first-seen (highest
+// score) order. Returns nil when no insight was searched.
+func (st *turnState) insightSources() []commonmodels.AskSessionSource {
+	if len(st.insightHits) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(st.insightHits))
+	out := make([]commonmodels.AskSessionSource, 0, len(st.insightHits))
+	for _, h := range st.insightHits {
+		if h.ID == "" || seen[h.ID] {
+			continue
+		}
+		seen[h.ID] = true
+		out = append(out, commonmodels.AskSessionSource{
+			ID:           h.ID,
+			Type:         h.Type,
+			Name:         h.Name,
+			Score:        h.Score,
+			Severity:     h.Severity,
+			AnalysisArea: h.AnalysisArea,
+			Description:  h.Description,
+		})
+	}
+	return out
 }
 
 // trimHistory drops the oldest messages until the running character total is
@@ -690,6 +752,47 @@ func searchSummary(hits []ai.SearchHit) []map[string]any {
 			"blurb":     h.Blurb,
 			"row_count": h.RowCount,
 			"score":     h.Score,
+		})
+	}
+	return out
+}
+
+func formatInsights(query string, hits []ai.InsightHit) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Insight search results for %q:\n", query)
+	if len(hits) == 0 {
+		b.WriteString("(no matching insights or recommendations)")
+	}
+	for i, h := range hits {
+		typ := h.Type
+		if typ == "" {
+			typ = "insight"
+		}
+		fmt.Fprintf(&b, "%d. [%s] %s", i+1, typ, h.Name)
+		if h.Severity != "" {
+			fmt.Fprintf(&b, " (severity: %s)", h.Severity)
+		}
+		if h.Description != "" {
+			fmt.Fprintf(&b, " — %s", h.Description)
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// insightsSummary is the compact, lowercase-keyed record persisted as the
+// search_insights tool event's output (ai.InsightHit has no json tags).
+func insightsSummary(hits []ai.InsightHit) []map[string]any {
+	out := make([]map[string]any, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, map[string]any{
+			"id":            h.ID,
+			"type":          h.Type,
+			"name":          h.Name,
+			"description":   h.Description,
+			"severity":      h.Severity,
+			"analysis_area": h.AnalysisArea,
+			"score":         h.Score,
 		})
 	}
 	return out

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -657,6 +657,7 @@ func (st *turnState) insightSources() []commonmodels.AskSessionSource {
 			Severity:     h.Severity,
 			AnalysisArea: h.AnalysisArea,
 			Description:  h.Description,
+			DiscoveryID:  h.DiscoveryID,
 		})
 	}
 	return out
@@ -792,6 +793,7 @@ func insightsSummary(hits []ai.InsightHit) []map[string]any {
 			"description":   h.Description,
 			"severity":      h.Severity,
 			"analysis_area": h.AnalysisArea,
+			"discovery_id":  h.DiscoveryID,
 			"score":         h.Score,
 		})
 	}

--- a/services/agent/internal/askserve/loop_tools_test.go
+++ b/services/agent/internal/askserve/loop_tools_test.go
@@ -95,6 +95,110 @@ func hasTool(tools []gollm.ToolDefinition, name string) bool {
 	return false
 }
 
+// fakeInsights is an ai.InsightsProvider returning canned hits.
+type fakeInsights struct {
+	hits  []ai.InsightHit
+	err   error
+	calls int
+}
+
+func (f *fakeInsights) SearchInsights(ctx context.Context, query string, k int) ([]ai.InsightHit, error) {
+	f.calls++
+	return f.hits, f.err
+}
+
+func runOnceToolsIns(t *testing.T, p *scriptedToolProvider, wh *testutil.MockWarehouseProvider, ins ai.InsightsProvider) *fakeStore {
+	t.Helper()
+	cfg := Config{MaxRounds: 8, MaxQueriesPerTurn: 6, MaxFetchRows: 1000, PreviewRows: 50}
+	store := &fakeStore{}
+	r := &runner{cfg: cfg, store: store}
+	rt := toolRuntime(p, wh, nil, "")
+	rt.InsightsProvider = ins
+	r.run(context.Background(), rt, TurnRequest{TurnID: "t1", SessionID: "s1", ProjectID: "p1", Question: "what did we find?"})
+	if store.final == nil {
+		t.Fatal("turn did not finalize")
+	}
+	return store
+}
+
+func TestLoopTools_SearchInsightsGroundsAndCites(t *testing.T) {
+	// An insight search is real evidence: it grounds the turn so the model can
+	// answer with NO SQL, and its hits become the message's citation Sources.
+	wh := testutil.NewMockWarehouseProvider("ds")
+	ins := &fakeInsights{hits: []ai.InsightHit{
+		{ID: "i1", Type: "insight", Name: "Churn spike", Description: "Q3 churn up 12%", Severity: "high", AnalysisArea: "retention", Score: 0.9},
+		{ID: "r1", Type: "recommendation", Name: "Launch winback", Severity: "medium", Score: 0.7},
+	}}
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actSearchInsights), map[string]any{"query": "key risks"}),
+		toolCall(string(actAnswer), map[string]any{"text": "The main risk is a Q3 churn spike."}),
+	}}
+	store := runOnceToolsIns(t, p, wh, ins)
+
+	if store.final.Status != commonmodels.AskTurnStatusDone || store.final.Answer == "" {
+		t.Fatalf("status=%q answer=%q", store.final.Status, store.final.Answer)
+	}
+	if len(store.events) != 1 || store.events[0].Name != "search_insights" {
+		t.Fatalf("events = %+v, want one search_insights event", store.events)
+	}
+	if len(wh.Calls) != 0 {
+		t.Fatalf("no SQL should run for an insights answer; warehouse calls = %d", len(wh.Calls))
+	}
+	// answer offered on the 2nd call → the insight search grounded the turn.
+	if !hasTool(p.reqs[1].Tools, string(actAnswer)) {
+		t.Fatal("answer should be offered after a successful search_insights (grounded)")
+	}
+	// Sources carry the cited insights, deduped, in order.
+	if len(store.final.Sources) != 2 || store.final.Sources[0].ID != "i1" || store.final.Sources[1].ID != "r1" {
+		t.Fatalf("Sources not populated from insight hits: %+v", store.final.Sources)
+	}
+	if store.final.Sources[0].Type != "insight" || store.final.Sources[0].Severity != "high" {
+		t.Fatalf("source[0] fields not mapped: %+v", store.final.Sources[0])
+	}
+}
+
+func TestLoopTools_SearchInsightsOfferedOnlyWithProvider(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("ds")
+	// No insights provider → tool not offered.
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT 1 FROM ds.t"}),
+		toolCall(string(actAnswer), map[string]any{"text": "ok"}),
+	}}
+	runOnceToolsIns(t, p, wh, nil)
+	if hasTool(p.reqs[0].Tools, string(actSearchInsights)) {
+		t.Fatal("search_insights must not be offered without an insights provider")
+	}
+	// With provider → offered.
+	ins := &fakeInsights{hits: []ai.InsightHit{{ID: "i1", Type: "insight", Name: "x", Score: 0.5}}}
+	p2 := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actSearchInsights), map[string]any{"query": "risks"}),
+		toolCall(string(actAnswer), map[string]any{"text": "ok"}),
+	}}
+	runOnceToolsIns(t, p2, testutil.NewMockWarehouseProvider("ds"), ins)
+	if !hasTool(p2.reqs[0].Tools, string(actSearchInsights)) {
+		t.Fatal("search_insights should be offered when an insights provider is set")
+	}
+}
+
+func TestParseTurnAction_SearchInsights(t *testing.T) {
+	// Plain key form (JSON-text fallback path).
+	act, err := parseTurnAction(`{"search_insights":"churn risk","insights_limit":3}`)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if act.Kind != actSearchInsights || act.SearchInsights != "churn risk" || act.InsightsLimit != 3 {
+		t.Fatalf("parsed = %+v", act)
+	}
+	// Tool-use envelope form.
+	act, err = parseTurnAction(`{"name":"search_insights","input":{"query":"churn","limit":2}}`)
+	if err != nil {
+		t.Fatalf("envelope err = %v", err)
+	}
+	if act.Kind != actSearchInsights || act.SearchInsights != "churn" || act.InsightsLimit != 2 {
+		t.Fatalf("envelope parsed = %+v", act)
+	}
+}
+
 func TestToolsSupported_DetectsProvider(t *testing.T) {
 	wh := testutil.NewMockWarehouseProvider("ds")
 	// Default test runtime has no provenance → unknown provider → fallback.

--- a/services/agent/internal/askserve/loop_tools_test.go
+++ b/services/agent/internal/askserve/loop_tools_test.go
@@ -126,7 +126,7 @@ func TestLoopTools_SearchInsightsGroundsAndCites(t *testing.T) {
 	// answer with NO SQL, and its hits become the message's citation Sources.
 	wh := testutil.NewMockWarehouseProvider("ds")
 	ins := &fakeInsights{hits: []ai.InsightHit{
-		{ID: "i1", Type: "insight", Name: "Churn spike", Description: "Q3 churn up 12%", Severity: "high", AnalysisArea: "retention", Score: 0.9},
+		{ID: "i1", Type: "insight", Name: "Churn spike", Description: "Q3 churn up 12%", Severity: "high", AnalysisArea: "retention", Score: 0.9, DiscoveryID: "disc-7"},
 		{ID: "r1", Type: "recommendation", Name: "Launch winback", Severity: "medium", Score: 0.7},
 	}}
 	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
@@ -152,7 +152,7 @@ func TestLoopTools_SearchInsightsGroundsAndCites(t *testing.T) {
 	if len(store.final.Sources) != 2 || store.final.Sources[0].ID != "i1" || store.final.Sources[1].ID != "r1" {
 		t.Fatalf("Sources not populated from insight hits: %+v", store.final.Sources)
 	}
-	if store.final.Sources[0].Type != "insight" || store.final.Sources[0].Severity != "high" {
+	if store.final.Sources[0].Type != "insight" || store.final.Sources[0].Severity != "high" || store.final.Sources[0].DiscoveryID != "disc-7" {
 		t.Fatalf("source[0] fields not mapped: %+v", store.final.Sources[0])
 	}
 }

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -32,7 +32,10 @@ func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
 
 	writeResultHandling(&b, cfg)
 
-	b.WriteString("\nGROUNDING (required): you MUST run at least one query_data action and observe its result before you give an `answer`. Never state a table name, count, total, or specific value you have not seen in a query result in this conversation — do not answer from prior knowledge or guesses. If you don't yet know the tables or columns, your FIRST action must be a discovery query — e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES` — or a search_tables / lookup_schema; do not invent table or column names. An answer with no query behind it will be rejected; only use clarify or decline if the question genuinely cannot be turned into any query.\n")
+	b.WriteString("\nGROUNDING (required): you MUST gather evidence and observe its result before you give an `answer`. Never state a table name, count, total, or specific value you have not seen in a result in this conversation — do not answer from prior knowledge or guesses. If you don't yet know the tables or columns, your FIRST action must be a discovery query — e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES` — or a search_tables / lookup_schema; do not invent table or column names. An answer with no evidence behind it will be rejected; only use clarify or decline if the question genuinely cannot be turned into any query.\n")
+	if rt.InsightsProvider != nil {
+		b.WriteString("For questions about what prior analysis found or recommended, a search_insights result is sufficient grounding on its own — you do not need to run SQL.\n")
+	}
 
 	b.WriteString("\nFinish with an \"answer\", \"clarify\", or \"decline\" action. The answer should be concise, analyst-style prose that directly addresses the question and references the figures you found.")
 
@@ -62,7 +65,14 @@ func buildSystemPromptForTools(rt *ProjectRuntime, cfg Config) string {
 
 	writeResultHandling(&b, cfg)
 
-	b.WriteString("\nGROUNDING (required): you MUST run at least one query_data, search_tables, or lookup_schema call and observe its result before you answer. Never state a table name, count, total, or value you have not seen in a result this turn — do not answer from prior knowledge or guesses. If you don't know the tables or columns, start with search_tables or a discovery query (e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES`); do not invent names. Only clarify when the request is genuinely too ambiguous to query, and prefer a discovery query before you decline.\n")
+	evidence := "query_data, search_tables, or lookup_schema"
+	if rt.InsightsProvider != nil {
+		evidence = "query_data, search_tables, lookup_schema, or search_insights"
+	}
+	fmt.Fprintf(&b, "\nGROUNDING (required): you MUST run at least one %s call and observe its result before you answer. Never state a table name, count, total, or value you have not seen in a result this turn — do not answer from prior knowledge or guesses. If you don't know the tables or columns, start with search_tables or a discovery query (e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES`); do not invent names. Only clarify when the request is genuinely too ambiguous to query, and prefer gathering evidence before you decline.\n", evidence)
+	if rt.InsightsProvider != nil {
+		b.WriteString("For questions about what prior analysis found or recommended, a search_insights result is sufficient grounding on its own — you do not need to run SQL.\n")
+	}
 
 	b.WriteString("\nFinish by calling answer (concise, analyst-style prose referencing the figures you found), clarify, or decline.")
 

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -23,6 +23,9 @@ func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
 	b.WriteString(`  {"thinking":"...","query":"SELECT ...","purpose":"what this answers"}` + "  — run a read-only SQL query\n")
 	b.WriteString(`  {"thinking":"...","lookup_schema":["dataset.table_a","dataset.table_b"]}` + "  — get columns + sample rows for tables\n")
 	b.WriteString(`  {"thinking":"...","search_tables":"keywords describing what you need"}` + "  — find relevant tables semantically\n")
+	if rt.InsightsProvider != nil {
+		b.WriteString(`  {"thinking":"...","search_insights":"keywords"}` + "  — search prior discovered insights & recommendations\n")
+	}
 	b.WriteString(`  {"thinking":"...","answer":"final grounded answer for the user"}` + "  — when you can answer\n")
 	b.WriteString(`  {"thinking":"...","clarify":"a single clarifying question"}` + "  — when the question is too ambiguous to answer\n")
 	b.WriteString(`  {"thinking":"...","decline":"why this cannot be answered from the data"}` + "  — when it is unanswerable\n")
@@ -52,6 +55,9 @@ func buildSystemPromptForTools(rt *ProjectRuntime, cfg Config) string {
 	b.WriteString("\nTOOLS\n")
 	b.WriteString("- query_data: run one read-only SQL query and observe a summary of the result.\n")
 	b.WriteString("- search_tables / lookup_schema: discover which tables exist and what columns they have.\n")
+	if rt.InsightsProvider != nil {
+		b.WriteString("- search_insights: search the project's prior discovered insights & recommendations; prefer it for \"what did we find\" / \"what do you recommend\" questions, and combine with query_data when a finding needs a fresh number.\n")
+	}
 	b.WriteString("- answer / clarify / decline: finish the turn.\n")
 
 	writeResultHandling(&b, cfg)

--- a/services/agent/internal/askserve/tools.go
+++ b/services/agent/internal/askserve/tools.go
@@ -66,6 +66,23 @@ func toolSearchTables() gollm.ToolDefinition {
 	}
 }
 
+func toolSearchInsights() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name: string(actSearchInsights),
+		Description: "Semantic search over the project's already-discovered insights and recommendations (what prior analysis found and advised). " +
+			"Prefer this for questions like \"what did we find\", \"what are the risks\", or \"what do you recommend\" — it returns grounded findings without running SQL. " +
+			"Use query_data instead for fresh ad-hoc numbers; combine both when a finding needs a current figure.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"query": map[string]interface{}{"type": "string", "description": "Keywords describing the finding or recommendation you're looking for."},
+				"limit": map[string]interface{}{"type": "integer", "description": "Max hits to return (optional; default 5, capped at 20)."},
+			},
+			"required": []string{"query"},
+		},
+	}
+}
+
 func toolAnswer() gollm.ToolDefinition {
 	return gollm.ToolDefinition{
 		Name:        string(actAnswer),
@@ -114,11 +131,15 @@ func toolDecline() gollm.ToolDefinition {
 // toolChoiceForPhase("any") this makes fabrication impossible by construction.
 // clarify / decline stay available so a genuinely ambiguous or unanswerable
 // question can still terminate without inventing data. Schema tools are offered
-// only when a schema provider is wired.
-func toolsForPhase(grounded, hasSchema bool) []gollm.ToolDefinition {
+// only when a schema provider is wired; search_insights only when an insights
+// provider is wired.
+func toolsForPhase(grounded, hasSchema, hasInsights bool) []gollm.ToolDefinition {
 	tools := []gollm.ToolDefinition{toolQueryData()}
 	if hasSchema {
 		tools = append(tools, toolLookupSchema(), toolSearchTables())
+	}
+	if hasInsights {
+		tools = append(tools, toolSearchInsights())
 	}
 	if grounded {
 		tools = append(tools, toolAnswer())
@@ -173,6 +194,12 @@ func toolCallToAction(tc gollm.ToolCall) (*turnAction, error) {
 			return nil, fmt.Errorf("search_tables requires a non-empty %q argument", "query")
 		}
 		return &turnAction{Kind: actSearch, SearchTables: q, SearchTopK: toInt(tc.Input["top_k"])}, nil
+	case actSearchInsights:
+		q := getStr("query")
+		if q == "" {
+			return nil, fmt.Errorf("search_insights requires a non-empty %q argument", "query")
+		}
+		return &turnAction{Kind: actSearchInsights, SearchInsights: q, InsightsLimit: toInt(tc.Input["limit"])}, nil
 	case actAnswer:
 		txt := getStr("text")
 		if txt == "" {

--- a/services/agent/internal/askserve/turnstore.go
+++ b/services/agent/internal/askserve/turnstore.go
@@ -207,6 +207,7 @@ func (s *turnStore) Finalize(ctx context.Context, fin TurnFinal) error {
 		InputTokens:  fin.InputTokens,
 		OutputTokens: fin.OutputTokens,
 		ToolEvents:   fin.ToolEvents,
+		Sources:      fin.Sources,
 		CreatedAt:    now,
 	}
 	// Append via an aggregation pipeline with $ifNull so a legacy session whose
@@ -292,4 +293,8 @@ type TurnFinal struct {
 	InputTokens  int
 	OutputTokens int
 	ToolEvents   []commonmodels.ToolEvent
+	// Sources are the insights/recommendations the turn cited (from
+	// search_insights), persisted on the message so the dashboard renders them
+	// as citations on history reload.
+	Sources []commonmodels.AskSessionSource
 }

--- a/services/agent/internal/askserve/types.go
+++ b/services/agent/internal/askserve/types.go
@@ -50,6 +50,10 @@ type ProjectRuntime struct {
 	// SchemaProvider serves lookup_schema / search_tables. May be nil when the
 	// project has no schema index — the loop degrades gracefully.
 	SchemaProvider ai.SchemaProvider
+	// InsightsProvider serves search_insights (semantic search over the
+	// project's discovered insights + recommendations). May be nil when the
+	// project has no embedder / vector store — the tool is then not offered.
+	InsightsProvider ai.InsightsProvider
 	// AIClient drives the reasoning LLM (multi-turn CreateMessage).
 	AIClient *ai.Client
 	// Model is the project's configured model id (for the transcript record).

--- a/services/agent/internal/insightsearch/insightsearch.go
+++ b/services/agent/internal/insightsearch/insightsearch.go
@@ -1,0 +1,129 @@
+// Package insightsearch is the ask-serve agent's read-only retriever over a
+// project's discovered insights and recommendations. It implements
+// ai.InsightsProvider by embedding the query, searching the shared vector store
+// (scoped to the project), and enriching each hit from the Mongo insights /
+// recommendations collections. It mirrors the enterprise ask/services
+// InsightSearcher but takes the per-project embedder the ask-serve builder
+// already constructs, so it needs no secret or project lookup.
+package insightsearch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	goembedding "github.com/decisionbox-io/decisionbox/libs/go-common/embedding"
+	"github.com/decisionbox-io/decisionbox/libs/go-common/vectorstore"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/ai"
+)
+
+const (
+	defaultLimit = 5
+	maxLimit     = 20
+)
+
+// enrichFunc resolves a hit's display fields (name/description/severity/area)
+// by id + type. Mongo-backed in production; stubbed in tests. Returns false
+// when the doc can't be found — the hit is still returned (id/type/score) so a
+// stale vector entry degrades gracefully rather than dropping the result.
+type enrichFunc func(ctx context.Context, id, docType string) (ai.InsightHit, bool)
+
+// Searcher is a per-project ai.InsightsProvider.
+type Searcher struct {
+	projectID string
+	vs        vectorstore.Provider
+	embedder  goembedding.Provider
+	enrich    enrichFunc
+}
+
+// New builds a Searcher. Returns nil when the Mongo db, vector store, or
+// embedder is absent — the caller treats a nil provider as "insights tool
+// unavailable" and simply doesn't offer the tool.
+func New(projectID string, db *mongo.Database, vs vectorstore.Provider, embedder goembedding.Provider) *Searcher {
+	if db == nil || vs == nil || embedder == nil {
+		return nil
+	}
+	return &Searcher{projectID: projectID, vs: vs, embedder: embedder, enrich: mongoEnricher(db, projectID)}
+}
+
+// mongoEnricher reads the canonical insights / recommendations collections.
+func mongoEnricher(db *mongo.Database, projectID string) enrichFunc {
+	return func(ctx context.Context, id, docType string) (ai.InsightHit, bool) {
+		switch docType {
+		case "insight":
+			var ins struct {
+				Name          string `bson:"name"`
+				Description   string `bson:"description"`
+				Severity      string `bson:"severity"`
+				AnalysisArea  string `bson:"analysis_area"`
+				AffectedCount int    `bson:"affected_count"`
+			}
+			if err := db.Collection("insights").FindOne(ctx, bson.M{"_id": id, "project_id": projectID}).Decode(&ins); err != nil {
+				return ai.InsightHit{}, false
+			}
+			return ai.InsightHit{Name: ins.Name, Description: ins.Description, Severity: ins.Severity, AnalysisArea: ins.AnalysisArea, AffectedCount: ins.AffectedCount}, true
+		case "recommendation":
+			var rec struct {
+				Title        string `bson:"title"`
+				Description  string `bson:"description"`
+				Severity     string `bson:"severity"`
+				AnalysisArea string `bson:"analysis_area"`
+			}
+			if err := db.Collection("recommendations").FindOne(ctx, bson.M{"_id": id, "project_id": projectID}).Decode(&rec); err != nil {
+				return ai.InsightHit{}, false
+			}
+			return ai.InsightHit{Name: rec.Title, Description: rec.Description, Severity: rec.Severity, AnalysisArea: rec.AnalysisArea}, true
+		}
+		return ai.InsightHit{}, false
+	}
+}
+
+// SearchInsights embeds the query, searches the project's insight vectors, and
+// enriches each hit with its title/description/severity. Hits are returned in
+// vector-score order.
+func (s *Searcher) SearchInsights(ctx context.Context, query string, k int) ([]ai.InsightHit, error) {
+	if s == nil || s.vs == nil || s.embedder == nil {
+		return nil, errors.New("insight search not configured")
+	}
+	if k <= 0 {
+		k = defaultLimit
+	}
+	if k > maxLimit {
+		k = maxLimit
+	}
+
+	vecs, err := s.embedder.Embed(ctx, []string{query})
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
+	}
+	if len(vecs) == 0 {
+		return nil, errors.New("embed query: no vector returned")
+	}
+
+	res, err := s.vs.Search(ctx, vecs[0], vectorstore.SearchOpts{
+		ProjectIDs:     []string{s.projectID},
+		EmbeddingModel: s.embedder.ModelName(),
+		Limit:          k,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("vector search: %w", err)
+	}
+
+	out := make([]ai.InsightHit, 0, len(res))
+	for _, r := range res {
+		docType, _ := r.Payload["type"].(string)
+		hit := ai.InsightHit{ID: r.ID, Type: docType, Score: r.Score}
+		if enriched, ok := s.enrich(ctx, r.ID, docType); ok {
+			hit.Name = enriched.Name
+			hit.Description = enriched.Description
+			hit.Severity = enriched.Severity
+			hit.AnalysisArea = enriched.AnalysisArea
+			hit.AffectedCount = enriched.AffectedCount
+		}
+		out = append(out, hit)
+	}
+	return out, nil
+}

--- a/services/agent/internal/insightsearch/insightsearch.go
+++ b/services/agent/internal/insightsearch/insightsearch.go
@@ -60,22 +60,24 @@ func mongoEnricher(db *mongo.Database, projectID string) enrichFunc {
 				Severity      string `bson:"severity"`
 				AnalysisArea  string `bson:"analysis_area"`
 				AffectedCount int    `bson:"affected_count"`
+				DiscoveryID   string `bson:"discovery_id"`
 			}
 			if err := db.Collection("insights").FindOne(ctx, bson.M{"_id": id, "project_id": projectID}).Decode(&ins); err != nil {
 				return ai.InsightHit{}, false
 			}
-			return ai.InsightHit{Name: ins.Name, Description: ins.Description, Severity: ins.Severity, AnalysisArea: ins.AnalysisArea, AffectedCount: ins.AffectedCount}, true
+			return ai.InsightHit{Name: ins.Name, Description: ins.Description, Severity: ins.Severity, AnalysisArea: ins.AnalysisArea, AffectedCount: ins.AffectedCount, DiscoveryID: ins.DiscoveryID}, true
 		case "recommendation":
 			var rec struct {
 				Title        string `bson:"title"`
 				Description  string `bson:"description"`
 				Severity     string `bson:"severity"`
 				AnalysisArea string `bson:"analysis_area"`
+				DiscoveryID  string `bson:"discovery_id"`
 			}
 			if err := db.Collection("recommendations").FindOne(ctx, bson.M{"_id": id, "project_id": projectID}).Decode(&rec); err != nil {
 				return ai.InsightHit{}, false
 			}
-			return ai.InsightHit{Name: rec.Title, Description: rec.Description, Severity: rec.Severity, AnalysisArea: rec.AnalysisArea}, true
+			return ai.InsightHit{Name: rec.Title, Description: rec.Description, Severity: rec.Severity, AnalysisArea: rec.AnalysisArea, DiscoveryID: rec.DiscoveryID}, true
 		}
 		return ai.InsightHit{}, false
 	}
@@ -122,6 +124,7 @@ func (s *Searcher) SearchInsights(ctx context.Context, query string, k int) ([]a
 			hit.Severity = enriched.Severity
 			hit.AnalysisArea = enriched.AnalysisArea
 			hit.AffectedCount = enriched.AffectedCount
+			hit.DiscoveryID = enriched.DiscoveryID
 		}
 		out = append(out, hit)
 	}

--- a/services/agent/internal/insightsearch/insightsearch_test.go
+++ b/services/agent/internal/insightsearch/insightsearch_test.go
@@ -1,0 +1,136 @@
+package insightsearch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/decisionbox-io/decisionbox/libs/go-common/vectorstore"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/ai"
+)
+
+// fakeVS implements vectorstore.Provider; only Search is exercised.
+type fakeVS struct {
+	gotVector []float64
+	gotOpts   vectorstore.SearchOpts
+	results   []vectorstore.SearchResult
+	err       error
+}
+
+func (f *fakeVS) Search(ctx context.Context, vector []float64, opts vectorstore.SearchOpts) ([]vectorstore.SearchResult, error) {
+	f.gotVector = vector
+	f.gotOpts = opts
+	return f.results, f.err
+}
+func (f *fakeVS) Upsert(context.Context, []vectorstore.Point) error { return nil }
+func (f *fakeVS) FindDuplicates(context.Context, []float64, string, string, string, float64) ([]vectorstore.SearchResult, error) {
+	return nil, nil
+}
+func (f *fakeVS) Delete(context.Context, []string) error             { return nil }
+func (f *fakeVS) HealthCheck(context.Context) error                  { return nil }
+func (f *fakeVS) EnsureCollection(context.Context, int) error        { return nil }
+func (f *fakeVS) SearchSchemaIndex(context.Context, string, []float64, int) ([]vectorstore.SearchResult, error) {
+	return nil, nil
+}
+
+// fakeEmbedder implements goembedding.Provider.
+type fakeEmbedder struct {
+	model string
+	vec   []float64
+	err   error
+}
+
+func (e *fakeEmbedder) Embed(ctx context.Context, texts []string) ([][]float64, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	return [][]float64{e.vec}, nil
+}
+func (e *fakeEmbedder) Dimensions() int            { return len(e.vec) }
+func (e *fakeEmbedder) ModelName() string          { return e.model }
+func (e *fakeEmbedder) Validate(context.Context) error { return nil }
+
+// newTestSearcher builds a Searcher with injected fakes + a stub enricher,
+// bypassing Mongo.
+func newTestSearcher(vs vectorstore.Provider, emb *fakeEmbedder, enrich enrichFunc) *Searcher {
+	return &Searcher{projectID: "p1", vs: vs, embedder: emb, enrich: enrich}
+}
+
+func TestNew_NilDepsReturnsNil(t *testing.T) {
+	emb := &fakeEmbedder{model: "m", vec: []float64{1}}
+	vs := &fakeVS{}
+	if New("p1", nil, vs, emb) != nil {
+		t.Error("nil db should yield nil searcher")
+	}
+	if New("p1", nil, nil, emb) != nil {
+		t.Error("nil vs should yield nil searcher")
+	}
+}
+
+func TestSearchInsights_MapsAndEnriches(t *testing.T) {
+	vs := &fakeVS{results: []vectorstore.SearchResult{
+		{ID: "i1", Score: 0.91, Payload: map[string]interface{}{"type": "insight"}},
+		{ID: "r1", Score: 0.80, Payload: map[string]interface{}{"type": "recommendation"}},
+		{ID: "x9", Score: 0.50, Payload: map[string]interface{}{"type": "insight"}}, // not found in enrich
+	}}
+	emb := &fakeEmbedder{model: "text-embedding-3-large", vec: []float64{0.1, 0.2}}
+	enrich := func(_ context.Context, id, docType string) (ai.InsightHit, bool) {
+		switch id {
+		case "i1":
+			return ai.InsightHit{Name: "Churn spike", Description: "d", Severity: "high", AnalysisArea: "retention", AffectedCount: 42}, true
+		case "r1":
+			return ai.InsightHit{Name: "Offer winback", Description: "d2", Severity: "medium"}, true
+		}
+		return ai.InsightHit{}, false
+	}
+	s := newTestSearcher(vs, emb, enrich)
+
+	hits, err := s.SearchInsights(context.Background(), "why are users leaving", 3)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(hits) != 3 {
+		t.Fatalf("hits = %d, want 3", len(hits))
+	}
+	// Score + type carried from the vector result; name/severity from enrich.
+	if hits[0].ID != "i1" || hits[0].Type != "insight" || hits[0].Name != "Churn spike" || hits[0].Severity != "high" || hits[0].AffectedCount != 42 || hits[0].Score != 0.91 {
+		t.Fatalf("hit[0] not mapped/enriched: %+v", hits[0])
+	}
+	if hits[1].Type != "recommendation" || hits[1].Name != "Offer winback" {
+		t.Fatalf("hit[1] recommendation mismatch: %+v", hits[1])
+	}
+	// Unenriched hit still returned with id/type/score, empty display fields.
+	if hits[2].ID != "x9" || hits[2].Name != "" || hits[2].Score != 0.50 {
+		t.Fatalf("hit[2] should degrade gracefully: %+v", hits[2])
+	}
+	// Project scope + embedding model are passed to the vector store.
+	if len(vs.gotOpts.ProjectIDs) != 1 || vs.gotOpts.ProjectIDs[0] != "p1" {
+		t.Fatalf("ProjectIDs = %v, want [p1]", vs.gotOpts.ProjectIDs)
+	}
+	if vs.gotOpts.EmbeddingModel != "text-embedding-3-large" {
+		t.Fatalf("EmbeddingModel = %q", vs.gotOpts.EmbeddingModel)
+	}
+}
+
+func TestSearchInsights_LimitClamped(t *testing.T) {
+	vs := &fakeVS{}
+	emb := &fakeEmbedder{model: "m", vec: []float64{1}}
+	noEnrich := func(context.Context, string, string) (ai.InsightHit, bool) { return ai.InsightHit{}, false }
+	s := newTestSearcher(vs, emb, noEnrich)
+
+	for _, tc := range []struct{ in, want int }{{0, defaultLimit}, {-5, defaultLimit}, {3, 3}, {999, maxLimit}} {
+		if _, err := s.SearchInsights(context.Background(), "q", tc.in); err != nil {
+			t.Fatalf("k=%d err=%v", tc.in, err)
+		}
+		if vs.gotOpts.Limit != tc.want {
+			t.Errorf("k=%d → Limit %d, want %d", tc.in, vs.gotOpts.Limit, tc.want)
+		}
+	}
+}
+
+func TestSearchInsights_EmbedError(t *testing.T) {
+	s := newTestSearcher(&fakeVS{}, &fakeEmbedder{err: errors.New("boom")}, nil)
+	if _, err := s.SearchInsights(context.Background(), "q", 5); err == nil {
+		t.Fatal("expected embed error to propagate")
+	}
+}

--- a/services/agent/internal/insightsearch/insightsearch_test.go
+++ b/services/agent/internal/insightsearch/insightsearch_test.go
@@ -77,7 +77,7 @@ func TestSearchInsights_MapsAndEnriches(t *testing.T) {
 	enrich := func(_ context.Context, id, docType string) (ai.InsightHit, bool) {
 		switch id {
 		case "i1":
-			return ai.InsightHit{Name: "Churn spike", Description: "d", Severity: "high", AnalysisArea: "retention", AffectedCount: 42}, true
+			return ai.InsightHit{Name: "Churn spike", Description: "d", Severity: "high", AnalysisArea: "retention", AffectedCount: 42, DiscoveryID: "disc-7"}, true
 		case "r1":
 			return ai.InsightHit{Name: "Offer winback", Description: "d2", Severity: "medium"}, true
 		}
@@ -93,7 +93,7 @@ func TestSearchInsights_MapsAndEnriches(t *testing.T) {
 		t.Fatalf("hits = %d, want 3", len(hits))
 	}
 	// Score + type carried from the vector result; name/severity from enrich.
-	if hits[0].ID != "i1" || hits[0].Type != "insight" || hits[0].Name != "Churn spike" || hits[0].Severity != "high" || hits[0].AffectedCount != 42 || hits[0].Score != 0.91 {
+	if hits[0].ID != "i1" || hits[0].Type != "insight" || hits[0].Name != "Churn spike" || hits[0].Severity != "high" || hits[0].AffectedCount != 42 || hits[0].Score != 0.91 || hits[0].DiscoveryID != "disc-7" {
 		t.Fatalf("hit[0] not mapped/enriched: %+v", hits[0])
 	}
 	if hits[1].Type != "recommendation" || hits[1].Name != "Offer winback" {


### PR DESCRIPTION
## What

Gives the agentic Ask data-query agent a **`search_insights`** tool — semantic search over the project's discovered **insights + recommendations** — so a single tool-using loop reasons over *both* insights and SQL and chooses per question.

## Why

Reported in testing: on a warehouse project, **every** `/ask` question routes to the SQL data-query agent (the eager `DataQuery.Eligible` gate checks only feature-flag + role + warehouse-present), and that agent had **no** access to insights/recommendations. So Ask stopped surfacing insights entirely — a regression vs the in-API RAG loop, which the gate bypasses. It was two disjoint agents picked by a flag, not one agent reasoning per question.

## How

One agent, both capabilities:
- **`ai.InsightsProvider` + `InsightHit`** — mirrors `SchemaProvider`/`SearchHit`.
- **`internal/insightsearch`** — per-project retriever: embed query → `vectorstore.Search` scoped to the project → enrich from the `insights`/`recommendations` Mongo collections. Mirrors the enterprise `ask/services` `InsightSearcher` but reuses the per-project embedder ask-serve already builds. Doc lookup is behind an enricher seam so it unit-tests without Mongo.
- **`ask_serve.go`** — constructs a shared vector store once; lifts the embedder out so both schema search and insights use it; builds the insights provider per project (nil-safe → tool simply not offered when there's no embedder/index).
- **`search_insights` wired into both paths**: the native tool set (`toolsForPhase`) and the JSON-text fallback vocabulary (`action.go`), gated in both prompts on the provider being present.
- **Grounding**: a *successful* `search_insights` counts as grounding, so the agent can answer purely from insights (no SQL). The eager routing gate is now *correct* and unchanged.
- **Citations**: insight hits accumulate on the turn and map to the message's `Sources` at finalize (`TurnFinal.Sources` → `AskSessionMessage.Sources`), restoring the dashboard's cited-sources rendering on history reload.

**Scope:** insights + recommendations only — the data that was lost. Notes/proposals (enterprise/sources-coupled) stay in the in-API loop; noted as follow-ups.

## Verification

- **Unit:** `insightsearch` (embed→search→enrich mapping, limit clamping, graceful degrade on missing doc, embed-error propagation); `loop_tools_test` (search_insights offered only with a provider; an insight result **grounds** the turn so the agent answers with **no** SQL; hits flow to the event Output; `finalize` populates `Sources` deduped); text-path parse of `search_insights` (plain + tool-use-envelope forms). `go test ./...` (agent module) green; `golangci-lint` clean; `go build ./...` ok.
- **Live E2E** (host Mongo, real BigQuery, Novo Nordisk project — 84 insights / 45 recommendations):
  - *"What are the key risks/insights… and what do you recommend?"* → `search_insights` → grounded answer.
  - *"How many prescribers…"* → `query_data` only.
  - *"Summarise the top finding and back it with a current number"* → `search_insights` + 3× `query_data`.
  - Persisted session message carried **5 citation sources**.
  - A **Vertex/Gemini** project (text fallback) answered an insights question via `search_insights` too.

## Note

Stacks on #289 (native tool-calling) and #288 (grounding guard). Diff narrows as those merge to `beta`. Phase-2 of the conversational-Ask work (#287/#289).

— Co-coded with Jale 🤖