### PR TITLE
fix(charts): sanitize field names + single-y series_by (Codex follow-up to #305)

### DIFF
--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -180,6 +180,19 @@ func validateSeriesShape(spec ChartSpec, caps Caps) error {
 	if spec.SeriesBy != "" && len(spec.Y) != 1 {
 		return ruleErr("shape", "series_by", "series_by pivots a single measure — use exactly one y with series_by (or list measures as separate y series without series_by)")
 	}
+	// Each (x, series_by) slot must be unique — a pivot has one value per slot, so
+	// two rows sharing an (x, series) pair are ambiguous and a renderer would
+	// silently drop one. Aggregate in SQL so each slot is single-valued.
+	if spec.SeriesBy != "" {
+		seen := make(map[string]struct{}, len(spec.Data))
+		for ri, row := range spec.Data {
+			slot := fmt.Sprintf("%v\x00%v", row[spec.X.Field], row[spec.SeriesBy])
+			if _, dup := seen[slot]; dup {
+				return ruleErr("shape", "series_by", fmt.Sprintf("data row %d repeats the (x=%v, %s=%v) slot; each x/series pair must be unique (aggregate in SQL)", ri, row[spec.X.Field], spec.SeriesBy, row[spec.SeriesBy]))
+			}
+			seen[slot] = struct{}{}
+		}
+	}
 	// A pie has one value dimension (its slices) and negative slices are
 	// meaningless — require exactly one y and non-negative values so a renderer
 	// never has to silently drop or recompute slices.
@@ -548,10 +561,18 @@ func sanitizeStrings(spec ChartSpec, caps Caps) error {
 			if err := check(fmt.Sprintf("data[%d] key", ri), k); err != nil {
 				return err
 			}
-			if s, ok := v.(string); ok {
-				if err := check(fmt.Sprintf("data[%d].%s", ri, k), s); err != nil {
+			switch cell := v.(type) {
+			case nil, bool, float64, float32, int, int32, int64, json.Number:
+				// scalar numeric/bool/null — fine.
+			case string:
+				if err := check(fmt.Sprintf("data[%d].%s", ri, k), cell); err != nil {
 					return err
 				}
+			default:
+				// A JSON/RECORD/ARRAY source column decodes to a map/slice; a chart
+				// plots scalars, and a nested value could smuggle markup past the
+				// top-level string check — reject non-scalar cells outright.
+				return ruleErr("shape", fmt.Sprintf("data[%d].%s", ri, k), "chart data cells must be scalar (string, number, bool, or null), not an object or array")
 			}
 		}
 	}

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 )
 
@@ -500,8 +501,18 @@ func isNumericOrNull(v any) bool {
 	if v == nil {
 		return true
 	}
-	_, ok := asFloat(v)
-	return ok
+	if _, ok := asFloat(v); ok {
+		return true
+	}
+	// A numeric STRING counts as numeric: some warehouses (e.g. BigQuery
+	// NUMERIC/BIGNUMERIC) encode exact-decimal columns as JSON strings to keep
+	// precision, so a monetary measure arrives as "1234.56". The model copies the
+	// cell verbatim (grounds string==string) and every renderer parses it.
+	if s, ok := v.(string); ok {
+		_, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		return err == nil && strings.TrimSpace(s) != ""
+	}
+	return false
 }
 
 // sanitizeStrings rejects any human-facing string that could break out of a

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -180,6 +180,19 @@ func validateSeriesShape(spec ChartSpec, caps Caps) error {
 	if spec.SeriesBy != "" && len(spec.Y) != 1 {
 		return ruleErr("shape", "series_by", "series_by pivots a single measure — use exactly one y with series_by (or list measures as separate y series without series_by)")
 	}
+	// A pie has one value dimension (its slices) and negative slices are
+	// meaningless — require exactly one y and non-negative values so a renderer
+	// never has to silently drop or recompute slices.
+	if spec.Type == ChartPie {
+		if len(spec.Y) != 1 {
+			return ruleErr("shape", "y", "a pie chart uses exactly one y measure (its slice values)")
+		}
+		for ri, row := range spec.Data {
+			if v, ok := asFloat(row[spec.Y[0].Field]); ok && v < 0 {
+				return ruleErr("shape", spec.Y[0].Field, fmt.Sprintf("a pie slice cannot be negative; data row %d has a negative %q", ri, spec.Y[0].Field))
+			}
+		}
+	}
 	// series_by turns one field into one rendered series per distinct value, so
 	// it multiplies the effective series count — cap the fan-out too, or a
 	// high-cardinality series_by would blow past MaxSeries.
@@ -254,6 +267,12 @@ func ValidateGrounded(spec ChartSpec, src GroundingSource, caps Caps) error {
 		return groundKPI(spec, src, cols, preview)
 	}
 	dataRows := canonicalizeRows(spec.Data)
+	// canonicalizeRows drops a row it can't JSON round-trip (e.g. a NaN/Inf
+	// value); a dropped data row would silently skip grounding, so reject the
+	// spec instead of validating a subset.
+	if len(dataRows) != len(spec.Data) {
+		return ruleErr("shape", "data", "a data row holds a value that is not representable in JSON (e.g. NaN or Infinity); chart only finite numbers and plain values")
+	}
 
 	// Every charted field must be a real column of the source preview.
 	for _, f := range chartedFields(spec) {

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -173,9 +173,16 @@ func validateSeriesShape(spec ChartSpec, caps Caps) error {
 	if caps.MaxPoints > 0 && len(spec.Data) > caps.MaxPoints {
 		return ruleErr("caps", "data", fmt.Sprintf("%d data points exceeds the limit of %d; aggregate in SQL to fewer rows", len(spec.Data), caps.MaxPoints))
 	}
-	// series_by pivots one field into one rendered series per distinct value, so
-	// it multiplies the effective series count — cap the fan-out too, or a single
-	// y with a high-cardinality series_by would blow past MaxSeries.
+	// series_by pivots a SINGLE measure into one series per distinct value. Both
+	// renderers (Recharts + the SVG export) chart y[0] under series_by, so more
+	// than one y with series_by is ambiguous — reject it (chart one measure, or
+	// drop series_by and list measures as separate y series).
+	if spec.SeriesBy != "" && len(spec.Y) != 1 {
+		return ruleErr("shape", "series_by", "series_by pivots a single measure — use exactly one y with series_by (or list measures as separate y series without series_by)")
+	}
+	// series_by turns one field into one rendered series per distinct value, so
+	// it multiplies the effective series count — cap the fan-out too, or a
+	// high-cardinality series_by would blow past MaxSeries.
 	if spec.SeriesBy != "" && caps.MaxSeries > 0 {
 		distinct := map[string]struct{}{}
 		for _, row := range spec.Data {
@@ -484,8 +491,14 @@ func sanitizeStrings(spec ChartSpec, caps Caps) error {
 	if err := check("caption", spec.Caption); err != nil {
 		return err
 	}
+	// Field references and data keys are rendered too — a renderer falls back to
+	// the field name for a legend/axis/tooltip when no label is set — so a column
+	// aliased to markup/control text must be rejected just like a label.
 	if spec.X != nil {
 		if err := check("x.label", spec.X.Label); err != nil {
+			return err
+		}
+		if err := check("x.field", spec.X.Field); err != nil {
 			return err
 		}
 	}
@@ -493,14 +506,29 @@ func sanitizeStrings(spec ChartSpec, caps Caps) error {
 		if err := check(fmt.Sprintf("y[%d].label", i), s.Label); err != nil {
 			return err
 		}
+		if err := check(fmt.Sprintf("y[%d].field", i), s.Field); err != nil {
+			return err
+		}
+	}
+	if err := check("series_by", spec.SeriesBy); err != nil {
+		return err
 	}
 	if spec.KPI != nil {
 		if err := check("kpi.unit", spec.KPI.Unit); err != nil {
 			return err
 		}
+		if err := check("kpi.value_field", spec.KPI.ValueField); err != nil {
+			return err
+		}
+		if err := check("kpi.delta_field", spec.KPI.DeltaField); err != nil {
+			return err
+		}
 	}
 	for ri, row := range spec.Data {
 		for k, v := range row {
+			if err := check(fmt.Sprintf("data[%d] key", ri), k); err != nil {
+				return err
+			}
 			if s, ok := v.(string); ok {
 				if err := check(fmt.Sprintf("data[%d].%s", ri, k), s); err != nil {
 					return err

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -135,6 +135,38 @@ func TestValidate_Rejects(t *testing.T) {
 	}
 }
 
+func TestValidate_SeriesByRequiresSingleY(t *testing.T) {
+	base := ChartSpec{
+		Type: ChartBar, SourceStepID: "q1", SeriesBy: "region",
+		X: &Axis{Field: "month"}, Y: []Series{{Field: "revenue"}, {Field: "cost"}},
+		Data: []map[string]any{{"month": "a", "region": "NA", "revenue": 1.0, "cost": 2.0}},
+	}
+	if err := Validate(base, DefaultCaps); err == nil {
+		t.Error("series_by with more than one y must be rejected")
+	}
+	base.Y = []Series{{Field: "revenue"}}
+	if err := Validate(base, DefaultCaps); err != nil {
+		t.Errorf("series_by with a single y should pass: %v", err)
+	}
+}
+
+func TestValidate_RejectsUnsafeFieldName(t *testing.T) {
+	// A column aliased to markup (a renderer falls back to the field name for a
+	// legend/axis) must be rejected like any other rendered string.
+	s := barSpec()
+	s.Y = []Series{{Field: "<script>"}}
+	s.Data = []map[string]any{{"month": "a", "<script>": 1.0}}
+	if err := Validate(s, DefaultCaps); err == nil {
+		t.Error("an unsafe y field name must be rejected")
+	}
+	// And an unsafe data key.
+	s2 := barSpec()
+	s2.Data = []map[string]any{{"month": "a", "revenue": 1.0, "on<load>": "x"}}
+	if err := Validate(s2, DefaultCaps); err == nil {
+		t.Error("an unsafe data key must be rejected")
+	}
+}
+
 func TestValidate_Caps(t *testing.T) {
 	caps := Caps{MaxPoints: 2, MaxSeries: 1, MaxLabelLen: 10}
 	s := barSpec()

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -174,6 +174,36 @@ func TestValidate_PieSingleYNonNegative(t *testing.T) {
 	}
 }
 
+func TestValidateGrounded_NumericStringMeasure(t *testing.T) {
+	// BigQuery NUMERIC/BIGNUMERIC arrives as a JSON string; a copied string
+	// measure must pass the numeric-y check and ground (string == string).
+	src := GroundingSource{
+		StepID:  "q1",
+		Columns: []string{"month", "amount"},
+		Preview: []map[string]any{
+			{"month": "2024-01", "amount": "1234.56"},
+			{"month": "2024-02", "amount": "2000.00"},
+		},
+	}
+	s := ChartSpec{
+		Type: ChartBar, SourceStepID: "q1",
+		X: &Axis{Field: "month"}, Y: []Series{{Field: "amount"}},
+		Data: []map[string]any{
+			{"month": "2024-01", "amount": "1234.56"},
+			{"month": "2024-02", "amount": "2000.00"},
+		},
+	}
+	if err := ValidateGrounded(s, src, DefaultCaps); err != nil {
+		t.Fatalf("a numeric-string measure should validate + ground: %v", err)
+	}
+	// A genuinely non-numeric string measure is still rejected.
+	bad := s
+	bad.Data = []map[string]any{{"month": "2024-01", "amount": "lots"}}
+	if err := Validate(bad, DefaultCaps); err == nil {
+		t.Error("a non-numeric string y must still be rejected")
+	}
+}
+
 func TestValidateGrounded_RejectsNonJSONNumber(t *testing.T) {
 	src := revenueSource()
 	s := barSpec()

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 )
@@ -147,6 +148,38 @@ func TestValidate_SeriesByRequiresSingleY(t *testing.T) {
 	base.Y = []Series{{Field: "revenue"}}
 	if err := Validate(base, DefaultCaps); err != nil {
 		t.Errorf("series_by with a single y should pass: %v", err)
+	}
+}
+
+func TestValidate_PieSingleYNonNegative(t *testing.T) {
+	pie := ChartSpec{
+		Type: ChartPie, SourceStepID: "q1",
+		X: &Axis{Field: "region"}, Y: []Series{{Field: "share"}},
+		Data: []map[string]any{{"region": "NA", "share": 60.0}, {"region": "EU", "share": 40.0}},
+	}
+	if err := Validate(pie, DefaultCaps); err != nil {
+		t.Fatalf("valid pie = %v", err)
+	}
+	// Multiple y on a pie.
+	bad := pie
+	bad.Y = []Series{{Field: "share"}, {Field: "other"}}
+	if err := Validate(bad, DefaultCaps); err == nil {
+		t.Error("a pie with more than one y must be rejected")
+	}
+	// Negative slice.
+	neg := pie
+	neg.Data = []map[string]any{{"region": "NA", "share": -5.0}}
+	if err := Validate(neg, DefaultCaps); err == nil {
+		t.Error("a negative pie slice must be rejected")
+	}
+}
+
+func TestValidateGrounded_RejectsNonJSONNumber(t *testing.T) {
+	src := revenueSource()
+	s := barSpec()
+	s.Data = []map[string]any{{"month": "2024-01", "revenue": math.NaN()}}
+	if err := ValidateGrounded(s, src, DefaultCaps); err == nil {
+		t.Error("a NaN data value must be rejected, not silently dropped")
 	}
 }
 

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -183,6 +183,35 @@ func TestValidateGrounded_RejectsNonJSONNumber(t *testing.T) {
 	}
 }
 
+func TestValidate_RejectsNonScalarDataCell(t *testing.T) {
+	// A JSON/ARRAY source column decodes to a map/slice — a chart plots scalars,
+	// and a nested string could smuggle markup past the top-level check.
+	s := barSpec()
+	s.Data = []map[string]any{{"month": "a", "revenue": 1.0, "meta": map[string]any{"note": "<script>"}}}
+	if err := Validate(s, DefaultCaps); err == nil {
+		t.Error("a non-scalar (object) data cell must be rejected")
+	}
+	s2 := barSpec()
+	s2.Data = []map[string]any{{"month": "a", "revenue": 1.0, "tags": []any{"<script>"}}}
+	if err := Validate(s2, DefaultCaps); err == nil {
+		t.Error("a non-scalar (array) data cell must be rejected")
+	}
+}
+
+func TestValidate_SeriesByRejectsDuplicateSlot(t *testing.T) {
+	s := ChartSpec{
+		Type: ChartBar, SourceStepID: "q1", SeriesBy: "region",
+		X: &Axis{Field: "month"}, Y: []Series{{Field: "revenue"}},
+		Data: []map[string]any{
+			{"month": "a", "region": "NA", "revenue": 1.0},
+			{"month": "a", "region": "NA", "revenue": 2.0}, // same (x, series) slot
+		},
+	}
+	if err := Validate(s, DefaultCaps); err == nil {
+		t.Error("a duplicate (x, series_by) slot must be rejected")
+	}
+}
+
 func TestValidate_RejectsUnsafeFieldName(t *testing.T) {
 	// A column aliased to markup (a renderer falls back to the field name for a
 	// legend/axis) must be rejected like any other rendered string.


### PR DESCRIPTION
Follow-up to #305 (already merged into `ask-charts`), addressing two more Codex review findings on the charts foundation:

- **Sanitize field references + data keys** as rendered text. A renderer falls back to the column name for a legend/axis/tooltip when no label is set, so a column aliased to markup/control text (`x.field`, `y[].field`, `series_by`, `kpi.*_field`, data-row keys) must be rejected like any label.
- **`series_by` requires exactly one `y`.** Both renderers (Recharts + the enterprise SVG export) chart `y[0]` under `series_by`, so more than one `y` with `series_by` is ambiguous — reject it (chart one measure, or list measures as separate `y` series without `series_by`).

One finding was **WONTFIX-by-design** and noted in the commit: preserving the raw JSON literal of a data number before grounding would require `UseNumber` in `Decode`, which breaks BSON persistence (numbers → strings). A sub-2^53 value that float64-matches a source cell renders exactly that source value, so displayed data always equals observed data; values ≥ 2^53 are already rejected.

`go test ./charts/...` + `./internal/askserve/...` + `golangci-lint` green. Part of decisionbox-enterprise#128.

— Co-coded with Jale 🤖