### PR TITLE
feat(ask-serve): grounded charts — ChartSpec + render_chart tool (charts bridge)

### DIFF
--- a/libs/go-common/charts/charts.go
+++ b/libs/go-common/charts/charts.go
@@ -45,16 +45,16 @@ const (
 // and how the values should be interpreted. Only the X axis is modeled
 // explicitly; Y is a list of Series so multi-measure charts share one struct.
 type Axis struct {
-	Field string `json:"field"`
-	Label string `json:"label,omitempty"`
-	Type  string `json:"type,omitempty"` // category | time | number
+	Field string `json:"field" bson:"field"`
+	Label string `json:"label,omitempty" bson:"label,omitempty"`
+	Type  string `json:"type,omitempty" bson:"type,omitempty"` // category | time | number
 }
 
 // Series is one plotted measure: the row field carrying its values and an
 // optional display label.
 type Series struct {
-	Field string `json:"field"`
-	Label string `json:"label,omitempty"`
+	Field string `json:"field" bson:"field"`
+	Label string `json:"label,omitempty" bson:"label,omitempty"`
 }
 
 // KPI is a single headline figure (the "kpi" chart type): a value, an optional
@@ -62,11 +62,11 @@ type Series struct {
 // *Field members bind the figure to a column of the source query preview so a
 // KPI's provenance is provable, not asserted.
 type KPI struct {
-	Value      float64  `json:"value"`
-	Unit       string   `json:"unit,omitempty"`
-	Delta      *float64 `json:"delta,omitempty"`
-	ValueField string   `json:"value_field"`
-	DeltaField string   `json:"delta_field,omitempty"`
+	Value      float64  `json:"value" bson:"value"`
+	Unit       string   `json:"unit,omitempty" bson:"unit,omitempty"`
+	Delta      *float64 `json:"delta,omitempty" bson:"delta,omitempty"`
+	ValueField string   `json:"value_field" bson:"value_field"`
+	DeltaField string   `json:"delta_field,omitempty" bson:"delta_field,omitempty"`
 }
 
 // ChartSpec is the full, declarative chart artifact the agent emits via the
@@ -75,25 +75,25 @@ type KPI struct {
 // type, its axes/series, and embedded data cells that must exactly match the
 // referenced query preview (see ValidateGrounded).
 type ChartSpec struct {
-	Type    ChartType `json:"type"`
-	Title   string    `json:"title,omitempty"`
-	Caption string    `json:"caption,omitempty"`
+	Type    ChartType `json:"type" bson:"type"`
+	Title   string    `json:"title,omitempty" bson:"title,omitempty"`
+	Caption string    `json:"caption,omitempty" bson:"caption,omitempty"`
 
-	X        *Axis    `json:"x,omitempty"`
-	Y        []Series `json:"y,omitempty"`
-	SeriesBy string   `json:"series_by,omitempty"`
-	Stacked  *bool    `json:"stacked,omitempty"`
+	X        *Axis    `json:"x,omitempty" bson:"x,omitempty"`
+	Y        []Series `json:"y,omitempty" bson:"y,omitempty"`
+	SeriesBy string   `json:"series_by,omitempty" bson:"series_by,omitempty"`
+	Stacked  *bool    `json:"stacked,omitempty" bson:"stacked,omitempty"`
 
 	// Data is the embedded, capped, grounded data: an exact projection of the
 	// referenced query's preview rows. The model may drop columns/rows and
 	// reorder, but every cell must equal a cell of the source preview.
-	Data []map[string]any `json:"data,omitempty"`
+	Data []map[string]any `json:"data,omitempty" bson:"data,omitempty"`
 
 	// SourceStepID names the query step this data came from, e.g. "q2". It binds
 	// the chart to a specific observed result so grounding can be verified.
-	SourceStepID string `json:"source_step_id"`
+	SourceStepID string `json:"source_step_id" bson:"source_step_id"`
 
-	KPI *KPI `json:"kpi,omitempty"`
+	KPI *KPI `json:"kpi,omitempty" bson:"kpi,omitempty"`
 }
 
 // Caps bounds a chart so a single spec cannot exhaust tokens, memory, or the

--- a/libs/go-common/charts/charts.go
+++ b/libs/go-common/charts/charts.go
@@ -1,0 +1,118 @@
+// Package charts is the renderer-agnostic source of truth for the data agent's
+// chart artifacts. A ChartSpec is a small, declarative JSON description of a
+// chart (bar / line / area / pie / scatter / KPI) whose data is an EXACT
+// projection of a query result the agent already observed — never derived,
+// never invented. The same spec is rendered client-side (Recharts, in the web
+// dashboard) and server-side (go-chart, for PNG/SVG export), and mirrored in
+// Dart for the mobile app; keeping the type + validator here (a leaf package
+// with no service dependencies) lets every renderer share one contract.
+//
+// This package deliberately holds no product wiring: it defines the shape, the
+// structural validator, and the grounding validator, and nothing about who is
+// allowed to produce a chart. Gating lives in the caller (the data agent's
+// serve loop and the enterprise API), so this package stays neutral and
+// importable from anywhere.
+package charts
+
+// ChartType is the discriminant selecting how a ChartSpec is rendered. The set
+// is closed on purpose — an unknown type is rejected by Validate — so every
+// renderer can exhaustively switch over it.
+type ChartType string
+
+const (
+	ChartBar     ChartType = "bar"
+	ChartLine    ChartType = "line"
+	ChartArea    ChartType = "area"
+	ChartPie     ChartType = "pie"
+	ChartScatter ChartType = "scatter"
+	ChartKPI     ChartType = "kpi"
+)
+
+// AllChartTypes is the canonical ordered list of chart types (used by the
+// schema drift test and by callers building UI selectors).
+var AllChartTypes = []ChartType{ChartBar, ChartLine, ChartArea, ChartPie, ChartScatter, ChartKPI}
+
+// axisKind constrains an Axis.Type. category = discrete labels; time = a
+// temporal axis; number = a continuous numeric axis. Empty is treated as
+// category for the X axis.
+const (
+	AxisCategory = "category"
+	AxisTime     = "time"
+	AxisNumber   = "number"
+)
+
+// Axis describes one chart axis: which row field feeds it, its human label,
+// and how the values should be interpreted. Only the X axis is modeled
+// explicitly; Y is a list of Series so multi-measure charts share one struct.
+type Axis struct {
+	Field string `json:"field"`
+	Label string `json:"label,omitempty"`
+	Type  string `json:"type,omitempty"` // category | time | number
+}
+
+// Series is one plotted measure: the row field carrying its values and an
+// optional display label.
+type Series struct {
+	Field string `json:"field"`
+	Label string `json:"label,omitempty"`
+}
+
+// KPI is a single headline figure (the "kpi" chart type): a value, an optional
+// delta, their units, and the source columns those figures were read from. The
+// *Field members bind the figure to a column of the source query preview so a
+// KPI's provenance is provable, not asserted.
+type KPI struct {
+	Value      float64  `json:"value"`
+	Unit       string   `json:"unit,omitempty"`
+	Delta      *float64 `json:"delta,omitempty"`
+	ValueField string   `json:"value_field"`
+	DeltaField string   `json:"delta_field,omitempty"`
+}
+
+// ChartSpec is the full, declarative chart artifact the agent emits via the
+// render_chart tool and the dashboard/export renders. It is intentionally
+// declarative-only: no expressions, no formatting code, no URLs — just a chart
+// type, its axes/series, and embedded data cells that must exactly match the
+// referenced query preview (see ValidateGrounded).
+type ChartSpec struct {
+	Type    ChartType `json:"type"`
+	Title   string    `json:"title,omitempty"`
+	Caption string    `json:"caption,omitempty"`
+
+	X        *Axis    `json:"x,omitempty"`
+	Y        []Series `json:"y,omitempty"`
+	SeriesBy string   `json:"series_by,omitempty"`
+	Stacked  *bool    `json:"stacked,omitempty"`
+
+	// Data is the embedded, capped, grounded data: an exact projection of the
+	// referenced query's preview rows. The model may drop columns/rows and
+	// reorder, but every cell must equal a cell of the source preview.
+	Data []map[string]any `json:"data,omitempty"`
+
+	// SourceStepID names the query step this data came from, e.g. "q2". It binds
+	// the chart to a specific observed result so grounding can be verified.
+	SourceStepID string `json:"source_step_id"`
+
+	KPI *KPI `json:"kpi,omitempty"`
+}
+
+// Caps bounds a chart so a single spec cannot exhaust tokens, memory, or the
+// renderer. Zero fields mean "unbounded" for that dimension; callers supply
+// DefaultCaps (or config-derived caps) rather than the zero value.
+type Caps struct {
+	MaxPoints    int // max Data rows
+	MaxSeries    int // max Y series
+	MaxSpecBytes int // max raw JSON bytes of the spec (checked in Decode)
+	MaxLabelLen  int // max length of any title/caption/label/string cell
+}
+
+// DefaultCaps are conservative defaults used when a caller does not override
+// them. MaxPoints intentionally matches the data agent's default query preview
+// row count (50): a chart is grounded against the preview, so it can never have
+// more points than the preview carries.
+var DefaultCaps = Caps{
+	MaxPoints:    50,
+	MaxSeries:    8,
+	MaxSpecBytes: 32768,
+	MaxLabelLen:  120,
+}

--- a/libs/go-common/charts/charts.go
+++ b/libs/go-common/charts/charts.go
@@ -62,7 +62,10 @@ type Series struct {
 // *Field members bind the figure to a column of the source query preview so a
 // KPI's provenance is provable, not asserted.
 type KPI struct {
-	Value      float64  `json:"value" bson:"value"`
+	// Value is a pointer so an omitted/null value is distinguishable from a
+	// legitimate 0 — a missing value must be rejected for repair, not silently
+	// grounded against a source cell that happens to be zero.
+	Value      *float64 `json:"value" bson:"value"`
 	Unit       string   `json:"unit,omitempty" bson:"unit,omitempty"`
 	Delta      *float64 `json:"delta,omitempty" bson:"delta,omitempty"`
 	ValueField string   `json:"value_field" bson:"value_field"`

--- a/libs/go-common/charts/schema.json
+++ b/libs/go-common/charts/schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://decisionbox.io/schemas/chart-spec.json",
+  "title": "ChartSpec",
+  "description": "Renderer-agnostic chart artifact emitted by the data agent's render_chart tool. Data must be an exact projection of the query preview named by source_step_id — never derived or invented. This JSON Schema is the language-neutral contract mirrored by the Go type (libs/go-common/charts) and the Dart renderer (decisionbox-chat-app).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["type", "source_step_id"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["bar", "line", "area", "pie", "scatter", "kpi"]
+    },
+    "title": { "type": "string" },
+    "caption": { "type": "string" },
+    "source_step_id": {
+      "type": "string",
+      "description": "The query step this chart's data came from, e.g. \"q2\"."
+    },
+    "x": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field"],
+      "properties": {
+        "field": { "type": "string" },
+        "label": { "type": "string" },
+        "type": { "type": "string", "enum": ["category", "time", "number"] }
+      }
+    },
+    "y": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["field"],
+        "properties": {
+          "field": { "type": "string" },
+          "label": { "type": "string" }
+        }
+      }
+    },
+    "series_by": {
+      "type": "string",
+      "description": "Field to split into one series per distinct value (bar/line/area only)."
+    },
+    "stacked": {
+      "type": "boolean",
+      "description": "Stack series (bar/area only)."
+    },
+    "data": {
+      "type": "array",
+      "description": "Embedded, capped, grounded data rows — an exact projection of the source preview.",
+      "items": { "type": "object" }
+    },
+    "kpi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "value_field"],
+      "properties": {
+        "value": { "type": "number" },
+        "unit": { "type": "string" },
+        "delta": { "type": "number" },
+        "value_field": {
+          "type": "string",
+          "description": "Source column the value was read from."
+        },
+        "delta_field": {
+          "type": "string",
+          "description": "Source column the delta was read from."
+        }
+      }
+    }
+  }
+}

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
 )
 
@@ -117,6 +116,11 @@ func validateKPIShape(spec ChartSpec) error {
 	if strings.TrimSpace(spec.KPI.ValueField) == "" {
 		return ruleErr("field_ref", "kpi.value_field", "kpi.value_field must name the source column the value was read from")
 	}
+	// A delta must also name its source column, or it could be computed/invented
+	// (grounding then has nothing to check it against).
+	if spec.KPI.Delta != nil && strings.TrimSpace(spec.KPI.DeltaField) == "" {
+		return ruleErr("field_ref", "kpi.delta_field", "kpi.delta_field must name the source column when a delta is provided")
+	}
 	return nil
 }
 
@@ -150,6 +154,18 @@ func validateSeriesShape(spec ChartSpec, caps Caps) error {
 	}
 	if caps.MaxPoints > 0 && len(spec.Data) > caps.MaxPoints {
 		return ruleErr("caps", "data", fmt.Sprintf("%d data points exceeds the limit of %d; aggregate in SQL to fewer rows", len(spec.Data), caps.MaxPoints))
+	}
+	// series_by pivots one field into one rendered series per distinct value, so
+	// it multiplies the effective series count — cap the fan-out too, or a single
+	// y with a high-cardinality series_by would blow past MaxSeries.
+	if spec.SeriesBy != "" && caps.MaxSeries > 0 {
+		distinct := map[string]struct{}{}
+		for _, row := range spec.Data {
+			distinct[fmt.Sprintf("%v", row[spec.SeriesBy])] = struct{}{}
+		}
+		if effective := len(spec.Y) * len(distinct); effective > caps.MaxSeries {
+			return ruleErr("caps", "series_by", fmt.Sprintf("series_by fans out to %d rendered series (%d values × %d measures), over the limit of %d; group the long tail in SQL", effective, len(distinct), len(spec.Y), caps.MaxSeries))
+		}
 	}
 
 	// Every charted field must be a key in every Data row, and every y cell
@@ -203,11 +219,21 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 			return ruleErr("grounding", f, fmt.Sprintf("field %q is not a column of source step %q; chart only columns the query returned", f, src.StepID))
 		}
 	}
-	fields := chartedFields(spec)
+	// Exact projection over EVERY key in each data row (not only the plotted
+	// fields): an invented key, or a real column carrying an altered value, must
+	// be rejected. So each row's keys must all be source columns AND the whole
+	// row must equal some preview row on all of them.
 	for ri, row := range spec.Data {
-		if !rowMatchesPreview(row, fields, preview) {
+		keys := make([]string, 0, len(row))
+		for k := range row {
+			if _, ok := cols[k]; !ok {
+				return ruleErr("grounding", k, fmt.Sprintf("data row %d has field %q that source step %q never returned; chart only the query's own columns (no invented fields)", ri, k, src.StepID))
+			}
+			keys = append(keys, k)
+		}
+		if !rowMatchesPreview(row, keys, preview) {
 			return ruleErr("grounding", "data",
-				fmt.Sprintf("data row %d does not match any row of source step %q on the charted fields; chart the exact query cells (do not compute or round values — aggregate in SQL instead)", ri, src.StepID))
+				fmt.Sprintf("data row %d does not match any row of source step %q; chart the exact query cells (do not compute, round, or add values — aggregate in SQL instead)", ri, src.StepID))
 		}
 	}
 	return nil
@@ -305,10 +331,13 @@ func canonicalizeRows(rows []map[string]any) []map[string]any {
 	return out
 }
 
-// cellsEqual compares two post-JSON cell values: numbers within a JSON
-// round-trip epsilon (this is re-encoding slack, NOT a licence to derive
-// values), everything else by exact type + value, with a string fallback for
-// unlike types.
+// cellsEqual compares two cell values for the exact-projection rule. Both the
+// chart data and the source preview are JSON-canonicalized to the same numeric
+// representation (float64) before comparison, so equal numbers are bit-identical
+// — exact equality is correct and, unlike a relative tolerance, cannot let a
+// rounded/scaled large number ("1,000,000,000,000" charted as "1,000,000,001,000")
+// pass as grounded. Non-numbers compare by exact type + value, with a string
+// fallback for unlike types.
 func cellsEqual(a, b any) bool {
 	if a == nil && b == nil {
 		return true
@@ -318,7 +347,7 @@ func cellsEqual(a, b any) bool {
 	}
 	if af, aok := asFloat(a); aok {
 		if bf, bok := asFloat(b); bok {
-			return math.Abs(af-bf) <= math.Max(1e-9, 1e-9*math.Abs(bf))
+			return af == bf
 		}
 		return false
 	}

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -280,6 +280,12 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 // read from the named columns.
 func groundKPI(spec ChartSpec, src GroundingSource, cols map[string]struct{}, preview []map[string]any) error {
 	k := spec.KPI
+	// kpi.value/delta are float64 in the struct, so a magnitude beyond float64's
+	// exact-integer range can't be proven equal to a source cell (both sides
+	// round) — reject, mirroring the series-data precision guard.
+	if math.Abs(k.Value) >= maxExactInt || (k.Delta != nil && math.Abs(*k.Delta) >= maxExactInt) {
+		return ruleErr("grounding", "kpi", "the kpi figure is too large to ground with exact precision; aggregate, round, or scale it in SQL first")
+	}
 	if _, ok := cols[k.ValueField]; !ok {
 		return ruleErr("grounding", "kpi.value_field", fmt.Sprintf("value_field %q is not a column of source step %q", k.ValueField, src.StepID))
 	}

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -1,0 +1,427 @@
+package charts
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// Error is a structured, model-readable validation failure. The data agent
+// feeds Error() back to the model as a tool error so it can repair the spec or
+// re-query; Rule + Field name the exact rule violated.
+type Error struct {
+	Rule  string // e.g. "type", "field_ref", "grounding", "caps", "sanitize"
+	Field string // the offending field, when known
+	Msg   string
+}
+
+func (e *Error) Error() string {
+	switch {
+	case e.Field != "":
+		return fmt.Sprintf("chart rejected [%s: %s]: %s", e.Rule, e.Field, e.Msg)
+	default:
+		return fmt.Sprintf("chart rejected [%s]: %s", e.Rule, e.Msg)
+	}
+}
+
+func ruleErr(rule, field, msg string) *Error { return &Error{Rule: rule, Field: field, Msg: msg} }
+
+// GroundingSource is the subset of a query result a chart may be grounded
+// against: the columns the result exposed, the preview rows the chart data must
+// be an exact projection of, and whether the preview omitted rows. A truncated
+// preview is not the full result, so it cannot ground a chart — the agent must
+// aggregate in SQL until the whole result fits the preview.
+//
+// It is a plain value type (not the agent's internal QuerySummary) so this leaf
+// package stays free of service dependencies; the caller adapts its own summary
+// into this shape.
+type GroundingSource struct {
+	StepID    string
+	Columns   []string
+	Preview   []map[string]any
+	Truncated bool
+}
+
+// Decode strict-parses raw render_chart input into a ChartSpec and runs the
+// structural Validate. It enforces the byte cap first (a spec far over budget
+// is rejected without decoding) and rejects unknown fields so the artifact
+// stays strictly declarative — a model cannot smuggle an unmodeled field (an
+// expression, a URL, a script) past the contract.
+func Decode(raw []byte, caps Caps) (ChartSpec, error) {
+	var spec ChartSpec
+	if caps.MaxSpecBytes > 0 && len(raw) > caps.MaxSpecBytes {
+		return spec, ruleErr("caps", "spec", fmt.Sprintf("chart spec is %d bytes, over the %d-byte limit; reduce the number of points or series", len(raw), caps.MaxSpecBytes))
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&spec); err != nil {
+		return spec, ruleErr("shape", "", fmt.Sprintf("could not parse chart spec: %v", err))
+	}
+	if err := Validate(spec, caps); err != nil {
+		return spec, err
+	}
+	return spec, nil
+}
+
+// Validate checks a ChartSpec's structure, field references (within its own
+// Data), numeric-y typing, caps, and sanitization — everything that does not
+// require the source query. ValidateGrounded adds the grounding rules. Both
+// return an *Error the model can act on.
+func Validate(spec ChartSpec, caps Caps) error {
+	if err := validateType(spec); err != nil {
+		return err
+	}
+	if strings.TrimSpace(spec.SourceStepID) == "" {
+		return ruleErr("grounding", "source_step_id", "every chart must set source_step_id to the query step it charts, e.g. \"q2\"")
+	}
+	if err := sanitizeStrings(spec, caps); err != nil {
+		return err
+	}
+	if spec.Type == ChartKPI {
+		return validateKPIShape(spec)
+	}
+	return validateSeriesShape(spec, caps)
+}
+
+// validateType rejects unknown types and enforces the per-type presence rules
+// (kpi vs the axis/series family) that the rest of validation assumes.
+func validateType(spec ChartSpec) error {
+	switch spec.Type {
+	case ChartBar, ChartLine, ChartArea, ChartPie, ChartScatter, ChartKPI:
+	default:
+		return ruleErr("type", "type", fmt.Sprintf("unknown chart type %q; allowed: bar, line, area, pie, scatter, kpi", spec.Type))
+	}
+	// Stacked only makes sense for bar/area; SeriesBy only for bar/line/area.
+	if spec.Stacked != nil && spec.Type != ChartBar && spec.Type != ChartArea {
+		return ruleErr("shape", "stacked", "stacked is only valid for bar and area charts")
+	}
+	if spec.SeriesBy != "" && spec.Type != ChartBar && spec.Type != ChartLine && spec.Type != ChartArea {
+		return ruleErr("shape", "series_by", "series_by is only valid for bar, line, and area charts")
+	}
+	if spec.Type == ChartKPI {
+		if spec.X != nil || len(spec.Y) > 0 {
+			return ruleErr("shape", "kpi", "a kpi chart must not set x or y")
+		}
+	}
+	return nil
+}
+
+// validateKPIShape checks a KPI carries a value binding. Grounding (that the
+// value equals a source cell) is checked in ValidateGrounded.
+func validateKPIShape(spec ChartSpec) error {
+	if spec.KPI == nil {
+		return ruleErr("shape", "kpi", "a kpi chart must set the kpi object")
+	}
+	if strings.TrimSpace(spec.KPI.ValueField) == "" {
+		return ruleErr("field_ref", "kpi.value_field", "kpi.value_field must name the source column the value was read from")
+	}
+	return nil
+}
+
+// validateSeriesShape checks the axis/series family: an X axis, at least one Y
+// series within the series cap, non-empty Data within the points cap, and that
+// every referenced field is a key in every Data row and carries numeric values
+// where required.
+func validateSeriesShape(spec ChartSpec, caps Caps) error {
+	if spec.KPI != nil {
+		return ruleErr("shape", "kpi", "kpi is only valid on a kpi chart")
+	}
+	if spec.X == nil || strings.TrimSpace(spec.X.Field) == "" {
+		return ruleErr("shape", "x", "this chart type requires an x axis with a field")
+	}
+	if spec.X.Type != "" && spec.X.Type != AxisCategory && spec.X.Type != AxisTime && spec.X.Type != AxisNumber {
+		return ruleErr("shape", "x.type", fmt.Sprintf("unknown x.type %q; allowed: category, time, number", spec.X.Type))
+	}
+	if len(spec.Y) == 0 {
+		return ruleErr("shape", "y", "this chart type requires at least one y series")
+	}
+	if caps.MaxSeries > 0 && len(spec.Y) > caps.MaxSeries {
+		return ruleErr("caps", "y", fmt.Sprintf("%d series exceeds the limit of %d", len(spec.Y), caps.MaxSeries))
+	}
+	for i, s := range spec.Y {
+		if strings.TrimSpace(s.Field) == "" {
+			return ruleErr("shape", fmt.Sprintf("y[%d].field", i), "every y series must name a field")
+		}
+	}
+	if len(spec.Data) == 0 {
+		return ruleErr("shape", "data", "this chart type requires non-empty data")
+	}
+	if caps.MaxPoints > 0 && len(spec.Data) > caps.MaxPoints {
+		return ruleErr("caps", "data", fmt.Sprintf("%d data points exceeds the limit of %d; aggregate in SQL to fewer rows", len(spec.Data), caps.MaxPoints))
+	}
+
+	// Every charted field must be a key in every Data row, and every y cell
+	// must be numeric (or null) so the renderer can plot it.
+	for _, f := range chartedFields(spec) {
+		for ri, row := range spec.Data {
+			if _, ok := row[f]; !ok {
+				return ruleErr("field_ref", f, fmt.Sprintf("data row %d has no field %q", ri, f))
+			}
+		}
+	}
+	for _, s := range spec.Y {
+		for ri, row := range spec.Data {
+			if !isNumericOrNull(row[s.Field]) {
+				return ruleErr("shape", s.Field, fmt.Sprintf("y field %q must be numeric; data row %d is not", s.Field, ri))
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateGrounded enforces the hard grounding rule: the chart's data must be an
+// exact projection of the referenced query's preview — the model may drop
+// columns/rows and reorder, but may not compute new numbers (all aggregation
+// happens in SQL). It assumes Validate already passed (call Decode first, or
+// Validate then this). src must be the query the spec's SourceStepID names.
+func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
+	if err := Validate(spec, caps); err != nil {
+		return err
+	}
+	if src.Truncated {
+		return ruleErr("grounding", "source_step_id",
+			fmt.Sprintf("step %q was truncated (its preview omits rows), so it cannot ground a chart; aggregate in SQL (GROUP BY/LIMIT) so the full result fits the preview, then chart that", src.StepID))
+	}
+	cols := map[string]struct{}{}
+	for _, c := range src.Columns {
+		cols[c] = struct{}{}
+	}
+	// Canonicalize the preview through JSON so numeric cells compare as the
+	// float64 the model actually saw in the observation text (the preview is
+	// shown to the model as JSON), not as a driver-specific int/int64/time type.
+	preview := canonicalizeRows(src.Preview)
+
+	if spec.Type == ChartKPI {
+		return groundKPI(spec, src, cols, preview)
+	}
+
+	// Every charted field must be a real column of the source preview.
+	for _, f := range chartedFields(spec) {
+		if _, ok := cols[f]; !ok {
+			return ruleErr("grounding", f, fmt.Sprintf("field %q is not a column of source step %q; chart only columns the query returned", f, src.StepID))
+		}
+	}
+	fields := chartedFields(spec)
+	for ri, row := range spec.Data {
+		if !rowMatchesPreview(row, fields, preview) {
+			return ruleErr("grounding", "data",
+				fmt.Sprintf("data row %d does not match any row of source step %q on the charted fields; chart the exact query cells (do not compute or round values — aggregate in SQL instead)", ri, src.StepID))
+		}
+	}
+	return nil
+}
+
+// groundKPI checks a KPI's value (and optional delta) each equal a source cell,
+// read from the named columns.
+func groundKPI(spec ChartSpec, src GroundingSource, cols map[string]struct{}, preview []map[string]any) error {
+	k := spec.KPI
+	if _, ok := cols[k.ValueField]; !ok {
+		return ruleErr("grounding", "kpi.value_field", fmt.Sprintf("value_field %q is not a column of source step %q", k.ValueField, src.StepID))
+	}
+	if k.DeltaField != "" {
+		if _, ok := cols[k.DeltaField]; !ok {
+			return ruleErr("grounding", "kpi.delta_field", fmt.Sprintf("delta_field %q is not a column of source step %q", k.DeltaField, src.StepID))
+		}
+	}
+	for _, row := range preview {
+		if !cellsEqual(k.Value, row[k.ValueField]) {
+			continue
+		}
+		if k.DeltaField == "" || k.Delta == nil {
+			return nil
+		}
+		if cellsEqual(*k.Delta, row[k.DeltaField]) {
+			return nil
+		}
+	}
+	return ruleErr("grounding", "kpi",
+		fmt.Sprintf("the kpi value (and delta, if set) must equal a cell of source step %q; read the figure from the query result, do not compute it", src.StepID))
+}
+
+// chartedFields returns every source field the spec plots: the x field, each y
+// field, and series_by. Deduplicated, so a field used twice is checked once.
+func chartedFields(spec ChartSpec) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(f string) {
+		if f == "" {
+			return
+		}
+		if _, ok := seen[f]; ok {
+			return
+		}
+		seen[f] = struct{}{}
+		out = append(out, f)
+	}
+	if spec.X != nil {
+		add(spec.X.Field)
+	}
+	for _, s := range spec.Y {
+		add(s.Field)
+	}
+	add(spec.SeriesBy)
+	return out
+}
+
+// rowMatchesPreview reports whether some preview row equals the data row on all
+// charted fields — the "exact projection" test. A data row must come, in whole,
+// from one observed preview row; the model may not stitch fields from different
+// rows.
+func rowMatchesPreview(row map[string]any, fields []string, preview []map[string]any) bool {
+	for _, p := range preview {
+		match := true
+		for _, f := range fields {
+			if !cellsEqual(row[f], p[f]) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalizeRows JSON round-trips each row so its cells become the same
+// post-JSON scalars (float64 numbers, string/bool/nil) the model was shown in
+// the observation preview. A row that fails to round-trip is dropped (it cannot
+// match anything), which only ever tightens grounding.
+func canonicalizeRows(rows []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		b, err := json.Marshal(r)
+		if err != nil {
+			continue
+		}
+		var m map[string]any
+		if json.Unmarshal(b, &m) != nil {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// cellsEqual compares two post-JSON cell values: numbers within a JSON
+// round-trip epsilon (this is re-encoding slack, NOT a licence to derive
+// values), everything else by exact type + value, with a string fallback for
+// unlike types.
+func cellsEqual(a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if af, aok := asFloat(a); aok {
+		if bf, bok := asFloat(b); bok {
+			return math.Abs(af-bf) <= math.Max(1e-9, 1e-9*math.Abs(bf))
+		}
+		return false
+	}
+	switch av := a.(type) {
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	}
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+func asFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	}
+	return 0, false
+}
+
+func isNumericOrNull(v any) bool {
+	if v == nil {
+		return true
+	}
+	_, ok := asFloat(v)
+	return ok
+}
+
+// sanitizeStrings rejects any human-facing string that could break out of a
+// declarative render into markup/script, and enforces the label-length cap.
+// Applies to titles, captions, axis/series labels, and every string data cell.
+func sanitizeStrings(spec ChartSpec, caps Caps) error {
+	check := func(field, s string) error {
+		if caps.MaxLabelLen > 0 && len(s) > caps.MaxLabelLen {
+			return ruleErr("caps", field, fmt.Sprintf("%q exceeds the %d-character label limit", field, caps.MaxLabelLen))
+		}
+		if unsafeString(s) {
+			return ruleErr("sanitize", field, fmt.Sprintf("%q contains disallowed characters (markup, script, or control characters); use plain text", field))
+		}
+		return nil
+	}
+	if err := check("title", spec.Title); err != nil {
+		return err
+	}
+	if err := check("caption", spec.Caption); err != nil {
+		return err
+	}
+	if spec.X != nil {
+		if err := check("x.label", spec.X.Label); err != nil {
+			return err
+		}
+	}
+	for i, s := range spec.Y {
+		if err := check(fmt.Sprintf("y[%d].label", i), s.Label); err != nil {
+			return err
+		}
+	}
+	if spec.KPI != nil {
+		if err := check("kpi.unit", spec.KPI.Unit); err != nil {
+			return err
+		}
+	}
+	for ri, row := range spec.Data {
+		for k, v := range row {
+			if s, ok := v.(string); ok {
+				if err := check(fmt.Sprintf("data[%d].%s", ri, k), s); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// unsafeString reports whether s carries markup, a javascript: scheme, or
+// control characters — anything a declarative renderer should never receive.
+func unsafeString(s string) bool {
+	if strings.ContainsAny(s, "<>") {
+		return true
+	}
+	if strings.Contains(strings.ToLower(s), "javascript:") {
+		return true
+	}
+	for _, r := range s {
+		if r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -4,8 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
+	"math/big"
 	"strings"
 )
+
+// maxExactInt is float64's largest exactly-representable integer (2^53). A chart
+// data cell above this can't have survived JSON decoding (float64) without
+// possible rounding, so it can't be proven an exact projection of the source —
+// grounding rejects it rather than risk a rounded value matching.
+const maxExactInt = 1 << 53
 
 // Error is a structured, model-readable validation failure. The data agent
 // feeds Error() back to the model as a tool error so it can repair the spec or
@@ -211,14 +219,16 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 	for _, c := range src.Columns {
 		cols[c] = struct{}{}
 	}
-	// Canonicalize the preview through JSON so numeric cells compare as the
-	// float64 the model actually saw in the observation text (the preview is
-	// shown to the model as JSON), not as a driver-specific int/int64/time type.
+	// Canonicalize both sides through JSON with UseNumber so numeric cells compare
+	// as the exact number the model saw in the observation text (the preview is
+	// shown as JSON) — as json.Number, not float64, so an integer beyond float64's
+	// exact range (|x| >= 2^53) can't be silently rounded into a false match.
 	preview := canonicalizeRows(src.Preview)
 
 	if spec.Type == ChartKPI {
 		return groundKPI(spec, src, cols, preview)
 	}
+	dataRows := canonicalizeRows(spec.Data)
 
 	// Every charted field must be a real column of the source preview.
 	for _, f := range chartedFields(spec) {
@@ -234,11 +244,16 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 	// one observed row into many duplicate bars/points the query never returned —
 	// the chart data is a sub-multiset of the preview, not just a subset.
 	used := make([]bool, len(preview))
-	for ri, row := range spec.Data {
+	for ri, row := range dataRows {
 		keys := make([]string, 0, len(row))
-		for k := range row {
+		for k, v := range row {
 			if _, ok := cols[k]; !ok {
 				return ruleErr("grounding", k, fmt.Sprintf("data row %d has field %q that source step %q never returned; chart only the query's own columns (no invented fields)", ri, k, src.StepID))
+			}
+			if n, ok := v.(json.Number); ok {
+				if f, err := n.Float64(); err == nil && math.Abs(f) >= maxExactInt {
+					return ruleErr("grounding", k, fmt.Sprintf("data row %d value for %q is too large to chart with exact precision; aggregate, round, or scale it in SQL first", ri, k))
+				}
 			}
 			keys = append(keys, k)
 		}
@@ -327,9 +342,10 @@ func rowEqualsOn(row map[string]any, fields []string, p map[string]any) bool {
 }
 
 // canonicalizeRows JSON round-trips each row so its cells become the same
-// post-JSON scalars (float64 numbers, string/bool/nil) the model was shown in
-// the observation preview. A row that fails to round-trip is dropped (it cannot
-// match anything), which only ever tightens grounding.
+// post-JSON scalars the model was shown in the observation preview, with numbers
+// decoded as json.Number (exact decimal text) rather than float64 — so a large
+// integer is compared by value, not by a lossy float. A row that fails to
+// round-trip is dropped (it cannot match anything), which only tightens grounding.
 func canonicalizeRows(rows []map[string]any) []map[string]any {
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
@@ -337,8 +353,10 @@ func canonicalizeRows(rows []map[string]any) []map[string]any {
 		if err != nil {
 			continue
 		}
+		dec := json.NewDecoder(bytes.NewReader(b))
+		dec.UseNumber()
 		var m map[string]any
-		if json.Unmarshal(b, &m) != nil {
+		if dec.Decode(&m) != nil {
 			continue
 		}
 		out = append(out, m)
@@ -346,19 +364,24 @@ func canonicalizeRows(rows []map[string]any) []map[string]any {
 	return out
 }
 
-// cellsEqual compares two cell values for the exact-projection rule. Both the
-// chart data and the source preview are JSON-canonicalized to the same numeric
-// representation (float64) before comparison, so equal numbers are bit-identical
-// — exact equality is correct and, unlike a relative tolerance, cannot let a
-// rounded/scaled large number ("1,000,000,000,000" charted as "1,000,000,001,000")
-// pass as grounded. Non-numbers compare by exact type + value, with a string
-// fallback for unlike types.
+// cellsEqual compares two cell values for the exact-projection rule. When both
+// sides are json.Number (the data-grounding path, where both come from JSON
+// text), they are compared as exact decimals via big.Rat — so a rounded or
+// altered large number ("9007199254740993" charted as "9007199254740992")
+// cannot pass, and trivial re-representations ("100" vs "100.0") still match.
+// Otherwise (e.g. a KPI's float64 value against a source cell) it falls back to
+// float64 numeric equality, then exact string/bool comparison.
 func cellsEqual(a, b any) bool {
 	if a == nil && b == nil {
 		return true
 	}
 	if a == nil || b == nil {
 		return false
+	}
+	if an, aok := a.(json.Number); aok {
+		if bn, bok := b.(json.Number); bok {
+			return numberEqual(an, bn)
+		}
 	}
 	if af, aok := asFloat(a); aok {
 		if bf, bok := asFloat(b); bok {
@@ -375,6 +398,19 @@ func cellsEqual(a, b any) bool {
 		return ok && av == bv
 	}
 	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+// numberEqual compares two JSON numbers by exact decimal value (big.Rat), so
+// integers beyond float64's exact range compare precisely. Falls back to exact
+// string equality if either is not a parseable rational (should not happen for
+// JSON numbers).
+func numberEqual(a, b json.Number) bool {
+	ra, oka := new(big.Rat).SetString(a.String())
+	rb, okb := new(big.Rat).SetString(b.String())
+	if oka && okb {
+		return ra.Cmp(rb) == 0
+	}
+	return a.String() == b.String()
 }
 
 func asFloat(v any) (float64, bool) {

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -121,6 +121,13 @@ func validateKPIShape(spec ChartSpec) error {
 	if spec.KPI.Delta != nil && strings.TrimSpace(spec.KPI.DeltaField) == "" {
 		return ruleErr("field_ref", "kpi.delta_field", "kpi.delta_field must name the source column when a delta is provided")
 	}
+	// A KPI's figures come from kpi.value/delta (grounded against the source
+	// cell), not from a data array. Reject a stray data array so it can't smuggle
+	// ungrounded, uncapped cells past validation (the KPI grounding path never
+	// inspects Data).
+	if len(spec.Data) > 0 {
+		return ruleErr("shape", "data", "a kpi chart must not carry a data array; its figure comes from kpi.value (read from the source)")
+	}
 	return nil
 }
 
@@ -222,7 +229,11 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 	// Exact projection over EVERY key in each data row (not only the plotted
 	// fields): an invented key, or a real column carrying an altered value, must
 	// be rejected. So each row's keys must all be source columns AND the whole
-	// row must equal some preview row on all of them.
+	// row must equal some preview row on all of them. Preview rows are matched
+	// WITHOUT replacement (each consumed at most once) so the model cannot repeat
+	// one observed row into many duplicate bars/points the query never returned —
+	// the chart data is a sub-multiset of the preview, not just a subset.
+	used := make([]bool, len(preview))
 	for ri, row := range spec.Data {
 		keys := make([]string, 0, len(row))
 		for k := range row {
@@ -231,10 +242,21 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 			}
 			keys = append(keys, k)
 		}
-		if !rowMatchesPreview(row, keys, preview) {
-			return ruleErr("grounding", "data",
-				fmt.Sprintf("data row %d does not match any row of source step %q; chart the exact query cells (do not compute, round, or add values — aggregate in SQL instead)", ri, src.StepID))
+		matched := -1
+		for pi, p := range preview {
+			if used[pi] {
+				continue
+			}
+			if rowEqualsOn(row, keys, p) {
+				matched = pi
+				break
+			}
 		}
+		if matched < 0 {
+			return ruleErr("grounding", "data",
+				fmt.Sprintf("data row %d does not match an unused row of source step %q; chart the exact query cells without inventing, altering, or duplicating rows (aggregate in SQL instead)", ri, src.StepID))
+		}
+		used[matched] = true
 	}
 	return nil
 }
@@ -291,24 +313,17 @@ func chartedFields(spec ChartSpec) []string {
 	return out
 }
 
-// rowMatchesPreview reports whether some preview row equals the data row on all
-// charted fields — the "exact projection" test. A data row must come, in whole,
-// from one observed preview row; the model may not stitch fields from different
-// rows.
-func rowMatchesPreview(row map[string]any, fields []string, preview []map[string]any) bool {
-	for _, p := range preview {
-		match := true
-		for _, f := range fields {
-			if !cellsEqual(row[f], p[f]) {
-				match = false
-				break
-			}
-		}
-		if match {
-			return true
+// rowEqualsOn reports whether the data row equals one preview row on all the
+// given fields — the per-row "exact projection" test. A data row must come, in
+// whole, from one observed preview row; the model may not stitch fields from
+// different rows.
+func rowEqualsOn(row map[string]any, fields []string, p map[string]any) bool {
+	for _, f := range fields {
+		if !cellsEqual(row[f], p[f]) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // canonicalizeRows JSON round-trips each row so its cells become the same

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -121,6 +121,9 @@ func validateKPIShape(spec ChartSpec) error {
 	if spec.KPI == nil {
 		return ruleErr("shape", "kpi", "a kpi chart must set the kpi object")
 	}
+	if spec.KPI.Value == nil {
+		return ruleErr("shape", "kpi.value", "kpi.value is required (a missing value is not the same as 0)")
+	}
 	if strings.TrimSpace(spec.KPI.ValueField) == "" {
 		return ruleErr("field_ref", "kpi.value_field", "kpi.value_field must name the source column the value was read from")
 	}
@@ -196,6 +199,21 @@ func validateSeriesShape(spec ChartSpec, caps Caps) error {
 		for ri, row := range spec.Data {
 			if !isNumericOrNull(row[s.Field]) {
 				return ruleErr("shape", s.Field, fmt.Sprintf("y field %q must be numeric; data row %d is not", s.Field, ri))
+			}
+		}
+	}
+	// A scatter plots a continuous x, and a declared number x-axis promises
+	// numeric x values — reject non-numeric x cells so a renderer never gets a
+	// numeric axis over strings (mis-scaled or blank). category/time x may be
+	// non-numeric.
+	if spec.Type == ChartScatter || spec.X.Type == AxisNumber {
+		for ri, row := range spec.Data {
+			if !isNumericOrNull(row[spec.X.Field]) {
+				kind := "a scatter"
+				if spec.Type != ChartScatter {
+					kind = "a number x-axis"
+				}
+				return ruleErr("shape", spec.X.Field, fmt.Sprintf("%s requires numeric x values; data row %d has a non-numeric %q (use x.type category/time for labels)", kind, ri, spec.X.Field))
 			}
 		}
 	}
@@ -280,10 +298,11 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 // read from the named columns.
 func groundKPI(spec ChartSpec, src GroundingSource, cols map[string]struct{}, preview []map[string]any) error {
 	k := spec.KPI
-	// kpi.value/delta are float64 in the struct, so a magnitude beyond float64's
-	// exact-integer range can't be proven equal to a source cell (both sides
-	// round) — reject, mirroring the series-data precision guard.
-	if math.Abs(k.Value) >= maxExactInt || (k.Delta != nil && math.Abs(*k.Delta) >= maxExactInt) {
+	// kpi.value/delta are float64, so a magnitude beyond float64's exact-integer
+	// range can't be proven equal to a source cell (both sides round) — reject,
+	// mirroring the series-data precision guard. (Validate already ensured
+	// Value != nil.)
+	if math.Abs(*k.Value) >= maxExactInt || (k.Delta != nil && math.Abs(*k.Delta) >= maxExactInt) {
 		return ruleErr("grounding", "kpi", "the kpi figure is too large to ground with exact precision; aggregate, round, or scale it in SQL first")
 	}
 	if _, ok := cols[k.ValueField]; !ok {
@@ -295,7 +314,7 @@ func groundKPI(spec ChartSpec, src GroundingSource, cols map[string]struct{}, pr
 		}
 	}
 	for _, row := range preview {
-		if !cellsEqual(k.Value, row[k.ValueField]) {
+		if !cellsEqual(*k.Value, row[k.ValueField]) {
 			continue
 		}
 		if k.DeltaField == "" || k.Delta == nil {

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -333,6 +333,45 @@ func TestValidateGrounded_RejectsDuplicatedSourceRow(t *testing.T) {
 	}
 }
 
+func TestValidateGrounded_RejectsBeyondFloat64Precision(t *testing.T) {
+	// A value above 2^53 can't survive float64 JSON decoding without possible
+	// rounding, so it can't be proven an exact projection — reject it.
+	src := GroundingSource{
+		StepID:  "q1",
+		Columns: []string{"label", "amount"},
+		Preview: []map[string]any{{"label": "x", "amount": int64(9007199254740993)}},
+	}
+	s := ChartSpec{
+		Type: ChartBar, SourceStepID: "q1",
+		X: &Axis{Field: "label"}, Y: []Series{{Field: "amount"}},
+		Data: []map[string]any{{"label": "x", "amount": 9007199254740993.0}},
+	}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("a value beyond float64's exact-integer range must be rejected")
+	}
+}
+
+func TestValidateGrounded_ExactDecimalMatches(t *testing.T) {
+	src := GroundingSource{
+		StepID:  "q1",
+		Columns: []string{"label", "rate"},
+		Preview: []map[string]any{{"label": "a", "rate": 33.5}, {"label": "b", "rate": 12.25}},
+	}
+	s := ChartSpec{
+		Type: ChartLine, SourceStepID: "q1",
+		X: &Axis{Field: "label"}, Y: []Series{{Field: "rate"}},
+		Data: []map[string]any{{"label": "a", "rate": 33.5}, {"label": "b", "rate": 12.25}},
+	}
+	if err := ValidateGrounded(s, src, DefaultCaps); err != nil {
+		t.Errorf("exact decimals should ground: %v", err)
+	}
+	// An altered decimal is rejected.
+	s.Data[0]["rate"] = 33.6
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("an altered decimal must be rejected")
+	}
+}
+
 func TestValidateGrounded_KPIProvenance(t *testing.T) {
 	src := GroundingSource{
 		StepID:  "q1",

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -1,0 +1,272 @@
+package charts
+
+import (
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+//go:embed schema.json
+var schemaJSON []byte
+
+// f64 is a small helper for building *float64 test values.
+func f64(v float64) *float64 { return &v }
+
+func boolp(v bool) *bool { return &v }
+
+// source is a convenient grounding source: two-column monthly revenue.
+func revenueSource() GroundingSource {
+	return GroundingSource{
+		StepID:  "q2",
+		Columns: []string{"month", "revenue", "cost"},
+		Preview: []map[string]any{
+			{"month": "2024-01", "revenue": int64(100), "cost": int64(40)},
+			{"month": "2024-02", "revenue": int64(150), "cost": int64(55)},
+			{"month": "2024-03", "revenue": int64(210), "cost": int64(70)},
+		},
+	}
+}
+
+func barSpec() ChartSpec {
+	return ChartSpec{
+		Type:         ChartBar,
+		Title:        "Revenue by month",
+		X:            &Axis{Field: "month", Type: AxisCategory},
+		Y:            []Series{{Field: "revenue"}},
+		SourceStepID: "q2",
+		Data: []map[string]any{
+			{"month": "2024-01", "revenue": 100.0},
+			{"month": "2024-02", "revenue": 150.0},
+			{"month": "2024-03", "revenue": 210.0},
+		},
+	}
+}
+
+func TestValidate_Valid(t *testing.T) {
+	for _, spec := range []ChartSpec{
+		barSpec(),
+		func() ChartSpec { s := barSpec(); s.Type = ChartLine; return s }(),
+		func() ChartSpec { s := barSpec(); s.Type = ChartArea; s.Stacked = boolp(true); return s }(),
+		func() ChartSpec { s := barSpec(); s.Type = ChartScatter; return s }(),
+		{
+			Type: ChartKPI, Title: "Total", SourceStepID: "q2",
+			KPI: &KPI{Value: 460, Unit: "USD", ValueField: "revenue"},
+		},
+	} {
+		if err := Validate(spec, DefaultCaps); err != nil {
+			t.Errorf("Validate(%s) = %v, want nil", spec.Type, err)
+		}
+	}
+}
+
+func TestValidate_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		spec ChartSpec
+		rule string
+	}{
+		{"unknown type", func() ChartSpec { s := barSpec(); s.Type = "radar"; return s }(), "type"},
+		{"missing source_step_id", func() ChartSpec { s := barSpec(); s.SourceStepID = ""; return s }(), "grounding"},
+		{"no x", func() ChartSpec { s := barSpec(); s.X = nil; return s }(), "shape"},
+		{"no y", func() ChartSpec { s := barSpec(); s.Y = nil; return s }(), "shape"},
+		{"empty data", func() ChartSpec { s := barSpec(); s.Data = nil; return s }(), "shape"},
+		{"stacked on line", func() ChartSpec { s := barSpec(); s.Type = ChartLine; s.Stacked = boolp(true); return s }(), "shape"},
+		{"series_by on pie", func() ChartSpec { s := barSpec(); s.Type = ChartPie; s.SeriesBy = "region"; return s }(), "shape"},
+		{"y field missing from data", func() ChartSpec {
+			s := barSpec()
+			s.Y = []Series{{Field: "profit"}}
+			return s
+		}(), "field_ref"},
+		{"non-numeric y", func() ChartSpec {
+			s := barSpec()
+			s.Data = []map[string]any{{"month": "2024-01", "revenue": "lots"}}
+			return s
+		}(), "shape"},
+		{"html in title", func() ChartSpec { s := barSpec(); s.Title = "<script>x</script>"; return s }(), "sanitize"},
+		{"javascript in caption", func() ChartSpec { s := barSpec(); s.Caption = "javascript:alert(1)"; return s }(), "sanitize"},
+		{"kpi without kpi obj", ChartSpec{Type: ChartKPI, SourceStepID: "q2"}, "shape"},
+		{"kpi with x", ChartSpec{Type: ChartKPI, SourceStepID: "q2", X: &Axis{Field: "m"}, KPI: &KPI{ValueField: "revenue"}}, "shape"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := Validate(c.spec, DefaultCaps)
+			if err == nil {
+				t.Fatalf("Validate = nil, want rejection")
+			}
+			var ve *Error
+			if !errors.As(err, &ve) {
+				t.Fatalf("error type = %T, want *charts.Error", err)
+			}
+			if ve.Rule != c.rule {
+				t.Errorf("rule = %q, want %q (%v)", ve.Rule, c.rule, err)
+			}
+		})
+	}
+}
+
+func TestValidate_Caps(t *testing.T) {
+	caps := Caps{MaxPoints: 2, MaxSeries: 1, MaxLabelLen: 10}
+	s := barSpec()
+	if err := Validate(s, caps); err == nil {
+		t.Error("3 points over MaxPoints=2 should reject")
+	}
+	s2 := barSpec()
+	s2.Data = s2.Data[:2]
+	s2.Y = []Series{{Field: "revenue"}, {Field: "cost"}}
+	s2.Data = []map[string]any{{"month": "a", "revenue": 1.0, "cost": 2.0}, {"month": "b", "revenue": 3.0, "cost": 4.0}}
+	if err := Validate(s2, caps); err == nil {
+		t.Error("2 series over MaxSeries=1 should reject")
+	}
+	s3 := barSpec()
+	s3.Data = s3.Data[:2]
+	s3.Title = "this title is definitely longer than ten characters"
+	if err := Validate(s3, caps); err == nil {
+		t.Error("over-long label should reject")
+	}
+}
+
+func TestDecode_RejectsUnknownFieldAndOversize(t *testing.T) {
+	// Unknown field -> declarative-only contract violation.
+	raw := []byte(`{"type":"bar","source_step_id":"q2","x":{"field":"month"},"y":[{"field":"revenue"}],"data":[{"month":"a","revenue":1}],"onClick":"evil()"}`)
+	if _, err := Decode(raw, DefaultCaps); err == nil {
+		t.Error("Decode should reject an unknown field")
+	}
+	// Over byte cap.
+	if _, err := Decode(raw, Caps{MaxSpecBytes: 10}); err == nil {
+		t.Error("Decode should reject an oversize spec")
+	}
+	// Valid decode.
+	good := []byte(`{"type":"bar","source_step_id":"q2","x":{"field":"month"},"y":[{"field":"revenue"}],"data":[{"month":"a","revenue":1}]}`)
+	spec, err := Decode(good, DefaultCaps)
+	if err != nil {
+		t.Fatalf("Decode(valid) = %v", err)
+	}
+	if spec.Type != ChartBar {
+		t.Errorf("type = %q, want bar", spec.Type)
+	}
+}
+
+func TestValidateGrounded_ExactProjection(t *testing.T) {
+	src := revenueSource()
+	if err := ValidateGrounded(barSpec(), src, DefaultCaps); err != nil {
+		t.Fatalf("grounded valid bar = %v", err)
+	}
+
+	// A reordered/subset projection is still grounded.
+	s := barSpec()
+	s.Data = []map[string]any{
+		{"month": "2024-03", "revenue": 210.0},
+		{"month": "2024-01", "revenue": 100.0},
+	}
+	if err := ValidateGrounded(s, src, DefaultCaps); err != nil {
+		t.Errorf("reordered subset should ground: %v", err)
+	}
+}
+
+func TestValidateGrounded_RejectsDerivedNumbers(t *testing.T) {
+	src := revenueSource()
+	s := barSpec()
+	// The model "helpfully" scaled revenue to thousands — a derived number.
+	s.Data = []map[string]any{{"month": "2024-01", "revenue": 0.1}}
+	err := ValidateGrounded(s, src, DefaultCaps)
+	if err == nil {
+		t.Fatal("derived number should be rejected")
+	}
+	var ve *Error
+	if errors.As(err, &ve) && ve.Rule != "grounding" {
+		t.Errorf("rule = %q, want grounding", ve.Rule)
+	}
+}
+
+func TestValidateGrounded_RejectsStitchedRow(t *testing.T) {
+	src := revenueSource()
+	s := barSpec()
+	// month from row 1, revenue from row 2 — a Frankenstein row.
+	s.Data = []map[string]any{{"month": "2024-01", "revenue": 150.0}}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("row stitched from two preview rows should be rejected")
+	}
+}
+
+func TestValidateGrounded_RejectsTruncatedSource(t *testing.T) {
+	src := revenueSource()
+	src.Truncated = true
+	if err := ValidateGrounded(barSpec(), src, DefaultCaps); err == nil {
+		t.Error("truncated source must not ground a chart")
+	}
+}
+
+func TestValidateGrounded_RejectsUnknownColumn(t *testing.T) {
+	src := revenueSource()
+	s := barSpec()
+	s.Y = []Series{{Field: "revenue"}}
+	s.X = &Axis{Field: "quarter"} // not a source column
+	s.Data = []map[string]any{{"quarter": "Q1", "revenue": 100.0}}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("charting a field the query never returned should be rejected")
+	}
+}
+
+func TestValidateGrounded_KPIProvenance(t *testing.T) {
+	src := GroundingSource{
+		StepID:  "q1",
+		Columns: []string{"total", "prev"},
+		Preview: []map[string]any{{"total": int64(460), "prev": int64(400)}},
+	}
+	ok := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 460, ValueField: "total", Delta: f64(60 - 0), DeltaField: "prev"}}
+	// delta must equal the source cell (400), not a computed 60.
+	ok.KPI.Delta = f64(400)
+	if err := ValidateGrounded(ok, src, DefaultCaps); err != nil {
+		t.Fatalf("kpi with source-backed value+delta = %v", err)
+	}
+	bad := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 999, ValueField: "total"}}
+	if err := ValidateGrounded(bad, src, DefaultCaps); err == nil {
+		t.Error("kpi value not present in the source should be rejected")
+	}
+	computed := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 460, ValueField: "total", Delta: f64(60), DeltaField: "prev"}}
+	if err := ValidateGrounded(computed, src, DefaultCaps); err == nil {
+		t.Error("kpi delta computed as (total-prev) rather than read from the source should be rejected")
+	}
+}
+
+func TestSchemaJSON_InSyncWithType(t *testing.T) {
+	var schema struct {
+		Required   []string `json:"required"`
+		Properties map[string]struct {
+			Enum []string `json:"enum"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(schemaJSON, &schema); err != nil {
+		t.Fatalf("schema.json is not valid JSON: %v", err)
+	}
+	// Every chart type constant must appear in the schema enum.
+	typeEnum := map[string]bool{}
+	for _, e := range schema.Properties["type"].Enum {
+		typeEnum[e] = true
+	}
+	for _, ct := range AllChartTypes {
+		if !typeEnum[string(ct)] {
+			t.Errorf("schema.json type enum missing %q", ct)
+		}
+	}
+	// The Go struct's required-on-the-wire fields must be marked required.
+	if !contains(schema.Required, "type") || !contains(schema.Required, "source_step_id") {
+		t.Errorf("schema.json required = %v, want type + source_step_id", schema.Required)
+	}
+	// Guard the JSON tag the whole grounding mechanism hangs on.
+	b, _ := json.Marshal(ChartSpec{Type: ChartBar, SourceStepID: "q2"})
+	if !strings.Contains(string(b), `"source_step_id":"q2"`) {
+		t.Errorf("ChartSpec JSON tag drift: %s", b)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -44,15 +44,44 @@ func barSpec() ChartSpec {
 	}
 }
 
+// scatterSpec is a valid scatter (numeric x, numeric y).
+func scatterSpec() ChartSpec {
+	return ChartSpec{
+		Type:         ChartScatter,
+		X:            &Axis{Field: "qty", Type: AxisNumber},
+		Y:            []Series{{Field: "price"}},
+		SourceStepID: "q1",
+		Data: []map[string]any{
+			{"qty": 2.0, "price": 10.0},
+			{"qty": 5.0, "price": 22.0},
+		},
+	}
+}
+
+func TestValidate_RejectsNonNumericScatterX(t *testing.T) {
+	// A scatter over string x (or a declared number x-axis over strings) must be
+	// rejected — a numeric axis over labels renders blank/mis-scaled.
+	s := barSpec()
+	s.Type = ChartScatter // month strings on x
+	if err := Validate(s, DefaultCaps); err == nil {
+		t.Error("scatter with non-numeric x must be rejected")
+	}
+	s2 := barSpec()
+	s2.X = &Axis{Field: "month", Type: AxisNumber}
+	if err := Validate(s2, DefaultCaps); err == nil {
+		t.Error("a number x-axis over string values must be rejected")
+	}
+}
+
 func TestValidate_Valid(t *testing.T) {
 	for _, spec := range []ChartSpec{
 		barSpec(),
 		func() ChartSpec { s := barSpec(); s.Type = ChartLine; return s }(),
 		func() ChartSpec { s := barSpec(); s.Type = ChartArea; s.Stacked = boolp(true); return s }(),
-		func() ChartSpec { s := barSpec(); s.Type = ChartScatter; return s }(),
+		scatterSpec(),
 		{
 			Type: ChartKPI, Title: "Total", SourceStepID: "q2",
-			KPI: &KPI{Value: 460, Unit: "USD", ValueField: "revenue"},
+			KPI: &KPI{Value: f64(460), Unit: "USD", ValueField: "revenue"},
 		},
 	} {
 		if err := Validate(spec, DefaultCaps); err != nil {
@@ -236,7 +265,7 @@ func TestValidateGrounded_RejectsAlteredNonPlottedColumn(t *testing.T) {
 }
 
 func TestValidate_KPIDeltaRequiresDeltaField(t *testing.T) {
-	s := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 460, ValueField: "total", Delta: f64(60)}}
+	s := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: f64(460), ValueField: "total", Delta: f64(60)}}
 	err := Validate(s, DefaultCaps)
 	if err == nil {
 		t.Fatal("a KPI delta without delta_field must be rejected")
@@ -293,12 +322,30 @@ func TestValidateGrounded_ExactNumbersNoLargeTolerance(t *testing.T) {
 	}
 }
 
+func TestValidate_KPIValueRequired(t *testing.T) {
+	// A KPI with no value (omitted in JSON → nil pointer) must be rejected, not
+	// silently treated as 0.
+	s := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{ValueField: "total"}}
+	err := Validate(s, DefaultCaps)
+	if err == nil {
+		t.Fatal("a kpi with no value must be rejected")
+	}
+	var ve *Error
+	if errors.As(err, &ve) && ve.Field != "kpi.value" {
+		t.Errorf("field = %q, want kpi.value", ve.Field)
+	}
+	// The same missing value via Decode (JSON omits it) is rejected too.
+	if _, derr := Decode([]byte(`{"type":"kpi","source_step_id":"q1","kpi":{"value_field":"total"}}`), DefaultCaps); derr == nil {
+		t.Error("Decode of a kpi with no value must be rejected")
+	}
+}
+
 func TestValidate_KPIRejectsDataArray(t *testing.T) {
 	// A KPI must not carry a data array — the KPI grounding path never inspects
 	// it, so it would be an ungrounded, uncapped smuggling channel.
 	s := ChartSpec{
 		Type: ChartKPI, SourceStepID: "q1",
-		KPI:  &KPI{Value: 460, ValueField: "total"},
+		KPI:  &KPI{Value: f64(460), ValueField: "total"},
 		Data: []map[string]any{{"x": "a", "invented": 999.0}},
 	}
 	err := Validate(s, DefaultCaps)
@@ -378,7 +425,7 @@ func TestValidateGrounded_KPIRejectsBeyondFloat64Precision(t *testing.T) {
 		Columns: []string{"total"},
 		Preview: []map[string]any{{"total": int64(9007199254740993)}},
 	}
-	s := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 9007199254740993, ValueField: "total"}}
+	s := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: f64(9007199254740993), ValueField: "total"}}
 	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
 		t.Error("a KPI figure beyond float64's exact-integer range must be rejected")
 	}
@@ -390,17 +437,17 @@ func TestValidateGrounded_KPIProvenance(t *testing.T) {
 		Columns: []string{"total", "prev"},
 		Preview: []map[string]any{{"total": int64(460), "prev": int64(400)}},
 	}
-	ok := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 460, ValueField: "total", Delta: f64(60 - 0), DeltaField: "prev"}}
+	ok := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: f64(460), ValueField: "total", Delta: f64(60 - 0), DeltaField: "prev"}}
 	// delta must equal the source cell (400), not a computed 60.
 	ok.KPI.Delta = f64(400)
 	if err := ValidateGrounded(ok, src, DefaultCaps); err != nil {
 		t.Fatalf("kpi with source-backed value+delta = %v", err)
 	}
-	bad := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 999, ValueField: "total"}}
+	bad := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: f64(999), ValueField: "total"}}
 	if err := ValidateGrounded(bad, src, DefaultCaps); err == nil {
 		t.Error("kpi value not present in the source should be rejected")
 	}
-	computed := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 460, ValueField: "total", Delta: f64(60), DeltaField: "prev"}}
+	computed := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: f64(460), ValueField: "total", Delta: f64(60), DeltaField: "prev"}}
 	if err := ValidateGrounded(computed, src, DefaultCaps); err == nil {
 		t.Error("kpi delta computed as (total-prev) rather than read from the source should be rejected")
 	}

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -372,6 +372,18 @@ func TestValidateGrounded_ExactDecimalMatches(t *testing.T) {
 	}
 }
 
+func TestValidateGrounded_KPIRejectsBeyondFloat64Precision(t *testing.T) {
+	src := GroundingSource{
+		StepID:  "q1",
+		Columns: []string{"total"},
+		Preview: []map[string]any{{"total": int64(9007199254740993)}},
+	}
+	s := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 9007199254740993, ValueField: "total"}}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("a KPI figure beyond float64's exact-integer range must be rejected")
+	}
+}
+
 func TestValidateGrounded_KPIProvenance(t *testing.T) {
 	src := GroundingSource{
 		StepID:  "q1",

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -293,6 +293,46 @@ func TestValidateGrounded_ExactNumbersNoLargeTolerance(t *testing.T) {
 	}
 }
 
+func TestValidate_KPIRejectsDataArray(t *testing.T) {
+	// A KPI must not carry a data array — the KPI grounding path never inspects
+	// it, so it would be an ungrounded, uncapped smuggling channel.
+	s := ChartSpec{
+		Type: ChartKPI, SourceStepID: "q1",
+		KPI:  &KPI{Value: 460, ValueField: "total"},
+		Data: []map[string]any{{"x": "a", "invented": 999.0}},
+	}
+	err := Validate(s, DefaultCaps)
+	if err == nil {
+		t.Fatal("a kpi carrying a data array must be rejected")
+	}
+	var ve *Error
+	if errors.As(err, &ve) && ve.Field != "data" {
+		t.Errorf("field = %q, want data", ve.Field)
+	}
+}
+
+func TestValidateGrounded_RejectsDuplicatedSourceRow(t *testing.T) {
+	// The source has 3 distinct rows; repeating one of them 4× must be rejected —
+	// the chart data is a sub-multiset of the preview, not an unbounded subset.
+	src := revenueSource()
+	s := barSpec()
+	s.Data = []map[string]any{
+		{"month": "2024-01", "revenue": 100.0},
+		{"month": "2024-01", "revenue": 100.0},
+	}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("repeating a single source row must be rejected (row multiplicity)")
+	}
+	// Each distinct source row once is fine.
+	s.Data = []map[string]any{
+		{"month": "2024-01", "revenue": 100.0},
+		{"month": "2024-02", "revenue": 150.0},
+	}
+	if err := ValidateGrounded(s, src, DefaultCaps); err != nil {
+		t.Errorf("distinct source rows should ground: %v", err)
+	}
+}
+
 func TestValidateGrounded_KPIProvenance(t *testing.T) {
 	src := GroundingSource{
 		StepID:  "q1",

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -209,6 +209,90 @@ func TestValidateGrounded_RejectsUnknownColumn(t *testing.T) {
 	}
 }
 
+func TestValidateGrounded_RejectsInventedExtraKey(t *testing.T) {
+	src := revenueSource()
+	s := barSpec()
+	// A real month/revenue projection with an extra invented column smuggled in.
+	s.Data = []map[string]any{{"month": "2024-01", "revenue": 100.0, "invented": 999.0}}
+	err := ValidateGrounded(s, src, DefaultCaps)
+	if err == nil {
+		t.Fatal("an invented extra data key must be rejected")
+	}
+	var ve *Error
+	if errors.As(err, &ve) && ve.Rule != "grounding" {
+		t.Errorf("rule = %q, want grounding", ve.Rule)
+	}
+}
+
+func TestValidateGrounded_RejectsAlteredNonPlottedColumn(t *testing.T) {
+	src := revenueSource()
+	s := barSpec()
+	// cost is a real source column but its value here is altered — full-row
+	// projection must catch it even though cost is not plotted.
+	s.Data = []map[string]any{{"month": "2024-01", "revenue": 100.0, "cost": 999.0}}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("an altered value in a non-plotted source column must be rejected")
+	}
+}
+
+func TestValidate_KPIDeltaRequiresDeltaField(t *testing.T) {
+	s := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: 460, ValueField: "total", Delta: f64(60)}}
+	err := Validate(s, DefaultCaps)
+	if err == nil {
+		t.Fatal("a KPI delta without delta_field must be rejected")
+	}
+	var ve *Error
+	if errors.As(err, &ve) && ve.Field != "kpi.delta_field" {
+		t.Errorf("field = %q, want kpi.delta_field", ve.Field)
+	}
+}
+
+func TestValidate_SeriesByFanOutCapped(t *testing.T) {
+	caps := Caps{MaxPoints: 100, MaxSeries: 3, MaxLabelLen: 200}
+	s := ChartSpec{
+		Type: ChartBar, SourceStepID: "q1",
+		X: &Axis{Field: "month"}, Y: []Series{{Field: "revenue"}}, SeriesBy: "region",
+		Data: []map[string]any{
+			{"month": "2024-01", "region": "NA", "revenue": 1.0},
+			{"month": "2024-01", "region": "EU", "revenue": 2.0},
+			{"month": "2024-01", "region": "APAC", "revenue": 3.0},
+			{"month": "2024-01", "region": "LATAM", "revenue": 4.0},
+		},
+	}
+	// 4 distinct regions × 1 measure = 4 rendered series > MaxSeries 3.
+	if err := Validate(s, caps); err == nil {
+		t.Error("high-cardinality series_by should exceed MaxSeries")
+	}
+	// Under the cap it passes.
+	s.Data = s.Data[:2]
+	if err := Validate(s, caps); err != nil {
+		t.Errorf("2 series under the cap should pass: %v", err)
+	}
+}
+
+func TestValidateGrounded_ExactNumbersNoLargeTolerance(t *testing.T) {
+	src := GroundingSource{
+		StepID:  "q1",
+		Columns: []string{"label", "amount"},
+		Preview: []map[string]any{{"label": "total", "amount": int64(1_000_000_000_000)}},
+	}
+	s := ChartSpec{
+		Type: ChartBar, SourceStepID: "q1",
+		X: &Axis{Field: "label"}, Y: []Series{{Field: "amount"}},
+		// A trillion charted as a trillion+1000 — a relative epsilon would have
+		// let this pass; exact equality rejects it.
+		Data: []map[string]any{{"label": "total", "amount": 1_000_000_001_000.0}},
+	}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("a large number altered by ~1000 must not ground")
+	}
+	// The exact value grounds.
+	s.Data = []map[string]any{{"label": "total", "amount": 1_000_000_000_000.0}}
+	if err := ValidateGrounded(s, src, DefaultCaps); err != nil {
+		t.Errorf("the exact source value should ground: %v", err)
+	}
+}
+
 func TestValidateGrounded_KPIProvenance(t *testing.T) {
 	src := GroundingSource{
 		StepID:  "q1",

--- a/libs/go-common/policy/checker.go
+++ b/libs/go-common/policy/checker.go
@@ -114,6 +114,7 @@ const (
 	FeatureSources        = "sources_enabled"
 	FeaturePackGen        = "pack_gen_enabled"
 	FeatureDataQuery      = "data_query_enabled"
+	FeatureAskCharts      = "ask_charts_enabled"
 )
 
 // AllFeatures is the canonical, ordered list of wire flag names.
@@ -133,6 +134,7 @@ var AllFeatures = []string{
 	FeatureSources,
 	FeaturePackGen,
 	FeatureDataQuery,
+	FeatureAskCharts,
 }
 
 // Reservation kinds used in the /internal/deployments/{id}/usage/reserve/{kind}

--- a/libs/go-common/policy/policy_test.go
+++ b/libs/go-common/policy/policy_test.go
@@ -238,6 +238,7 @@ func TestAllFeatures_ContainsEveryConstant(t *testing.T) {
 		FeatureSources,
 		FeaturePackGen,
 		FeatureDataQuery,
+		FeatureAskCharts,
 	}
 	if len(AllFeatures) != len(want) {
 		t.Fatalf("AllFeatures length = %d, want %d", len(AllFeatures), len(want))
@@ -269,6 +270,7 @@ func TestNewFeatureConstants_WireStrings(t *testing.T) {
 		FeatureSources:   "sources_enabled",
 		FeaturePackGen:   "pack_gen_enabled",
 		FeatureDataQuery: "data_query_enabled",
+		FeatureAskCharts: "ask_charts_enabled",
 	}
 	for got, want := range cases {
 		if got != want {

--- a/services/agent/internal/askserve/action.go
+++ b/services/agent/internal/askserve/action.go
@@ -14,11 +14,15 @@ const (
 	actLookup         actionKind = "lookup_schema"
 	actSearch         actionKind = "search_tables"
 	actSearchInsights actionKind = "search_insights"
+	actRenderChart    actionKind = "render_chart"
 	actAnswer         actionKind = "answer"
 	actClarify        actionKind = "clarify"
 	actDecline        actionKind = "decline"
 )
 
+// terminal reports whether an action ends the turn. render_chart is NOT
+// terminal: it is an evidence-consuming side action (the model charts a prior
+// query result, then answers in a later step), so the turn continues after it.
 func (k actionKind) terminal() bool {
 	return k == actAnswer || k == actClarify || k == actDecline
 }
@@ -39,6 +43,8 @@ type turnAction struct {
 	SearchInsights string // search_insights (query)
 	InsightsLimit  int    // search_insights (optional)
 
+	Chart json.RawMessage // render_chart (the raw ChartSpec input, validated later)
+
 	Text string // answer / clarify / decline body
 }
 
@@ -58,6 +64,8 @@ type rawAction struct {
 
 	SearchInsights string `json:"search_insights"`
 	InsightsLimit  int    `json:"insights_limit"`
+
+	RenderChart json.RawMessage `json:"render_chart"`
 
 	Answer  string `json:"answer"`
 	Clarify string `json:"clarify"`
@@ -85,7 +93,18 @@ func parseTurnAction(response string) (*turnAction, error) {
 
 	act := &turnAction{Thinking: strings.TrimSpace(raw.Thinking)}
 
+	// A chart mixed with a terminal in one payload is rejected rather than
+	// silently dropped: the model must emit the chart, see it accepted, then
+	// finish in a separate step (the answer might otherwise reference a chart
+	// we have not validated). This mirrors the native path's same-batch refusal.
+	if hasChartPayload(raw.RenderChart) && (strings.TrimSpace(raw.Answer) != "" || strings.TrimSpace(raw.Decline) != "" || strings.TrimSpace(raw.Clarify) != "") {
+		return nil, fmt.Errorf("do not emit render_chart together with answer/clarify/decline — render the chart in its own step, then finish in the next")
+	}
+
 	switch {
+	case hasChartPayload(raw.RenderChart):
+		act.Kind = actRenderChart
+		act.Chart = raw.RenderChart
 	case strings.TrimSpace(raw.Answer) != "":
 		act.Kind = actAnswer
 		act.Text = strings.TrimSpace(raw.Answer)
@@ -111,9 +130,17 @@ func parseTurnAction(response string) (*turnAction, error) {
 		act.SearchInsights = strings.TrimSpace(raw.SearchInsights)
 		act.InsightsLimit = raw.InsightsLimit
 	default:
-		return nil, fmt.Errorf("action JSON has no answer, clarify, decline, query, lookup_schema, search_tables, or search_insights")
+		return nil, fmt.Errorf("action JSON has no answer, clarify, decline, query, lookup_schema, search_tables, search_insights, or render_chart")
 	}
 	return act, nil
+}
+
+// hasChartPayload reports whether a render_chart value carries an actual object
+// (not absent, not JSON null). Guards the parser against a `{"render_chart":null}`
+// stub being treated as a chart action.
+func hasChartPayload(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return s != "" && s != "null"
 }
 
 // normaliseToolEnvelope detects an Anthropic/OpenAI tool-use envelope
@@ -180,6 +207,14 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			if raw.InsightsLimit == 0 {
 				raw.InsightsLimit = in.Limit
 			}
+		}
+	case actRenderChart:
+		if hasChartPayload(raw.RenderChart) {
+			return
+		}
+		// The tool-use `input` IS the ChartSpec — capture it raw for validation.
+		if len(env.Input) > 0 {
+			raw.RenderChart = env.Input
 		}
 	case actAnswer, actClarify, actDecline:
 		var in struct {
@@ -303,7 +338,7 @@ func jsonHasActionKey(s string) bool {
 	if json.Unmarshal([]byte(s), &probe) != nil {
 		return false
 	}
-	for _, k := range []string{"answer", "clarify", "decline", "query", "lookup_schema", "search_tables", "search_insights", "name"} {
+	for _, k := range []string{"answer", "clarify", "decline", "query", "lookup_schema", "search_tables", "search_insights", "render_chart", "name"} {
 		if _, ok := probe[k]; ok {
 			return true
 		}

--- a/services/agent/internal/askserve/action.go
+++ b/services/agent/internal/askserve/action.go
@@ -93,12 +93,14 @@ func parseTurnAction(response string) (*turnAction, error) {
 
 	act := &turnAction{Thinking: strings.TrimSpace(raw.Thinking)}
 
-	// A chart mixed with a terminal in one payload is rejected rather than
-	// silently dropped: the model must emit the chart, see it accepted, then
-	// finish in a separate step (the answer might otherwise reference a chart
-	// we have not validated). This mirrors the native path's same-batch refusal.
-	if hasChartPayload(raw.RenderChart) && (strings.TrimSpace(raw.Answer) != "" || strings.TrimSpace(raw.Decline) != "" || strings.TrimSpace(raw.Clarify) != "") {
-		return nil, fmt.Errorf("do not emit render_chart together with answer/clarify/decline — render the chart in its own step, then finish in the next")
+	// A chart mixed with ANY other action in one payload is rejected rather than
+	// silently dropped: the model must emit the chart in its own step (it charts a
+	// PRIOR query result — mixing it with a fresh query would drop that query or
+	// let the chart reference a stale step, and mixing it with a terminal would
+	// finish before the chart is validated). This mirrors the native path's
+	// same-batch refusal.
+	if hasChartPayload(raw.RenderChart) && rawHasNonChartAction(&raw) {
+		return nil, fmt.Errorf("emit render_chart on its own — not together with a query, lookup, search, or answer/clarify/decline; render the chart in one step, then continue in the next")
 	}
 
 	switch {
@@ -141,6 +143,18 @@ func parseTurnAction(response string) (*turnAction, error) {
 func hasChartPayload(raw json.RawMessage) bool {
 	s := strings.TrimSpace(string(raw))
 	return s != "" && s != "null"
+}
+
+// rawHasNonChartAction reports whether the payload carries any action key other
+// than render_chart — used to reject a chart mixed with another action.
+func rawHasNonChartAction(raw *rawAction) bool {
+	return strings.TrimSpace(raw.Answer) != "" ||
+		strings.TrimSpace(raw.Decline) != "" ||
+		strings.TrimSpace(raw.Clarify) != "" ||
+		strings.TrimSpace(raw.Query) != "" ||
+		len(raw.LookupSchema) > 0 ||
+		strings.TrimSpace(raw.SearchTables) != "" ||
+		strings.TrimSpace(raw.SearchInsights) != ""
 }
 
 // normaliseToolEnvelope detects an Anthropic/OpenAI tool-use envelope

--- a/services/agent/internal/askserve/chart_test.go
+++ b/services/agent/internal/askserve/chart_test.go
@@ -169,7 +169,8 @@ func TestLoopTools_RenderChartSameBatchAsQueryRefused(t *testing.T) {
 func groundedChartState() *turnState {
 	return &turnState{
 		round:          2,
-		groundedEvents: 1, // the query already grounded the turn
+		groundedEvents: 1,    // the query already grounded the turn
+		chartsEnabled:  true, // entitled for this turn (the gate is tested separately)
 		querySummariesByID: map[string]QuerySummary{
 			"q1": {
 				Step:    "q1",
@@ -252,6 +253,27 @@ func TestExecRenderChart_HonorsMaxPerAnswer(t *testing.T) {
 	}
 	if obs == "" || obs[:19] != "chart limit reached" {
 		t.Fatalf("second chart should hit the per-answer cap, got %q", obs)
+	}
+}
+
+func TestExecRenderChart_RefusedWhenNotEntitled(t *testing.T) {
+	// The tool is only offered when charts are enabled, but the JSON-text parser
+	// accepts render_chart regardless and a provider could return an unoffered
+	// call. execRenderChart must refuse for a non-entitled turn and persist
+	// nothing — a prompt-injected chart must not become an artifact.
+	r := &runner{cfg: chartCfg(), store: &fakeStore{}}
+	st := groundedChartState()
+	st.chartsEnabled = false // entitlement absent for this turn
+	raw, _ := json.Marshal(validChartInput("q1"))
+	obs := r.execRenderChart(context.Background(), st, &turnAction{Kind: actRenderChart, Chart: raw})
+	if len(st.events) != 0 {
+		t.Fatalf("a non-entitled chart must not persist an event: %+v", st.events)
+	}
+	if st.chartsRendered != 0 {
+		t.Fatal("a non-entitled chart must not count as rendered")
+	}
+	if obs == "" {
+		t.Fatal("expected a refusal observation")
 	}
 }
 

--- a/services/agent/internal/askserve/chart_test.go
+++ b/services/agent/internal/askserve/chart_test.go
@@ -304,15 +304,24 @@ func TestParseTurnAction_RenderChart(t *testing.T) {
 	}
 }
 
-func TestParseTurnAction_RenderChartWithTerminalRejected(t *testing.T) {
-	// A chart mixed with a terminal in one payload is rejected (repair, not drop).
+func TestParseTurnAction_RenderChartWithAnyOtherActionRejected(t *testing.T) {
+	// A chart mixed with ANY other action (terminal OR a data action) is rejected
+	// rather than silently dropping the other action — matching the native batch
+	// refusal. The chart references a prior query, so it must be emitted alone.
 	for _, in := range []string{
 		`{"render_chart":{"type":"bar","source_step_id":"q1"},"answer":"done"}`,
 		`{"render_chart":{"type":"bar","source_step_id":"q1"},"decline":"x"}`,
+		`{"render_chart":{"type":"bar","source_step_id":"q1"},"query":"SELECT 1"}`,
+		`{"render_chart":{"type":"bar","source_step_id":"q1"},"search_tables":"users"}`,
+		`{"render_chart":{"type":"bar","source_step_id":"q1"},"lookup_schema":["ds.t"]}`,
 	} {
 		if _, err := parseTurnAction(in); err == nil {
-			t.Fatalf("expected rejection for chart+terminal payload: %s", in)
+			t.Fatalf("expected rejection for chart+other-action payload: %s", in)
 		}
+	}
+	// A chart on its own still parses.
+	if act, err := parseTurnAction(`{"render_chart":{"type":"bar","source_step_id":"q1"}}`); err != nil || act.Kind != actRenderChart {
+		t.Fatalf("a lone chart should parse: act=%+v err=%v", act, err)
 	}
 }
 

--- a/services/agent/internal/askserve/chart_test.go
+++ b/services/agent/internal/askserve/chart_test.go
@@ -1,0 +1,313 @@
+package askserve
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/decisionbox-io/decisionbox/libs/go-common/charts"
+	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
+	commonmodels "github.com/decisionbox-io/decisionbox/libs/go-common/models"
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/testutil"
+)
+
+// chartCfg is a tool-loop config with charting enabled (ops kill-switch on).
+func chartCfg() Config {
+	return Config{
+		MaxRounds: 8, MaxQueriesPerTurn: 6, MaxFetchRows: 1000, PreviewRows: 50,
+		ChartsEnabled: true, ChartMaxPerAnswer: 3, ChartCaps: charts.DefaultCaps,
+	}
+}
+
+// chartWarehouse returns a mock whose every query yields a small, chartable
+// month/revenue result (a category + a numeric column).
+func chartWarehouse() *testutil.MockWarehouseProvider {
+	wh := testutil.NewMockWarehouseProvider("ds")
+	wh.DefaultResult = &gowarehouse.QueryResult{
+		Columns: []string{"month", "revenue"},
+		Rows: []map[string]interface{}{
+			{"month": "2024-01", "revenue": int64(100)},
+			{"month": "2024-02", "revenue": int64(150)},
+			{"month": "2024-03", "revenue": int64(210)},
+		},
+	}
+	return wh
+}
+
+// validChartInput is a bar chart grounded in the chartWarehouse month/revenue
+// preview, sourced from step `step`.
+func validChartInput(step string) map[string]any {
+	return map[string]any{
+		"type":           "bar",
+		"title":          "Revenue by month",
+		"source_step_id": step,
+		"x":              map[string]any{"field": "month", "type": "category"},
+		"y":              []any{map[string]any{"field": "revenue"}},
+		"data": []any{
+			map[string]any{"month": "2024-01", "revenue": 100},
+			map[string]any{"month": "2024-02", "revenue": 150},
+			map[string]any{"month": "2024-03", "revenue": 210},
+		},
+	}
+}
+
+// runOnceToolsCharts runs a native-tool turn with EnableCharts set on the wire.
+func runOnceToolsCharts(t *testing.T, p *scriptedToolProvider, wh *testutil.MockWarehouseProvider) *fakeStore {
+	t.Helper()
+	store := &fakeStore{}
+	r := &runner{cfg: chartCfg(), store: store}
+	rt := toolRuntime(p, wh, nil, "")
+	r.run(context.Background(), rt, TurnRequest{TurnID: "t1", SessionID: "s1", ProjectID: "p1", Question: "revenue by month?", EnableCharts: true})
+	if store.final == nil {
+		t.Fatal("turn did not finalize")
+	}
+	return store
+}
+
+func TestLoopTools_ChartOfferedOnlyWhenEnabledAndChartable(t *testing.T) {
+	// Round 1 is ungrounded (no query yet) → render_chart withheld. Round 2, after
+	// a non-truncated query, render_chart is offered.
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT month, revenue FROM ds.t"}),
+		toolCall(string(actAnswer), map[string]any{"text": "done"}),
+	}}
+	runOnceToolsCharts(t, p, chartWarehouse())
+	if hasTool(p.reqs[0].Tools, string(actRenderChart)) {
+		t.Fatal("render_chart must not be offered before any chartable query")
+	}
+	if !hasTool(p.reqs[1].Tools, string(actRenderChart)) {
+		t.Fatal("render_chart should be offered after a non-truncated query")
+	}
+}
+
+func TestLoopTools_ChartGateOffWithoutCapability(t *testing.T) {
+	// ChartsEnabled true but the caller did NOT set EnableCharts → the tool stays
+	// dark. This is the enterprise-only entitlement gate (a checker-less agent
+	// must not leak the tool).
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT month, revenue FROM ds.t"}),
+		toolCall(string(actAnswer), map[string]any{"text": "done"}),
+	}}
+	store := &fakeStore{}
+	r := &runner{cfg: chartCfg(), store: store}
+	rt := toolRuntime(p, chartWarehouse(), nil, "")
+	// EnableCharts intentionally left false.
+	r.run(context.Background(), rt, TurnRequest{TurnID: "t1", SessionID: "s1", ProjectID: "p1", Question: "q"})
+	for i, req := range p.reqs {
+		if hasTool(req.Tools, string(actRenderChart)) {
+			t.Fatalf("render_chart offered on round %d despite EnableCharts=false", i+1)
+		}
+	}
+}
+
+func TestLoopTools_RenderChartGroundsAndPersists(t *testing.T) {
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT month, revenue FROM ds.t"}),
+		toolCall(string(actRenderChart), validChartInput("q1")),
+		toolCall(string(actAnswer), map[string]any{"text": "revenue rose month over month"}),
+	}}
+	store := runOnceToolsCharts(t, p, chartWarehouse())
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q", store.final.Status)
+	}
+	if len(store.events) != 2 {
+		t.Fatalf("events = %d, want query_data + render_chart", len(store.events))
+	}
+	ce := store.events[1]
+	if ce.Name != string(actRenderChart) || ce.Error != "" {
+		t.Fatalf("render_chart event = %+v", ce)
+	}
+	spec, ok := ce.Output.(charts.ChartSpec)
+	if !ok {
+		t.Fatalf("render_chart Output is %T, want charts.ChartSpec", ce.Output)
+	}
+	if spec.Type != charts.ChartBar || spec.SourceStepID != "q1" || len(spec.Data) != 3 {
+		t.Fatalf("persisted spec wrong: %+v", spec)
+	}
+	if ce.Args["source_step_id"] != "q1" {
+		t.Fatalf("render_chart args missing source ref: %+v", ce.Args)
+	}
+}
+
+func TestLoopTools_RenderChartSameBatchAsQueryRefused(t *testing.T) {
+	// A render_chart emitted in the SAME batch as a query is refused — charts may
+	// only reference a prior-round, already-observed result.
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		toolCall(string(actQuery), map[string]any{"query": "SELECT month, revenue FROM ds.t"}),
+		{
+			StopReason: "tool_use",
+			ToolCalls: []gollm.ToolCall{
+				{ID: "q2", Name: string(actQuery), Input: map[string]any{"query": "SELECT month, revenue FROM ds.u"}},
+				{ID: "c1", Name: string(actRenderChart), Input: validChartInput("q1")},
+			},
+			Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5},
+		},
+		toolCall(string(actAnswer), map[string]any{"text": "done"}),
+	}}
+	store := runOnceToolsCharts(t, p, chartWarehouse())
+	// Only the two queries ran; the batched chart was refused (no chart event).
+	for _, ev := range store.events {
+		if ev.Name == string(actRenderChart) {
+			t.Fatalf("render_chart in a query batch should have been refused, not executed: %+v", ev)
+		}
+	}
+	round2Results := p.reqs[2].Messages[len(p.reqs[2].Messages)-1].ToolResults
+	var refused bool
+	for _, tr := range round2Results {
+		if tr.CallID == "c1" && tr.IsError {
+			refused = true
+		}
+	}
+	if !refused {
+		t.Fatal("the batched render_chart call should receive an error tool_result")
+	}
+}
+
+// --- direct execRenderChart unit tests (grounding, self-heal, non-grounding, caps) ---
+
+func groundedChartState() *turnState {
+	return &turnState{
+		round:          2,
+		groundedEvents: 1, // the query already grounded the turn
+		querySummariesByID: map[string]QuerySummary{
+			"q1": {
+				Step:    "q1",
+				Columns: []string{"month", "revenue"},
+				Preview: []map[string]interface{}{
+					{"month": "2024-01", "revenue": int64(100)},
+					{"month": "2024-02", "revenue": int64(150)},
+					{"month": "2024-03", "revenue": int64(210)},
+				},
+			},
+		},
+	}
+}
+
+func TestExecRenderChart_AcceptsGroundedDoesNotGround(t *testing.T) {
+	r := &runner{cfg: chartCfg(), store: &fakeStore{}}
+	st := groundedChartState()
+	raw, _ := json.Marshal(validChartInput("q1"))
+	obs := r.execRenderChart(context.Background(), st, &turnAction{Kind: actRenderChart, Chart: raw})
+	if st.chartsRendered != 1 {
+		t.Fatalf("chartsRendered = %d, want 1", st.chartsRendered)
+	}
+	// A chart consumes evidence, it does not produce it — groundedEvents unchanged.
+	if st.groundedEvents != 1 {
+		t.Fatalf("render_chart must not ground: groundedEvents = %d, want 1", st.groundedEvents)
+	}
+	if len(st.events) != 1 || st.events[0].Error != "" || st.events[0].Output == nil {
+		t.Fatalf("expected one accepted chart event, got %+v", st.events)
+	}
+	if got := st.events[0].Name; got != string(actRenderChart) {
+		t.Fatalf("event name = %q", got)
+	}
+	_ = obs
+}
+
+func TestExecRenderChart_RejectsDerivedNumberAndSelfHeals(t *testing.T) {
+	r := &runner{cfg: chartCfg(), store: &fakeStore{}}
+	st := groundedChartState()
+	bad := validChartInput("q1")
+	bad["data"] = []any{map[string]any{"month": "2024-01", "revenue": 999}} // not an observed cell
+	raw, _ := json.Marshal(bad)
+	obs := r.execRenderChart(context.Background(), st, &turnAction{Kind: actRenderChart, Chart: raw})
+	if st.chartsRendered != 0 {
+		t.Fatalf("a rejected chart must not count: chartsRendered = %d", st.chartsRendered)
+	}
+	if len(st.events) != 1 || st.events[0].Error == "" {
+		t.Fatalf("rejected chart should persist an error event: %+v", st.events)
+	}
+	if st.groundedEvents != 1 {
+		t.Fatalf("rejected chart must not change grounding: %d", st.groundedEvents)
+	}
+	if obs == "" || obs[:14] != "Chart rejected" {
+		t.Fatalf("observation should be a repair prompt, got %q", obs)
+	}
+}
+
+func TestExecRenderChart_RejectsUnknownSourceStep(t *testing.T) {
+	r := &runner{cfg: chartCfg(), store: &fakeStore{}}
+	st := groundedChartState()
+	raw, _ := json.Marshal(validChartInput("q7")) // no such step
+	r.execRenderChart(context.Background(), st, &turnAction{Kind: actRenderChart, Chart: raw})
+	if len(st.events) != 1 || st.events[0].Error == "" {
+		t.Fatalf("unknown source step should be rejected: %+v", st.events)
+	}
+	if st.chartsRendered != 0 {
+		t.Fatal("unknown-source chart must not count as rendered")
+	}
+}
+
+func TestExecRenderChart_HonorsMaxPerAnswer(t *testing.T) {
+	cfg := chartCfg()
+	cfg.ChartMaxPerAnswer = 1
+	r := &runner{cfg: cfg, store: &fakeStore{}}
+	st := groundedChartState()
+	raw, _ := json.Marshal(validChartInput("q1"))
+	r.execRenderChart(context.Background(), st, &turnAction{Kind: actRenderChart, Chart: raw})
+	obs := r.execRenderChart(context.Background(), st, &turnAction{Kind: actRenderChart, Chart: raw})
+	if st.chartsRendered != 1 {
+		t.Fatalf("chart cap not enforced: chartsRendered = %d, want 1", st.chartsRendered)
+	}
+	if obs == "" || obs[:19] != "chart limit reached" {
+		t.Fatalf("second chart should hit the per-answer cap, got %q", obs)
+	}
+}
+
+// --- native + text parity for render_chart parsing ---
+
+func TestParseTurnAction_RenderChart(t *testing.T) {
+	// Plain key form (JSON-text fallback path).
+	act, err := parseTurnAction(`{"render_chart":{"type":"bar","source_step_id":"q2","x":{"field":"m"},"y":[{"field":"v"}],"data":[{"m":"a","v":1}]}}`)
+	if err != nil {
+		t.Fatalf("parse err = %v", err)
+	}
+	if act.Kind != actRenderChart || len(act.Chart) == 0 {
+		t.Fatalf("parsed = %+v", act)
+	}
+	// The captured raw chart must decode to a spec.
+	var probe map[string]any
+	if json.Unmarshal(act.Chart, &probe) != nil || probe["source_step_id"] != "q2" {
+		t.Fatalf("act.Chart not the chart object: %s", act.Chart)
+	}
+
+	// Tool-use envelope form.
+	act, err = parseTurnAction(`{"name":"render_chart","input":{"type":"kpi","source_step_id":"q1","kpi":{"value":5,"value_field":"c"}}}`)
+	if err != nil {
+		t.Fatalf("envelope err = %v", err)
+	}
+	if act.Kind != actRenderChart {
+		t.Fatalf("envelope kind = %q", act.Kind)
+	}
+}
+
+func TestParseTurnAction_RenderChartWithTerminalRejected(t *testing.T) {
+	// A chart mixed with a terminal in one payload is rejected (repair, not drop).
+	for _, in := range []string{
+		`{"render_chart":{"type":"bar","source_step_id":"q1"},"answer":"done"}`,
+		`{"render_chart":{"type":"bar","source_step_id":"q1"},"decline":"x"}`,
+	} {
+		if _, err := parseTurnAction(in); err == nil {
+			t.Fatalf("expected rejection for chart+terminal payload: %s", in)
+		}
+	}
+}
+
+func TestToolCallToAction_RenderChart(t *testing.T) {
+	tc := gollm.ToolCall{ID: "c1", Name: string(actRenderChart), Input: validChartInput("q2")}
+	act, err := toolCallToAction(tc)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if act.Kind != actRenderChart {
+		t.Fatalf("kind = %q", act.Kind)
+	}
+	spec, err := charts.Decode(act.Chart, charts.DefaultCaps)
+	if err != nil {
+		t.Fatalf("captured chart did not decode: %v", err)
+	}
+	if spec.SourceStepID != "q2" {
+		t.Fatalf("decoded source = %q", spec.SourceStepID)
+	}
+}

--- a/services/agent/internal/askserve/config.go
+++ b/services/agent/internal/askserve/config.go
@@ -15,6 +15,7 @@ package askserve
 import (
 	"time"
 
+	"github.com/decisionbox-io/decisionbox/libs/go-common/charts"
 	goconfig "github.com/decisionbox-io/decisionbox/libs/go-common/config"
 )
 
@@ -35,6 +36,15 @@ const (
 	EnvHistoryCharBudget   = "ASK_SERVE_HISTORY_CHAR_BUDGET"
 	EnvTurnTTLSeconds      = "ASK_SERVE_TURN_TTL_SECONDS"
 	EnvConnectTimeoutSecs  = "ASK_SERVE_CONNECT_TIMEOUT_SECONDS"
+
+	// Chart rendering (render_chart tool). Off by default — an ops kill-switch
+	// on top of the per-turn EnableCharts capability the caller must also set.
+	EnvChartsEnabled       = "ASK_SERVE_CHARTS_ENABLED"
+	EnvChartsMaxPoints     = "ASK_SERVE_CHARTS_MAX_POINTS"
+	EnvChartsMaxSeries     = "ASK_SERVE_CHARTS_MAX_SERIES"
+	EnvChartsMaxPerAnswer  = "ASK_SERVE_CHARTS_MAX_PER_ANSWER"
+	EnvChartsMaxSpecBytes  = "ASK_SERVE_CHARTS_MAX_SPEC_BYTES"
+	EnvChartsMaxLabelLen   = "ASK_SERVE_CHARTS_MAX_LABEL_LEN"
 )
 
 // Defaults match the reviewed plan. A single enterprise query can run for
@@ -66,6 +76,13 @@ const (
 	// connect + ValidateReadOnly + schema load). Kept separate from the turn
 	// budget so a misconfigured project fails fast instead of hanging a turn.
 	defaultConnectTimeout = 60 * time.Second
+
+	// Chart caps. MaxPoints defaults to PreviewRows (a chart is grounded against
+	// the query preview, so it can never carry more points than the preview has).
+	defaultChartsMaxSeries    = 8
+	defaultChartsMaxPerAnswer = 3
+	defaultChartsMaxSpecBytes = 32768
+	defaultChartsMaxLabelLen  = 120
 )
 
 // Config holds the serve-mode budgets and limits, all sourced from the
@@ -90,15 +107,23 @@ type Config struct {
 	HistoryCharBudget int
 	TurnTTL           time.Duration
 	ConnectTimeout    time.Duration
+
+	// ChartsEnabled is the ops kill-switch for the render_chart tool. Even when
+	// true, a turn only sees the tool if the caller also set EnableCharts on the
+	// request (the enterprise entitlement gate) — see loop.go.
+	ChartsEnabled     bool
+	ChartMaxPerAnswer int
+	ChartCaps         charts.Caps
 }
 
 // LoadConfig reads the ASK_SERVE_* environment into a Config, applying
 // defaults for any unset or invalid value.
 func LoadConfig() Config {
+	previewRows := positive(goconfig.GetEnvAsInt(EnvPreviewRows, defaultPreviewRows), defaultPreviewRows)
 	return Config{
 		Port:                    goconfig.GetEnvAsInt(EnvPort, defaultPort),
 		MaxFetchRows:            positive(goconfig.GetEnvAsInt(EnvMaxFetchRows, defaultMaxFetchRows), defaultMaxFetchRows),
-		PreviewRows:             positive(goconfig.GetEnvAsInt(EnvPreviewRows, defaultPreviewRows), defaultPreviewRows),
+		PreviewRows:             previewRows,
 		MaxQueriesPerTurn:       positive(goconfig.GetEnvAsInt(EnvMaxQueriesPerTurn, defaultMaxQueriesPerTurn), defaultMaxQueriesPerTurn),
 		MaxRounds:               positive(goconfig.GetEnvAsInt(EnvMaxRounds, defaultMaxRounds), defaultMaxRounds),
 		WallClock:               durationFromSeconds(EnvWallClockSeconds, defaultWallClock),
@@ -110,6 +135,17 @@ func LoadConfig() Config {
 		HistoryCharBudget:       positive(goconfig.GetEnvAsInt(EnvHistoryCharBudget, defaultHistoryCharBudget), defaultHistoryCharBudget),
 		TurnTTL:                 durationFromSeconds(EnvTurnTTLSeconds, defaultTurnTTL),
 		ConnectTimeout:          durationFromSeconds(EnvConnectTimeoutSecs, defaultConnectTimeout),
+
+		ChartsEnabled:     goconfig.GetEnvAsBool(EnvChartsEnabled, false),
+		ChartMaxPerAnswer: positive(goconfig.GetEnvAsInt(EnvChartsMaxPerAnswer, defaultChartsMaxPerAnswer), defaultChartsMaxPerAnswer),
+		ChartCaps: charts.Caps{
+			// MaxPoints defaults to the preview row count: a grounded chart can
+			// never carry more points than the preview it projects from.
+			MaxPoints:    positive(goconfig.GetEnvAsInt(EnvChartsMaxPoints, previewRows), previewRows),
+			MaxSeries:    positive(goconfig.GetEnvAsInt(EnvChartsMaxSeries, defaultChartsMaxSeries), defaultChartsMaxSeries),
+			MaxSpecBytes: positive(goconfig.GetEnvAsInt(EnvChartsMaxSpecBytes, defaultChartsMaxSpecBytes), defaultChartsMaxSpecBytes),
+			MaxLabelLen:  positive(goconfig.GetEnvAsInt(EnvChartsMaxLabelLen, defaultChartsMaxLabelLen), defaultChartsMaxLabelLen),
+		},
 	}
 }
 

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -75,6 +75,11 @@ type turnState struct {
 	// querySummariesByID maps a step id to the query summary the chart validator
 	// grounds against, for O(1) lookup of a chart's referenced source.
 	querySummariesByID map[string]QuerySummary
+	// chartsEnabled is the per-turn entitlement (caller EnableCharts AND the ops
+	// kill-switch). It gates EXECUTION, not just tool offering: the text-fallback
+	// parser accepts render_chart regardless, and a provider can return an
+	// unoffered tool call, so execRenderChart must recheck this.
+	chartsEnabled bool
 }
 
 // maxGroundingNudges bounds how many times the loop re-prompts a model that
@@ -124,6 +129,7 @@ func toolsSupported(rt *ProjectRuntime) bool {
 func (r *runner) runText(ctx context.Context, rt *ProjectRuntime, req TurnRequest, tokensIn, tokensOut int) {
 	st := &turnState{req: req, client: rt.AIClient, model: rt.Model, tokensIn: tokensIn, tokensOut: tokensOut}
 	chartsEnabled := req.EnableCharts && r.cfg.ChartsEnabled
+	st.chartsEnabled = chartsEnabled
 
 	conv := ai.NewConversation(ai.ConversationOptions{
 		SystemPrompt: buildSystemPrompt(rt, r.cfg, chartsEnabled),
@@ -267,6 +273,7 @@ func (st *turnState) callModel(ctx context.Context, conv *ai.Conversation, r *ru
 func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
 	st := &turnState{req: req, client: rt.AIClient, model: rt.Model}
 	chartsEnabled := req.EnableCharts && r.cfg.ChartsEnabled
+	st.chartsEnabled = chartsEnabled
 	system := buildSystemPromptForTools(rt, r.cfg, chartsEnabled)
 	hasSchema := rt.SchemaProvider != nil
 	hasInsights := rt.InsightsProvider != nil
@@ -541,6 +548,15 @@ func (r *runner) execQuery(ctx context.Context, rt *ProjectRuntime, st *turnStat
 // path (no separate machinery). It grounds against the referenced query's
 // preview: the chart data must be an exact projection of cells already observed.
 func (r *runner) execRenderChart(ctx context.Context, st *turnState, act *turnAction) string {
+	// Entitlement gate — defense in depth. render_chart is only OFFERED when
+	// charts are enabled for the turn, but the JSON-text parser accepts it
+	// regardless and a provider could return an unoffered tool call. Never
+	// execute or persist a chart for a non-entitled turn (nothing is emitted, so
+	// no artifact is created).
+	if !st.chartsEnabled {
+		return "render_chart is not available for this turn; do not call it — answer with prose."
+	}
+
 	ev := commonmodels.ToolEvent{Round: st.round, Name: string(actRenderChart)}
 
 	if r.cfg.ChartMaxPerAnswer > 0 && st.chartsRendered >= r.cfg.ChartMaxPerAnswer {

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/decisionbox-io/decisionbox/libs/go-common/charts"
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
 	commonmodels "github.com/decisionbox-io/decisionbox/libs/go-common/models"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/ai"
@@ -52,12 +53,28 @@ type turnState struct {
 	// groundedEvents counts evidence tool events that SUCCEEDED (no error). The
 	// native-tools loop grounds on this, not on len(events): a failed query /
 	// rejected tenant filter / unavailable schema search records an event but
-	// observed no data, so it must not unlock the answer tool.
+	// observed no data, so it must not unlock the answer tool. render_chart is
+	// deliberately NOT evidence — a chart consumes a query result, it does not
+	// produce one — so a successful render_chart never increments this (see emit).
 	groundedEvents int
 	// insightHits accumulates the insights/recommendations surfaced by
 	// search_insights across the turn, mapped to the message's Sources at
 	// finalize so the dashboard renders them as citations.
 	insightHits []ai.InsightHit
+
+	// queryStepSeq is a monotonic counter assigning each successful query a
+	// unique step id ("q1", "q2", …) the model references as a chart's
+	// source_step_id. Round is not unique (native mode batches queries), so a
+	// separate sequence is needed.
+	queryStepSeq int
+	// queriesChartable counts successful, non-truncated queries — a chart needs
+	// at least one to ground against, and only these can be its source.
+	queriesChartable int
+	// chartsRendered counts accepted render_chart events (for the per-answer cap).
+	chartsRendered int
+	// querySummariesByID maps a step id to the query summary the chart validator
+	// grounds against, for O(1) lookup of a chart's referenced source.
+	querySummariesByID map[string]QuerySummary
 }
 
 // maxGroundingNudges bounds how many times the loop re-prompts a model that
@@ -106,9 +123,10 @@ func toolsSupported(rt *ProjectRuntime) bool {
 // decline rather than emit an ungrounded answer) is the safety net there.
 func (r *runner) runText(ctx context.Context, rt *ProjectRuntime, req TurnRequest, tokensIn, tokensOut int) {
 	st := &turnState{req: req, client: rt.AIClient, model: rt.Model, tokensIn: tokensIn, tokensOut: tokensOut}
+	chartsEnabled := req.EnableCharts && r.cfg.ChartsEnabled
 
 	conv := ai.NewConversation(ai.ConversationOptions{
-		SystemPrompt: buildSystemPrompt(rt, r.cfg),
+		SystemPrompt: buildSystemPrompt(rt, r.cfg, chartsEnabled),
 		// Two messages per step (assistant action + observation) across the
 		// round budget, plus history headroom — generous so the engine's own
 		// caps, not this ceiling, bound the turn.
@@ -140,9 +158,12 @@ func (r *runner) runText(ctx context.Context, rt *ProjectRuntime, req TurnReques
 			// query / lookup / search) is ungrounded — the model fabricated it.
 			// Re-nudge it to gather evidence; if it still refuses after
 			// maxGroundingNudges, DECLINE rather than emit fabricated content.
-			// Any tool event (even a schema lookup) counts as grounding;
-			// clarify / decline need no data and are always accepted.
-			if act.Kind == actAnswer && len(st.events) == 0 {
+			// Any successful evidence event (even a schema lookup) counts as
+			// grounding; clarify / decline need no data and are always accepted.
+			// We test groundedEvents, not len(events): a failed query or a
+			// rejected render_chart records an event but observed no data, so it
+			// must not unlock an ungrounded answer.
+			if act.Kind == actAnswer && st.groundedEvents == 0 {
 				if st.groundingNudges < maxGroundingNudges {
 					st.groundingNudges++
 					conv.AddUserMessage(groundingNudge)
@@ -166,9 +187,9 @@ func (r *runner) runText(ctx context.Context, rt *ProjectRuntime, req TurnReques
 	// Round budget exhausted without a terminal action. Give the model one
 	// final, non-tool synthesis chance to answer with what it has gathered.
 	if act := r.synthesizeFinal(ctx, conv, st); act != nil {
-		// Still enforce grounding: a synthesized answer with no tool activity
-		// is fabricated — decline instead of emitting it.
-		if act.Kind == actAnswer && len(st.events) == 0 {
+		// Still enforce grounding: a synthesized answer with no successful
+		// evidence is fabricated — decline instead of emitting it.
+		if act.Kind == actAnswer && st.groundedEvents == 0 {
 			r.finishUngrounded(ctx, st)
 			return
 		}
@@ -245,7 +266,8 @@ func (st *turnState) callModel(ctx context.Context, conv *ai.Conversation, r *ru
 // blocks.
 func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnRequest) {
 	st := &turnState{req: req, client: rt.AIClient, model: rt.Model}
-	system := buildSystemPromptForTools(rt, r.cfg)
+	chartsEnabled := req.EnableCharts && r.cfg.ChartsEnabled
+	system := buildSystemPromptForTools(rt, r.cfg, chartsEnabled)
 	hasSchema := rt.SchemaProvider != nil
 	hasInsights := rt.InsightsProvider != nil
 
@@ -262,7 +284,7 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 		}
 
 		grounded := st.groundedEvents > 0
-		resp, err := st.callModelTools(ctx, messages, system, toolsForPhase(grounded, hasSchema, hasInsights), toolChoiceForPhase(grounded))
+		resp, err := st.callModelTools(ctx, messages, system, toolsForPhase(grounded, hasSchema, hasInsights, chartsEnabled, st.queriesChartable > 0), toolChoiceForPhase(grounded))
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				r.finishTimeout(ctx, st)
@@ -332,11 +354,27 @@ func (r *runner) runWithTools(ctx context.Context, rt *ProjectRuntime, req TurnR
 		// provider correlates each tool_result to its tool_use by id. A malformed
 		// call yields an error result without running (so it never emits a
 		// spuriously grounding event); a terminal call mixed into the batch is
-		// refused so the model reviews the data before finishing.
+		// refused so the model reviews the data before finishing; a render_chart
+		// mixed with the query it would chart (or with a terminal) is refused so
+		// charts only ever reference a prior-round, already-observed result.
+		batchHasQuery, batchHasTerminal := false, false
+		for _, tc := range resp.ToolCalls {
+			k := actionKind(tc.Name)
+			if k == actQuery {
+				batchHasQuery = true
+			}
+			if k.terminal() {
+				batchHasTerminal = true
+			}
+		}
 		results := make([]gollm.ToolResult, 0, len(resp.ToolCalls))
 		for _, tc := range resp.ToolCalls {
 			if actionKind(tc.Name).terminal() {
 				results = append(results, gollm.ToolResult{CallID: tc.ID, Content: "Do not finish in the same step as a data tool. Review the query results first, then call answer/clarify/decline on its own.", IsError: true})
+				continue
+			}
+			if actionKind(tc.Name) == actRenderChart && (batchHasQuery || batchHasTerminal) {
+				results = append(results, gollm.ToolResult{CallID: tc.ID, Content: "Call render_chart in its own step, after the query result is in — not together with a query or with answer/clarify/decline.", IsError: true})
 				continue
 			}
 			act, aerr := toolCallToAction(tc)
@@ -427,6 +465,8 @@ func (r *runner) execute(ctx context.Context, rt *ProjectRuntime, st *turnState,
 		return r.execSearch(ctx, rt, st, act)
 	case actSearchInsights:
 		return r.execSearchInsights(ctx, rt, st, act)
+	case actRenderChart:
+		return r.execRenderChart(ctx, st, act)
 	default:
 		return "Unknown action."
 	}
@@ -475,9 +515,68 @@ func (r *runner) execQuery(ctx context.Context, rt *ProjectRuntime, st *turnStat
 		return fmt.Sprintf("Query failed: %s\nTry a different query, or answer/decline with what you have.", err.Error())
 	}
 	sum := summarizeResult(res, act.Purpose, r.cfg)
+	// Assign the query a unique, model-visible step id so a later render_chart
+	// can bind to it via source_step_id. Only successful queries get one; a
+	// non-truncated one is chartable (a chart is an exact projection of the
+	// preview, so a truncated result — whose preview omits rows — cannot ground).
+	st.queryStepSeq++
+	sum.Step = fmt.Sprintf("q%d", st.queryStepSeq)
+	ev.Args["step"] = sum.Step
 	ev.Output = sum
+	if st.querySummariesByID == nil {
+		st.querySummariesByID = make(map[string]QuerySummary)
+	}
+	st.querySummariesByID[sum.Step] = sum
+	if !sum.Truncated {
+		st.queriesChartable++
+	}
 	r.emit(ctx, st, ev)
 	return sum.observation()
+}
+
+// execRenderChart validates and grounds a render_chart action, then persists it
+// as a (non-grounding) tool event carrying the accepted ChartSpec. A rejected
+// spec is persisted with its Error set and returned as an error observation so
+// the model can repair it or re-query — reusing the loop's existing self-heal
+// path (no separate machinery). It grounds against the referenced query's
+// preview: the chart data must be an exact projection of cells already observed.
+func (r *runner) execRenderChart(ctx context.Context, st *turnState, act *turnAction) string {
+	ev := commonmodels.ToolEvent{Round: st.round, Name: string(actRenderChart)}
+
+	if r.cfg.ChartMaxPerAnswer > 0 && st.chartsRendered >= r.cfg.ChartMaxPerAnswer {
+		ev.Error = fmt.Sprintf("chart limit reached (%d per answer)", r.cfg.ChartMaxPerAnswer)
+		r.emit(ctx, st, ev)
+		return ev.Error + "; do not render more — answer with the charts you have."
+	}
+
+	spec, err := charts.Decode(act.Chart, r.cfg.ChartCaps)
+	if err != nil {
+		ev.Error = err.Error()
+		r.emit(ctx, st, ev)
+		return "Chart rejected: " + err.Error() + ". Fix the spec or re-query, then try again."
+	}
+
+	src, ok := st.querySummariesByID[spec.SourceStepID]
+	if !ok {
+		ev.Args = map[string]any{"source_step_id": spec.SourceStepID, "type": string(spec.Type)}
+		ev.Error = fmt.Sprintf("unknown source_step_id %q", spec.SourceStepID)
+		r.emit(ctx, st, ev)
+		return fmt.Sprintf("Chart rejected: no query step %q in this turn. Set source_step_id to the q<N> id of a query you ran (shown in its result), then try again.", spec.SourceStepID)
+	}
+
+	gsrc := charts.GroundingSource{StepID: src.Step, Columns: src.Columns, Preview: src.Preview, Truncated: src.Truncated}
+	if err := charts.ValidateGrounded(spec, gsrc, r.cfg.ChartCaps); err != nil {
+		ev.Args = map[string]any{"source_step_id": spec.SourceStepID, "type": string(spec.Type)}
+		ev.Error = err.Error()
+		r.emit(ctx, st, ev)
+		return "Chart rejected: " + err.Error() + ". Fix the spec (chart only the exact cells you observed) or re-query, then try again."
+	}
+
+	ev.Args = map[string]any{"source_step_id": spec.SourceStepID, "type": string(spec.Type)}
+	ev.Output = spec
+	st.chartsRendered++
+	r.emit(ctx, st, ev)
+	return fmt.Sprintf("Chart accepted (%s from %s). Render another chart if useful, then answer.", spec.Type, spec.SourceStepID)
 }
 
 func (r *runner) execLookup(ctx context.Context, rt *ProjectRuntime, st *turnState, act *turnAction) string {
@@ -558,8 +657,10 @@ func (r *runner) execSearchInsights(ctx context.Context, rt *ProjectRuntime, st 
 // emit appends a tool event to the in-memory transcript and persists it.
 func (r *runner) emit(ctx context.Context, st *turnState, ev commonmodels.ToolEvent) {
 	st.events = append(st.events, ev)
-	if ev.Error == "" {
-		// A successful evidence event — the model actually observed data.
+	if ev.Error == "" && ev.Name != string(actRenderChart) {
+		// A successful EVIDENCE event — the model actually observed data. A
+		// render_chart consumes a result rather than producing one, so it never
+		// grounds: charting must not be a way to reach the answer tool.
 		st.groundedEvents++
 	}
 	// Persist under a short, detached deadline so a turn ctx already past its

--- a/services/agent/internal/askserve/loop_test.go
+++ b/services/agent/internal/askserve/loop_test.go
@@ -323,15 +323,25 @@ func TestLoop_SearchTablesSummaryIsLowercaseKeyed(t *testing.T) {
 }
 
 func TestLoop_SchemaToolUnavailableDegrades(t *testing.T) {
-	// nil schema provider → lookup returns an "unavailable" observation, loop continues.
+	// nil schema provider → search returns an "unavailable" observation and the
+	// loop continues. The unavailable search records an ERROR event (no data
+	// observed), so it does NOT ground: the model must still gather real evidence
+	// before it can answer. Here it recovers with a direct query, which grounds
+	// the answer. (An answer straight after the failed search — with no
+	// successful evidence — would be ungrounded and declined, same as the native
+	// path; see TestLoopTools_FailedEvidenceNotGrounding.)
 	store := runOnce(t, Config{}, []string{
 		`{"search_tables":"orders"}`,
-		`{"answer":"answered without schema search"}`,
+		`{"query":"SELECT count(*) AS c FROM ds.t"}`,
+		`{"answer":"answered after recovering with a direct query"}`,
 	}, testutil.NewMockWarehouseProvider("ds"), nil, "")
 	if store.final.Status != commonmodels.AskTurnStatusDone {
 		t.Fatalf("status = %q", store.final.Status)
 	}
-	if len(store.events) != 1 || store.events[0].Error == "" {
-		t.Fatalf("search event should record unavailability: %+v", store.events)
+	if len(store.events) != 2 || store.events[0].Error == "" {
+		t.Fatalf("search event should record unavailability + query should run: %+v", store.events)
+	}
+	if store.events[1].Name != string(actQuery) || store.events[1].Error != "" {
+		t.Fatalf("recovery query event = %+v", store.events[1])
 	}
 }

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -11,7 +11,7 @@ import (
 // JSON action vocabulary the loop parses, the hard safety rules, and the
 // result-summarization behaviour so the model reaches for aggregate SQL instead
 // of expecting full result sets.
-func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
+func buildSystemPrompt(rt *ProjectRuntime, cfg Config, chartsEnabled bool) string {
 	var b strings.Builder
 
 	b.WriteString("You are a data analyst agent. Answer the user's natural-language question about their data by reasoning step by step and running read-only SQL against their data warehouse. Ground every claim in query results — never invent numbers.\n\n")
@@ -26,11 +26,17 @@ func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
 	if rt.InsightsProvider != nil {
 		b.WriteString(`  {"thinking":"...","search_insights":"keywords"}` + "  — search prior discovered insights & recommendations\n")
 	}
+	if chartsEnabled {
+		b.WriteString(`  {"thinking":"...","render_chart":{"type":"bar","source_step_id":"q2","x":{"field":"month"},"y":[{"field":"revenue"}],"data":[...]}}` + "  — chart a prior query result\n")
+	}
 	b.WriteString(`  {"thinking":"...","answer":"final grounded answer for the user"}` + "  — when you can answer\n")
 	b.WriteString(`  {"thinking":"...","clarify":"a single clarifying question"}` + "  — when the question is too ambiguous to answer\n")
 	b.WriteString(`  {"thinking":"...","decline":"why this cannot be answered from the data"}` + "  — when it is unanswerable\n")
 
 	writeResultHandling(&b, cfg)
+	if chartsEnabled {
+		writeChartsSection(&b)
+	}
 
 	b.WriteString("\nGROUNDING (required): you MUST gather evidence and observe its result before you give an `answer`. Never state a table name, count, total, or specific value you have not seen in a result in this conversation — do not answer from prior knowledge or guesses. If you don't yet know the tables or columns, your FIRST action must be a discovery query — e.g. `SELECT table_name FROM <dataset>.INFORMATION_SCHEMA.TABLES` — or a search_tables / lookup_schema; do not invent table or column names. An answer with no evidence behind it will be rejected; only use clarify or decline if the question genuinely cannot be turned into any query.\n")
 	if rt.InsightsProvider != nil {
@@ -48,7 +54,7 @@ func buildSystemPrompt(rt *ProjectRuntime, cfg Config) string {
 // the loop withholds the `answer` tool until at least one query/lookup/search
 // has run, so grounding is enforced structurally rather than by prose. The
 // prose here is guidance, not a hard gate.
-func buildSystemPromptForTools(rt *ProjectRuntime, cfg Config) string {
+func buildSystemPromptForTools(rt *ProjectRuntime, cfg Config, chartsEnabled bool) string {
 	var b strings.Builder
 
 	b.WriteString("You are a data analyst agent. Answer the user's natural-language question about their data by reasoning step by step and using the provided tools to run read-only SQL against their data warehouse. Ground every claim in query results — never invent numbers, table names, or column names.\n\n")
@@ -61,9 +67,15 @@ func buildSystemPromptForTools(rt *ProjectRuntime, cfg Config) string {
 	if rt.InsightsProvider != nil {
 		b.WriteString("- search_insights: search the project's prior discovered insights & recommendations; prefer it for \"what did we find\" / \"what do you recommend\" questions, and combine with query_data when a finding needs a fresh number.\n")
 	}
+	if chartsEnabled {
+		b.WriteString("- render_chart: chart a prior query result (offered once a query has run). The chart data must be an exact projection of that query's preview.\n")
+	}
 	b.WriteString("- answer / clarify / decline: finish the turn.\n")
 
 	writeResultHandling(&b, cfg)
+	if chartsEnabled {
+		writeChartsSection(&b)
+	}
 
 	evidence := "query_data, search_tables, or lookup_schema"
 	if rt.InsightsProvider != nil {
@@ -101,6 +113,18 @@ func writeWarehouseSection(b *strings.Builder, rt *ProjectRuntime) {
 			fmt.Fprintf(b, "- SECURITY: every query MUST filter by %q (the tenant scope). A query missing this filter is rejected.\n", rt.FilterField)
 		}
 	}
+}
+
+// writeChartsSection renders the shared CHARTS guidance, included only when
+// charting is enabled for the turn. It tells the model when a chart helps, how
+// to keep it grounded (exact projection of a query preview — aggregate in SQL,
+// never compute chart numbers), and to decline to chart rather than invent.
+func writeChartsSection(b *strings.Builder) {
+	b.WriteString("\nCHARTS\n")
+	b.WriteString("- When a trend, comparison, breakdown, or single headline figure communicates the answer better than prose, render a chart with render_chart. Otherwise just answer.\n")
+	b.WriteString("- A chart's data MUST be an exact projection of a query result you already observed: copy the cells verbatim. Never compute, round, scale, or invent a chart number — if you need an aggregate or a smaller set of points, run the aggregation in SQL first, then chart that result.\n")
+	b.WriteString("- Set source_step_id to the q<N> id shown in the result you are charting. You can only chart a query whose full result fit the preview (not a truncated one) — aggregate in SQL until it does.\n")
+	b.WriteString("- Keep it readable: few series, clear labels. Types: bar, line, area, pie, scatter, kpi (a single headline figure). Render the chart in its own step, then answer in the next. If the data cannot honestly support a chart, don't force one.\n")
 }
 
 // writeResultHandling renders the shared RESULT HANDLING block. Shared verbatim

--- a/services/agent/internal/askserve/summarize.go
+++ b/services/agent/internal/askserve/summarize.go
@@ -15,6 +15,11 @@ import (
 // warehouse returned; Preview shows at most PreviewRows of them; Truncated is
 // set when the preview omits rows. No raw result set is ever stored.
 type QuerySummary struct {
+	// Step is the per-turn query step id (e.g. "q2") the model can reference as a
+	// chart's source_step_id. It is stamped on successful queries only and is
+	// unique within a turn — unlike ToolEvent.Round, which is not (native mode can
+	// run several queries in one round).
+	Step      string                   `json:"step,omitempty" bson:"step,omitempty"`
 	SQL       string                   `json:"sql" bson:"sql"`
 	Purpose   string                   `json:"purpose,omitempty" bson:"purpose,omitempty"`
 	RowCount  int                      `json:"row_count" bson:"row_count"`
@@ -76,10 +81,16 @@ func summarizeResult(res *queryexec.ExecuteResult, purpose string, cfg Config) Q
 // nudges the model toward aggregate SQL for exact totals.
 func (s QuerySummary) observation() string {
 	var b strings.Builder
+	// Lead with the step id so the model can reference it as a chart's
+	// source_step_id (e.g. `Query q2 — executed successfully.`).
+	step := ""
+	if s.Step != "" {
+		step = " " + s.Step + " —"
+	}
 	if s.Fixed {
-		b.WriteString("Query executed successfully (auto-repaired).\n")
+		fmt.Fprintf(&b, "Query%s executed successfully (auto-repaired).\n", step)
 	} else {
-		b.WriteString("Query executed successfully.\n")
+		fmt.Fprintf(&b, "Query%s executed successfully.\n", step)
 	}
 	fmt.Fprintf(&b, "Rows returned: %d\n", s.RowCount)
 	if len(s.Columns) > 0 {

--- a/services/agent/internal/askserve/tools.go
+++ b/services/agent/internal/askserve/tools.go
@@ -1,6 +1,7 @@
 package askserve
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -83,6 +84,69 @@ func toolSearchInsights() gollm.ToolDefinition {
 	}
 }
 
+// toolRenderChart is offered only when charting is enabled for the turn AND at
+// least one non-truncated query has run this turn. Its schema mirrors the shared
+// charts.ChartSpec (minus server-derived fields); the loop re-validates and
+// hard-grounds the emitted spec against the referenced query preview, so a
+// wrong or invented spec is rejected and fed back for repair rather than trusted.
+func toolRenderChart() gollm.ToolDefinition {
+	return gollm.ToolDefinition{
+		Name: string(actRenderChart),
+		Description: "Render a chart from a query result you ALREADY observed this turn. The chart data must be an EXACT projection of that query's preview rows — copy the cells, do not compute, round, or invent any number (aggregate in SQL first, then chart the result). " +
+			"Set source_step_id to the q<N> id of the query you are charting (shown in its result). Prefer a chart when a trend, comparison, breakdown, or single headline figure communicates the answer better than prose. Keep series small and readable. Do not call this in the same step as answer.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"type":           map[string]interface{}{"type": "string", "enum": []string{"bar", "line", "area", "pie", "scatter", "kpi"}, "description": "The chart type."},
+				"title":          map[string]interface{}{"type": "string", "description": "Short chart title (optional, plain text)."},
+				"caption":        map[string]interface{}{"type": "string", "description": "One-line caption/insight (optional, plain text)."},
+				"source_step_id": map[string]interface{}{"type": "string", "description": "The q<N> id of the query whose result this chart shows, e.g. \"q2\"."},
+				"x": map[string]interface{}{
+					"type":        "object",
+					"description": "The category/time/number axis (required for all types except kpi).",
+					"properties": map[string]interface{}{
+						"field": map[string]interface{}{"type": "string", "description": "The query column for the x axis."},
+						"label": map[string]interface{}{"type": "string"},
+						"type":  map[string]interface{}{"type": "string", "enum": []string{"category", "time", "number"}},
+					},
+				},
+				"y": map[string]interface{}{
+					"type":        "array",
+					"description": "One or more numeric measures to plot (required for all types except kpi).",
+					"items": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"field": map[string]interface{}{"type": "string", "description": "A numeric query column."},
+							"label": map[string]interface{}{"type": "string"},
+						},
+						"required": []string{"field"},
+					},
+				},
+				"series_by": map[string]interface{}{"type": "string", "description": "Optional column to split into one series per distinct value (bar/line/area only)."},
+				"stacked":   map[string]interface{}{"type": "boolean", "description": "Stack the series (bar/area only)."},
+				"data": map[string]interface{}{
+					"type":        "array",
+					"description": "The chart rows: an exact subset/projection of the query preview cells. Each object maps column name to the observed cell value.",
+					"items":       map[string]interface{}{"type": "object"},
+				},
+				"kpi": map[string]interface{}{
+					"type":        "object",
+					"description": "For the kpi type only: a single headline figure read from the query result.",
+					"properties": map[string]interface{}{
+						"value":       map[string]interface{}{"type": "number", "description": "The figure, copied from a source cell."},
+						"unit":        map[string]interface{}{"type": "string"},
+						"delta":       map[string]interface{}{"type": "number", "description": "Optional change figure, copied from a source cell."},
+						"value_field": map[string]interface{}{"type": "string", "description": "The source column the value was read from."},
+						"delta_field": map[string]interface{}{"type": "string", "description": "The source column the delta was read from."},
+					},
+					"required": []string{"value", "value_field"},
+				},
+			},
+			"required": []string{"type", "source_step_id"},
+		},
+	}
+}
+
 func toolAnswer() gollm.ToolDefinition {
 	return gollm.ToolDefinition{
 		Name:        string(actAnswer),
@@ -132,14 +196,18 @@ func toolDecline() gollm.ToolDefinition {
 // clarify / decline stay available so a genuinely ambiguous or unanswerable
 // question can still terminate without inventing data. Schema tools are offered
 // only when a schema provider is wired; search_insights only when an insights
-// provider is wired.
-func toolsForPhase(grounded, hasSchema, hasInsights bool) []gollm.ToolDefinition {
+// provider is wired. render_chart is offered only when charting is enabled for
+// the turn AND a non-truncated query result exists to ground a chart against.
+func toolsForPhase(grounded, hasSchema, hasInsights, chartsEnabled, hasChartableQuery bool) []gollm.ToolDefinition {
 	tools := []gollm.ToolDefinition{toolQueryData()}
 	if hasSchema {
 		tools = append(tools, toolLookupSchema(), toolSearchTables())
 	}
 	if hasInsights {
 		tools = append(tools, toolSearchInsights())
+	}
+	if chartsEnabled && hasChartableQuery {
+		tools = append(tools, toolRenderChart())
 	}
 	if grounded {
 		tools = append(tools, toolAnswer())
@@ -200,6 +268,15 @@ func toolCallToAction(tc gollm.ToolCall) (*turnAction, error) {
 			return nil, fmt.Errorf("search_insights requires a non-empty %q argument", "query")
 		}
 		return &turnAction{Kind: actSearchInsights, SearchInsights: q, InsightsLimit: toInt(tc.Input["limit"])}, nil
+	case actRenderChart:
+		// The whole tool input IS the ChartSpec. Re-encode it to raw JSON so the
+		// executor can strict-decode + ground it via the shared charts validator
+		// (which also rejects unknown fields the map would otherwise swallow).
+		raw, err := json.Marshal(tc.Input)
+		if err != nil {
+			return nil, fmt.Errorf("render_chart input could not be encoded: %w", err)
+		}
+		return &turnAction{Kind: actRenderChart, Chart: raw}, nil
 	case actAnswer:
 		txt := getStr("text")
 		if txt == "" {

--- a/services/agent/internal/askserve/types.go
+++ b/services/agent/internal/askserve/types.go
@@ -23,6 +23,14 @@ type TurnRequest struct {
 	// caller. The server applies a secondary newest-first character-budget
 	// trim so context stays bounded as a session grows.
 	History []HistoryMessage `json:"history,omitempty"`
+	// EnableCharts is the caller's per-turn capability grant for the render_chart
+	// tool. It is the entitlement gate: charts are offered only when the caller
+	// sets this AND the server's ASK_SERVE_CHARTS_ENABLED kill-switch is on. The
+	// community API never sets it (it never calls ask-serve); the enterprise
+	// delegate sets it only for entitled deployments. A policy check in-agent is
+	// not sufficient on its own (a checker-less agent's NoopChecker allows
+	// everything), so the capability rides the wire.
+	EnableCharts bool `json:"enable_charts,omitempty"`
 }
 
 // HistoryMessage is one prior conversation message. Role is "user" or


### PR DESCRIPTION
## What & why

Platform foundation for **enterprise Ask charts** (decisionbox-enterprise#128). This is **PR 1 of 3** on the shared `ask-charts` bridge branch; the control-plane plan-flag PR and the enterprise PR (chartexport + Recharts UI) build on it. Nothing downstream compiles without this.

The data agent (`ask-serve`) can now call a new **`render_chart`** tool that emits a constrained, renderer-agnostic **`ChartSpec`** (bar / line / area / pie / scatter / KPI), **hard-grounded** in a query result the agent already observed — never invented, never derived.

## Changes

**`libs/go-common/charts`** (new, leaf package — no service deps)
- `ChartSpec` type + `schema.json` (the language-neutral contract mirrored by the Go type and the Dart renderer for decisionbox-chat-app#8).
- `Validate` (structural) + `ValidateGrounded` — the hard rule: a chart's data must be an **exact projection** of the referenced query's preview (drop/reorder columns & rows, but never compute a new number — aggregate in SQL). Truncated sources are refused; KPIs must reference a source column; `Decode` rejects unknown fields so the artifact stays strictly declarative.
- `bson` tags mirror the `json` tags so the snake_case wire shape survives the Mongo round-trip (charts persist as `ToolEvent.Output`, no base-model change).

**`libs/go-common/policy`** — `FeatureAskCharts = "ask_charts_enabled"` + `AllFeatures`.

**`services/agent/internal/askserve`** — `render_chart` wired into both the native tool path and the JSON-text fallback:
- Per-query step ids (`q1`, `q2`, …) so a chart's `source_step_id` binds to a unique query (`Round` isn't unique — native mode batches queries).
- `render_chart` is **not evidence**: a successful chart never grounds the turn (it consumes a result, it doesn't produce one), so charting can't be a backdoor to the `answer` tool. The text-path grounding guard now tests successful evidence, not `len(events)`, so a failed/rejected chart can't unlock an ungrounded answer.
- Offered only when the caller sets `EnableCharts` on the wire **and** `ASK_SERVE_CHARTS_ENABLED` is on **and** a non-truncated query has run — the entitlement gate (a checker-less agent must not leak the tool) plus an ops kill-switch.
- Fallback parser rejects a `{render_chart, answer}` payload; the native batch loop refuses a chart mixed with a query or terminal. Parametric caps (`ASK_SERVE_CHARTS_*`), `MaxPoints` defaulting to `PREVIEW_ROWS`.

## Verification
- `go build ./...` (agent + go-common), `go test ./internal/askserve/... ./charts/... ./policy/...`, `golangci-lint run` — all green.
- New tests: grounding table (exact projection; derived numbers; stitched rows; truncated source; KPI provenance; unknown column; caps; unknown-field decode); native+text parity for `render_chart`; the non-grounding invariant; per-answer cap; same-batch refusal; entitlement gate offering. One pre-existing text-path test updated to the corrected grounding contract (a failed tool no longer unlocks an ungrounded answer — now consistent with the native path).

Rule 11: all prose here is neutral — a flag/capability-gated charting capability of the data agent, exactly like `query_data`. Community can't produce a chart (it never deploys/calls ask-serve, never sets `EnableCharts`).

Part of decisionbox-enterprise#128. Merge into `ask-charts`; syncs to `main` with the suite once E2E is green.

— Co-coded with Jale 🤖