### PR TITLE
feat(charts): number formatting — compact values + unit/format hints

### DIFF
--- a/libs/go-common/charts/charts.go
+++ b/libs/go-common/charts/charts.go
@@ -41,20 +41,35 @@ const (
 	AxisNumber   = "number"
 )
 
+// Number-format hints. These are PRESENTATION-ONLY: a renderer uses them to
+// format displayed values (axis ticks, tooltips, KPI) — currency prefixes a
+// symbol, percent appends "%" — but they never affect grounding, which always
+// validates the raw data values. Empty means a plain compact number.
+const (
+	FormatNumber   = "number"
+	FormatCurrency = "currency"
+	FormatPercent  = "percent"
+)
+
 // Axis describes one chart axis: which row field feeds it, its human label,
 // and how the values should be interpreted. Only the X axis is modeled
 // explicitly; Y is a list of Series so multi-measure charts share one struct.
 type Axis struct {
-	Field string `json:"field" bson:"field"`
-	Label string `json:"label,omitempty" bson:"label,omitempty"`
-	Type  string `json:"type,omitempty" bson:"type,omitempty"` // category | time | number
+	Field  string `json:"field" bson:"field"`
+	Label  string `json:"label,omitempty" bson:"label,omitempty"`
+	Type   string `json:"type,omitempty" bson:"type,omitempty"`     // category | time | number
+	Unit   string `json:"unit,omitempty" bson:"unit,omitempty"`     // presentation hint (see Series)
+	Format string `json:"format,omitempty" bson:"format,omitempty"` // number | currency | percent
 }
 
 // Series is one plotted measure: the row field carrying its values and an
-// optional display label.
+// optional display label. Unit + Format are presentation-only hints (see
+// Format) — they never affect grounding, which validates the raw data values.
 type Series struct {
-	Field string `json:"field" bson:"field"`
-	Label string `json:"label,omitempty" bson:"label,omitempty"`
+	Field  string `json:"field" bson:"field"`
+	Label  string `json:"label,omitempty" bson:"label,omitempty"`
+	Unit   string `json:"unit,omitempty" bson:"unit,omitempty"`
+	Format string `json:"format,omitempty" bson:"format,omitempty"` // number | currency | percent
 }
 
 // KPI is a single headline figure (the "kpi" chart type): a value, an optional
@@ -67,6 +82,7 @@ type KPI struct {
 	// grounded against a source cell that happens to be zero.
 	Value      *float64 `json:"value" bson:"value"`
 	Unit       string   `json:"unit,omitempty" bson:"unit,omitempty"`
+	Format     string   `json:"format,omitempty" bson:"format,omitempty"` // number | currency | percent
 	Delta      *float64 `json:"delta,omitempty" bson:"delta,omitempty"`
 	ValueField string   `json:"value_field" bson:"value_field"`
 	DeltaField string   `json:"delta_field,omitempty" bson:"delta_field,omitempty"`

--- a/libs/go-common/charts/validate.go
+++ b/libs/go-common/charts/validate.go
@@ -36,6 +36,15 @@ func (e *Error) Error() string {
 
 func ruleErr(rule, field, msg string) *Error { return &Error{Rule: rule, Field: field, Msg: msg} }
 
+// validFormat reports whether a number-format hint is allowed (empty = default).
+func validFormat(f string) bool {
+	switch f {
+	case "", FormatNumber, FormatCurrency, FormatPercent:
+		return true
+	}
+	return false
+}
+
 // GroundingSource is the subset of a query result a chart may be grounded
 // against: the columns the result exposed, the preview rows the chart data must
 // be an exact projection of, and whether the preview omitted rows. A truncated
@@ -133,6 +142,9 @@ func validateKPIShape(spec ChartSpec) error {
 	if spec.KPI.Delta != nil && strings.TrimSpace(spec.KPI.DeltaField) == "" {
 		return ruleErr("field_ref", "kpi.delta_field", "kpi.delta_field must name the source column when a delta is provided")
 	}
+	if !validFormat(spec.KPI.Format) {
+		return ruleErr("shape", "kpi.format", fmt.Sprintf("unknown format %q; allowed: number, currency, percent", spec.KPI.Format))
+	}
 	// A KPI's figures come from kpi.value/delta (grounded against the source
 	// cell), not from a data array. Reject a stray data array so it can't smuggle
 	// ungrounded, uncapped cells past validation (the KPI grounding path never
@@ -157,8 +169,16 @@ func validateSeriesShape(spec ChartSpec, caps Caps) error {
 	if spec.X.Type != "" && spec.X.Type != AxisCategory && spec.X.Type != AxisTime && spec.X.Type != AxisNumber {
 		return ruleErr("shape", "x.type", fmt.Sprintf("unknown x.type %q; allowed: category, time, number", spec.X.Type))
 	}
+	if !validFormat(spec.X.Format) {
+		return ruleErr("shape", "x.format", fmt.Sprintf("unknown format %q; allowed: number, currency, percent", spec.X.Format))
+	}
 	if len(spec.Y) == 0 {
 		return ruleErr("shape", "y", "this chart type requires at least one y series")
+	}
+	for i, s := range spec.Y {
+		if !validFormat(s.Format) {
+			return ruleErr("shape", fmt.Sprintf("y[%d].format", i), fmt.Sprintf("unknown format %q; allowed: number, currency, percent", s.Format))
+		}
 	}
 	if caps.MaxSeries > 0 && len(spec.Y) > caps.MaxSeries {
 		return ruleErr("caps", "y", fmt.Sprintf("%d series exceeds the limit of %d", len(spec.Y), caps.MaxSeries))
@@ -544,12 +564,18 @@ func sanitizeStrings(spec ChartSpec, caps Caps) error {
 		if err := check("x.field", spec.X.Field); err != nil {
 			return err
 		}
+		if err := check("x.unit", spec.X.Unit); err != nil {
+			return err
+		}
 	}
 	for i, s := range spec.Y {
 		if err := check(fmt.Sprintf("y[%d].label", i), s.Label); err != nil {
 			return err
 		}
 		if err := check(fmt.Sprintf("y[%d].field", i), s.Field); err != nil {
+			return err
+		}
+		if err := check(fmt.Sprintf("y[%d].unit", i), s.Unit); err != nil {
 			return err
 		}
 	}

--- a/libs/go-common/charts/validate_test.go
+++ b/libs/go-common/charts/validate_test.go
@@ -259,6 +259,33 @@ func TestValidate_RejectsUnsafeFieldName(t *testing.T) {
 	}
 }
 
+func TestValidate_NumberFormatHints(t *testing.T) {
+	// A valid currency/percent hint on a measure is accepted (presentation only).
+	s := barSpec()
+	s.Y = []Series{{Field: "revenue", Unit: "USD", Format: FormatCurrency}}
+	if err := Validate(s, DefaultCaps); err != nil {
+		t.Errorf("a currency measure hint should be valid: %v", err)
+	}
+	// An unknown format is rejected.
+	bad := barSpec()
+	bad.Y = []Series{{Field: "revenue", Format: "monopoly-money"}}
+	if err := Validate(bad, DefaultCaps); err == nil {
+		t.Error("an unknown format must be rejected")
+	}
+	// KPI format hint.
+	k := ChartSpec{Type: ChartKPI, SourceStepID: "q1", KPI: &KPI{Value: f64(5), ValueField: "c", Format: FormatPercent}}
+	if err := Validate(k, DefaultCaps); err != nil {
+		t.Errorf("a kpi percent hint should be valid: %v", err)
+	}
+	// Format is presentation-only: it does not affect grounding.
+	src := revenueSource()
+	g := barSpec()
+	g.Y = []Series{{Field: "revenue", Unit: "USD", Format: FormatCurrency}}
+	if err := ValidateGrounded(g, src, DefaultCaps); err != nil {
+		t.Errorf("a formatted measure should still ground on raw values: %v", err)
+	}
+}
+
 func TestValidate_Caps(t *testing.T) {
 	caps := Caps{MaxPoints: 2, MaxSeries: 1, MaxLabelLen: 10}
 	s := barSpec()

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -125,6 +125,7 @@ func writeChartsSection(b *strings.Builder) {
 	b.WriteString("- A chart's data MUST be an exact projection of a query result you already observed: copy the cells verbatim. Never compute, round, scale, or invent a chart number — if you need an aggregate or a smaller set of points, run the aggregation in SQL first, then chart that result.\n")
 	b.WriteString("- Set source_step_id to the q<N> id shown in the result you are charting. You can only chart a query whose full result fit the preview (not a truncated one) — aggregate in SQL until it does.\n")
 	b.WriteString("- Keep it readable: few series, clear labels. Types: bar, line, area, pie, scatter, kpi (a single headline figure). Render the chart in its own step, then answer in the next. If the data cannot honestly support a chart, don't force one.\n")
+	b.WriteString("- Set a measure's unit + format when you know what it is: currency values → format \"currency\" with the currency code as unit (e.g. USD, DKK); rates/shares → format \"percent\"; otherwise leave it plain. This only controls display (the renderer keeps the exact value) — it makes large figures read as e.g. $17.4B instead of 17392162956.\n")
 }
 
 // writeResultHandling renders the shared RESULT HANDLING block. Shared verbatim

--- a/services/agent/internal/askserve/tools.go
+++ b/services/agent/internal/askserve/tools.go
@@ -116,8 +116,10 @@ func toolRenderChart() gollm.ToolDefinition {
 					"items": map[string]interface{}{
 						"type": "object",
 						"properties": map[string]interface{}{
-							"field": map[string]interface{}{"type": "string", "description": "A numeric query column."},
-							"label": map[string]interface{}{"type": "string"},
+							"field":  map[string]interface{}{"type": "string", "description": "A numeric query column."},
+							"label":  map[string]interface{}{"type": "string"},
+							"unit":   map[string]interface{}{"type": "string", "description": "Unit for display, e.g. a currency code (USD, EUR, DKK) or \"%\"/\"kg\". Presentation only — does not change the value."},
+							"format": map[string]interface{}{"type": "string", "enum": []string{"number", "currency", "percent"}, "description": "How to format this measure's values: currency (prefixes the unit's symbol), percent (appends %), or number (default)."},
 						},
 						"required": []string{"field"},
 					},
@@ -134,7 +136,8 @@ func toolRenderChart() gollm.ToolDefinition {
 					"description": "For the kpi type only: a single headline figure read from the query result.",
 					"properties": map[string]interface{}{
 						"value":       map[string]interface{}{"type": "number", "description": "The figure, copied from a source cell."},
-						"unit":        map[string]interface{}{"type": "string"},
+						"unit":        map[string]interface{}{"type": "string", "description": "Unit for display, e.g. a currency code (USD, DKK) or \"%\"."},
+						"format":      map[string]interface{}{"type": "string", "enum": []string{"number", "currency", "percent"}, "description": "How to format the figure: currency, percent, or number (default)."},
 						"delta":       map[string]interface{}{"type": "number", "description": "Optional change figure, copied from a source cell."},
 						"value_field": map[string]interface{}{"type": "string", "description": "The source column the value was read from."},
 						"delta_field": map[string]interface{}{"type": "string", "description": "The source column the delta was read from."},


### PR DESCRIPTION
Follow-up on the charts feature (decisionbox-enterprise#128): chart numbers were rendering as raw floats (e.g. a `SUM` showing `17392162956.069977`). This adds display formatting.

- **Optional `unit` + `format` hints** on `charts.Axis`/`Series`/`KPI` (`number`|`currency`|`percent`). **Presentation-only** — they never affect grounding, which always validates the raw data values. Format enum validated, unit strings sanitized.
- The **ask-serve `render_chart` tool schema + prompt** let the agent set them when it knows a measure's semantics (currency for money, percent for rates). Verified live: Opus now emits `unit:"USD", format:"currency"` for a sales question.

The enterprise renderers (ChartCard + chartexport) do the actual formatting — see the enterprise PR. Together: `17392162956.07` → `$17.39B` on axis ticks, tooltips, and KPIs; the chart↔table fallback stays verbatim.

`go test ./charts/... ./internal/askserve/...` + `golangci-lint` green.

— Co-coded with Jale 🤖