### PR TITLE
Managed AI gateway: server-authoritative override + UI hide + agent-env forward (#16)

### DIFF
--- a/services/api/apiserver/apiserver.go
+++ b/services/api/apiserver/apiserver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/handler"
 	apilog "github.com/decisionbox-io/decisionbox/services/api/internal/log"
+	"github.com/decisionbox-io/decisionbox/services/api/internal/managedai"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/runner"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/schemaindex"
 	"github.com/decisionbox-io/decisionbox/services/api/internal/server"
@@ -88,6 +89,19 @@ func Run() {
 	if err != nil {
 		apilog.WithError(err).Error("Failed to load config")
 		os.Exit(1)
+	}
+
+	// Managed-inference gateway mode (opt-in via AI_GATEWAY_URL). Install
+	// the process-wide config and fail fast on a half-configured gateway
+	// — a missing alias or credential would otherwise mis-route or fail
+	// every inference call at run time. No-op when AI_GATEWAY_URL is unset.
+	managedai.Load()
+	if err := managedai.Validate(); err != nil {
+		apilog.WithError(err).Error("Invalid managed-inference gateway configuration")
+		os.Exit(1)
+	}
+	if managedai.Enabled() {
+		apilog.Info("Managed-inference gateway mode enabled: project AI config is preset and immutable")
 	}
 
 	apilog.WithFields(apilog.Fields{

--- a/services/api/internal/handler/config.go
+++ b/services/api/internal/handler/config.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/decisionbox-io/decisionbox/services/api/internal/managedai"
+)
+
+// appConfigResponse is the GET /api/v1/config payload: deployment-level
+// capability flags the dashboard reads once at load to decide what to
+// render. Deliberately small and non-secret — it is served to any
+// authenticated viewer and drives UI affordances only (the server, not
+// the UI, is authoritative for enforcement).
+type appConfigResponse struct {
+	// AIConfigManaged is true when this deployment routes all inference
+	// through a managed gateway (AI_GATEWAY_URL set). The dashboard hides
+	// the AI/Embedding + Blurb settings tabs and the AI/embedding/blurb
+	// new-project wizard steps when true — the config is preset and
+	// immutable server-side, so exposing it would only confuse.
+	AIConfigManaged bool `json:"ai_config_managed"`
+}
+
+// AppConfig returns deployment capability flags for the dashboard.
+//
+// GET /api/v1/config
+func AppConfig(w http.ResponseWriter, r *http.Request) {
+	// Never cache: the flag is cheap to compute and a stale value would
+	// show or hide config UI incorrectly across a deployment change.
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, appConfigResponse{
+		AIConfigManaged: managedai.Enabled(),
+	})
+}

--- a/services/api/internal/handler/managedai_enforcement_test.go
+++ b/services/api/internal/handler/managedai_enforcement_test.go
@@ -1,0 +1,253 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gosecrets "github.com/decisionbox-io/decisionbox/libs/go-common/secrets"
+	"github.com/decisionbox-io/decisionbox/services/api/internal/managedai"
+	"github.com/decisionbox-io/decisionbox/services/api/models"
+)
+
+// enableManagedForTest turns on managed-inference mode for the duration
+// of a test. It registers the reset cleanup BEFORE mutating the
+// environment: t.Cleanup is LIFO, so this reload runs AFTER t.Setenv has
+// restored the env, leaving the process-wide managedai singleton back in
+// its (disabled) default for every subsequent test in this binary.
+func enableManagedForTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(managedai.Load)
+	t.Setenv(managedai.EnvGatewayURL, "https://ai.example.com/v1")
+	t.Setenv(managedai.EnvAnalysisModel, "decisionbox-analysis-model")
+	t.Setenv(managedai.EnvBlurbModel, "decisionbox-blurb-model")
+	t.Setenv(managedai.EnvEmbedModel, "decisionbox-embed-model")
+	managedai.Load()
+}
+
+// recordingSecretProvider records Set calls so a test can assert the
+// managed-mode guard refused to persist an AI credential.
+type recordingSecretProvider struct {
+	setKeys []string
+	store   map[string]string
+}
+
+func (s *recordingSecretProvider) Get(_ context.Context, projectID, key string) (string, error) {
+	if v, ok := s.store[projectID+"/"+key]; ok {
+		return v, nil
+	}
+	return "", gosecrets.ErrNotFound
+}
+
+func (s *recordingSecretProvider) Set(_ context.Context, projectID, key, value string) error {
+	s.setKeys = append(s.setKeys, key)
+	if s.store == nil {
+		s.store = map[string]string{}
+	}
+	s.store[projectID+"/"+key] = value
+	return nil
+}
+
+func (s *recordingSecretProvider) List(_ context.Context, _ string) ([]gosecrets.SecretEntry, error) {
+	return nil, nil
+}
+
+// TestProjectsHandler_Create_ManagedOverride verifies that in managed
+// mode a crafted POST — different provider/model/base_url and a smuggled
+// credentials_json — is overridden with the gateway preset, not honored
+// (issue #16 acceptance: server-authoritative enforcement).
+func TestProjectsHandler_Create_ManagedOverride(t *testing.T) {
+	enableManagedForTest(t)
+	repo := newMockProjectRepo()
+	h := NewProjectsHandler(repo, nil)
+
+	body := `{
+		"name":"Attacker","domain":"gaming","category":"match3",
+		"llm":{"provider":"anthropic","model":"claude-x","config":{"base_url":"https://evil.example.com","credentials_json":"sk-attacker"}},
+		"embedding":{"provider":"cohere","model":"embed-x","config":{"credentials_json":"sk-attacker"}},
+		"blurb_llm":{"provider":"google","model":"gemini-x"}
+	}`
+	req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Create(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", w.Code, w.Body.String())
+	}
+	if len(repo.projects) != 1 {
+		t.Fatalf("repo should have 1 project, got %d", len(repo.projects))
+	}
+	var saved *models.Project
+	for _, p := range repo.projects {
+		saved = p
+	}
+
+	if saved.LLM.Provider != "openai" || saved.LLM.Model != "decisionbox-analysis-model" {
+		t.Errorf("analysis LLM = %s/%s; want openai/decisionbox-analysis-model", saved.LLM.Provider, saved.LLM.Model)
+	}
+	if saved.LLM.Config["base_url"] != "https://ai.example.com/v1" {
+		t.Errorf("analysis base_url = %q; want the gateway URL", saved.LLM.Config["base_url"])
+	}
+	if _, leaked := saved.LLM.Config["credentials_json"]; leaked {
+		t.Error("crafted credentials_json survived onto the stored analysis LLM")
+	}
+	if saved.Embedding.Provider != "openai" || saved.Embedding.Model != "decisionbox-embed-model" {
+		t.Errorf("embedding = %s/%s; want openai/decisionbox-embed-model", saved.Embedding.Provider, saved.Embedding.Model)
+	}
+	if _, leaked := saved.Embedding.Config["credentials_json"]; leaked {
+		t.Error("crafted credentials_json survived onto the stored embedding")
+	}
+	if saved.BlurbLLM == nil || saved.BlurbLLM.Provider != "openai" || saved.BlurbLLM.Model != "decisionbox-blurb-model" {
+		t.Errorf("blurb LLM = %+v; want openai/decisionbox-blurb-model", saved.BlurbLLM)
+	}
+}
+
+// TestProjectsHandler_Update_ManagedOverride verifies a crafted PUT is
+// neutralized: the persisted doc stays the gateway preset regardless of
+// what the request body sets.
+func TestProjectsHandler_Update_ManagedOverride(t *testing.T) {
+	enableManagedForTest(t)
+	repo := newMockProjectRepo()
+	h := NewProjectsHandler(repo, nil)
+
+	// Seed a project directly (bypassing the handler) so we can prove the
+	// Update path re-asserts the preset over a hostile body.
+	p := &models.Project{Name: "Seed", Domain: "gaming", Category: "match3"}
+	repo.Create(context.Background(), p)
+
+	body := `{"llm":{"provider":"anthropic","model":"claude-x","config":{"credentials_json":"sk-attacker"}},
+		"embedding":{"provider":"cohere","model":"embed-x"},
+		"blurb_llm":{"provider":"google","model":"gemini-x"}}`
+	req := httptest.NewRequest("PUT", "/api/v1/projects/"+p.ID, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", p.ID)
+	w := httptest.NewRecorder()
+
+	h.Update(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	updated, _ := repo.GetByID(context.Background(), p.ID)
+	if updated.LLM.Provider != "openai" || updated.LLM.Model != "decisionbox-analysis-model" {
+		t.Errorf("analysis LLM = %s/%s; want the gateway preset", updated.LLM.Provider, updated.LLM.Model)
+	}
+	if _, leaked := updated.LLM.Config["credentials_json"]; leaked {
+		t.Error("crafted credentials_json survived onto the updated analysis LLM")
+	}
+	if updated.Embedding.Provider != "openai" || updated.BlurbLLM == nil || updated.BlurbLLM.Provider != "openai" {
+		t.Errorf("embedding/blurb not forced to gateway preset: emb=%s blurb=%+v", updated.Embedding.Provider, updated.BlurbLLM)
+	}
+}
+
+// TestProjectsHandler_Create_UnmanagedHonorsBody is the off-by-default
+// control: with managed mode off, the request body is honored unchanged.
+func TestProjectsHandler_Create_UnmanagedHonorsBody(t *testing.T) {
+	// Ensure a clean disabled state regardless of prior tests in this binary.
+	t.Cleanup(managedai.Load)
+	t.Setenv(managedai.EnvGatewayURL, "")
+	managedai.Load()
+
+	repo := newMockProjectRepo()
+	h := NewProjectsHandler(repo, nil)
+	body := `{"name":"Self-hosted","domain":"gaming","category":"match3",
+		"llm":{"provider":"anthropic","model":"claude"}}`
+	req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Create(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", w.Code, w.Body.String())
+	}
+	var saved *models.Project
+	for _, p := range repo.projects {
+		saved = p
+	}
+	if saved.LLM.Provider != "anthropic" || saved.LLM.Model != "claude" {
+		t.Errorf("unmanaged create mutated LLM = %s/%s; want anthropic/claude", saved.LLM.Provider, saved.LLM.Model)
+	}
+}
+
+// TestSecretsHandler_Set_ManagedGuard verifies AI-credential writes are
+// refused (403) in managed mode and never reach the secret store, while
+// a non-AI key still writes.
+func TestSecretsHandler_Set_ManagedGuard(t *testing.T) {
+	enableManagedForTest(t)
+	repo := newMockProjectRepo()
+	p := &models.Project{Name: "S", Domain: "gaming", Category: "match3"}
+	repo.Create(context.Background(), p)
+	sp := &recordingSecretProvider{}
+	h := NewSecretsHandler(sp, repo)
+
+	for _, key := range []string{"llm-credentials", "embedding-credentials", "blurb-llm-credentials"} {
+		req := httptest.NewRequest("PUT", "/api/v1/projects/"+p.ID+"/secrets/"+key, strings.NewReader(`{"value":"sk-attacker"}`))
+		req.SetPathValue("id", p.ID)
+		req.SetPathValue("key", key)
+		w := httptest.NewRecorder()
+		h.Set(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("Set(%q) status = %d, want 403; body = %s", key, w.Code, w.Body.String())
+		}
+	}
+	if len(sp.setKeys) != 0 {
+		t.Errorf("secret store was written in managed mode: %v", sp.setKeys)
+	}
+
+	// A non-AI key is unaffected.
+	req := httptest.NewRequest("PUT", "/api/v1/projects/"+p.ID+"/secrets/warehouse-credentials", strings.NewReader(`{"value":"wh"}`))
+	req.SetPathValue("id", p.ID)
+	req.SetPathValue("key", "warehouse-credentials")
+	w := httptest.NewRecorder()
+	h.Set(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("Set(warehouse-credentials) status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if len(sp.setKeys) != 1 || sp.setKeys[0] != "warehouse-credentials" {
+		t.Errorf("warehouse-credentials should have been written once; got %v", sp.setKeys)
+	}
+}
+
+func TestAppConfig(t *testing.T) {
+	t.Run("managed", func(t *testing.T) {
+		enableManagedForTest(t)
+		req := httptest.NewRequest("GET", "/api/v1/config", nil)
+		w := httptest.NewRecorder()
+		AppConfig(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Cache-Control = %q, want no-store", cc)
+		}
+		var resp APIResponse
+		json.NewDecoder(w.Body).Decode(&resp)
+		data := resp.Data.(map[string]interface{})
+		if data["ai_config_managed"] != true {
+			t.Errorf("ai_config_managed = %v, want true", data["ai_config_managed"])
+		}
+	})
+
+	t.Run("unmanaged", func(t *testing.T) {
+		t.Cleanup(managedai.Load)
+		t.Setenv(managedai.EnvGatewayURL, "")
+		managedai.Load()
+		req := httptest.NewRequest("GET", "/api/v1/config", nil)
+		w := httptest.NewRecorder()
+		AppConfig(w, req)
+
+		var resp APIResponse
+		json.NewDecoder(w.Body).Decode(&resp)
+		data := resp.Data.(map[string]interface{})
+		if data["ai_config_managed"] != false {
+			t.Errorf("ai_config_managed = %v, want false", data["ai_config_managed"])
+		}
+	})
+}

--- a/services/api/internal/handler/projects.go
+++ b/services/api/internal/handler/projects.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decisionbox-io/decisionbox/libs/go-common/telemetry"
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	apilog "github.com/decisionbox-io/decisionbox/services/api/internal/log"
+	"github.com/decisionbox-io/decisionbox/services/api/internal/managedai"
 	"github.com/decisionbox-io/decisionbox/services/api/models"
 )
 
@@ -232,6 +233,16 @@ func (h *ProjectsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// state string.
 	p.State = models.ProjectStateReady
 
+	// Managed-inference override (no-op unless AI_GATEWAY_URL is set):
+	// replace whatever LLM/blurb/embedding config the request carried
+	// with the operator-configured gateway preset before anything else
+	// looks at it. Whole-object replacement (not field-patching) so a
+	// crafted Config["credentials_json"]/["base_url"] cannot survive.
+	// Placed right after decode so validation, the provider allow-list,
+	// and persistence all see the canonical gateway config — a crafted
+	// POST is overridden (200), never rejected.
+	managedai.Apply(&p)
+
 	if msg := validateLLMConfig(p.LLM.Provider, p.LLM.Config); msg != "" {
 		writeError(w, http.StatusBadRequest, msg)
 		return
@@ -409,6 +420,13 @@ func (h *ProjectsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
+
+	// Managed-inference override (no-op unless AI_GATEWAY_URL is set):
+	// canonicalize the incoming AI config to the gateway preset before
+	// the checks and the merge below, so a crafted PUT that sets a
+	// different provider/model/base_url is discarded — the merged
+	// `existing` persists the preset, not the request body.
+	managedai.Apply(&incoming)
 
 	// Plan-gate: if the request changes the LLM provider, validate the
 	// new provider against the plan's allow-list before persisting.

--- a/services/api/internal/handler/search.go
+++ b/services/api/internal/handler/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -216,6 +217,18 @@ func (h *SearchHandler) Search(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// credentialWithEnvFallback resolves an inference credential the way the
+// agent's resolveCredential does: the per-project secret wins, else the
+// named environment variable. Managed-inference gateway mode writes no
+// per-project AI secret, so the API-side inference paths (search/ask) rely
+// on this env fallback to reach the gateway.
+func credentialWithEnvFallback(secret, envVar string) string {
+	if secret != "" {
+		return secret
+	}
+	return os.Getenv(envVar)
+}
+
 // createEmbeddingProvider creates an embedding provider for a project.
 // The projectConfig map carries non-credential provider settings the
 // dashboard saved (auth_method, project_id, location, region, role_arn,
@@ -228,11 +241,19 @@ func (h *SearchHandler) createEmbeddingProvider(ctx context.Context, providerNam
 	for k, v := range projectConfig {
 		cfg[k] = v
 	}
+	secret := ""
 	if h.secretProvider != nil {
-		key, err := h.secretProvider.Get(ctx, projectID, "embedding-credentials")
-		if err == nil && key != "" {
-			cfg["credentials_json"] = key
+		if key, err := h.secretProvider.Get(ctx, projectID, "embedding-credentials"); err == nil {
+			secret = key
 		}
+	}
+	// Env fallback, mirroring the agent's resolveCredential order (secret
+	// wins, env next). The managed-inference gateway mode stores no
+	// per-project AI secret, so this API-side search path (which embeds the
+	// query) must fall back to EMBEDDING_API_KEY or it would build a
+	// credential-less provider and fail.
+	if cred := credentialWithEnvFallback(secret, "EMBEDDING_API_KEY"); cred != "" {
+		cfg["credentials_json"] = cred
 	}
 	return goembedding.NewProvider(providerName, cfg)
 }
@@ -832,13 +853,16 @@ func chunkCitationID(c gosources.Chunk) string {
 
 // createLLMProvider creates an LLM provider for a project's RAG answer synthesis.
 func (h *SearchHandler) createLLMProvider(ctx context.Context, project *models.Project, projectID string) (gollm.Provider, error) {
-	apiKey := ""
+	secret := ""
 	if h.secretProvider != nil {
-		key, err := h.secretProvider.Get(ctx, projectID, "llm-credentials")
-		if err == nil {
-			apiKey = key
+		if key, err := h.secretProvider.Get(ctx, projectID, "llm-credentials"); err == nil {
+			secret = key
 		}
 	}
+	// Env fallback, mirroring the agent's resolveCredential order. Managed
+	// mode stores no per-project AI secret, so Ask's RAG synthesis (which
+	// runs in the API process) must fall back to LLM_API_KEY.
+	apiKey := credentialWithEnvFallback(secret, "LLM_API_KEY")
 
 	cfg := gollm.ProviderConfig{
 		"credentials_json": apiKey,

--- a/services/api/internal/handler/search_credential_test.go
+++ b/services/api/internal/handler/search_credential_test.go
@@ -1,0 +1,31 @@
+package handler
+
+import "testing"
+
+// TestCredentialWithEnvFallback pins the resolution order the API-side
+// search/ask providers use: a per-project secret wins, and when it's empty
+// (managed-inference gateway mode stores no per-project AI secret) the
+// named env var is the fallback. Without the fallback, managed-mode Ask and
+// semantic search build credential-less providers and fail.
+func TestCredentialWithEnvFallback(t *testing.T) {
+	t.Run("secret wins over env", func(t *testing.T) {
+		t.Setenv("LLM_API_KEY", "from-env")
+		if got := credentialWithEnvFallback("from-secret", "LLM_API_KEY"); got != "from-secret" {
+			t.Errorf("got %q, want from-secret", got)
+		}
+	})
+
+	t.Run("env fallback when no secret", func(t *testing.T) {
+		t.Setenv("EMBEDDING_API_KEY", "dbx-live-embed")
+		if got := credentialWithEnvFallback("", "EMBEDDING_API_KEY"); got != "dbx-live-embed" {
+			t.Errorf("got %q, want dbx-live-embed", got)
+		}
+	})
+
+	t.Run("empty when neither", func(t *testing.T) {
+		t.Setenv("LLM_API_KEY", "")
+		if got := credentialWithEnvFallback("", "LLM_API_KEY"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}

--- a/services/api/internal/handler/secrets.go
+++ b/services/api/internal/handler/secrets.go
@@ -6,6 +6,7 @@ import (
 	"github.com/decisionbox-io/decisionbox/libs/go-common/secrets"
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	apilog "github.com/decisionbox-io/decisionbox/services/api/internal/log"
+	"github.com/decisionbox-io/decisionbox/services/api/internal/managedai"
 )
 
 // SecretsHandler handles per-project secret management.
@@ -28,6 +29,17 @@ func (h *SecretsHandler) Set(w http.ResponseWriter, r *http.Request) {
 	p, err := h.projectRepo.GetByID(r.Context(), projectID)
 	if err != nil || p == nil {
 		writeError(w, http.StatusNotFound, "project not found")
+		return
+	}
+
+	// Managed-inference guard: in managed mode the analysis/blurb/embedding
+	// credentials are the gateway key supplied via env fallback, never a
+	// per-project secret. Refuse writes to those slots — otherwise a
+	// crafted secret write would shadow the env key in resolveCredential
+	// and re-route inference off the gateway. No-op when managed mode is
+	// off (self-hosted keeps full per-project credential control).
+	if managedai.IsManagedSecretKey(key) {
+		writeError(w, http.StatusForbidden, "AI credentials are managed by the inference gateway on this deployment and cannot be set per project")
 		return
 	}
 

--- a/services/api/internal/managedai/managedai.go
+++ b/services/api/internal/managedai/managedai.go
@@ -1,0 +1,232 @@
+// Package managedai implements an optional "managed inference gateway"
+// mode for the API service. When the deployment sets AI_GATEWAY_URL,
+// every project's analysis LLM, blurb LLM, and embedding config is
+// overridden at write time to point at a single OpenAI-compatible
+// gateway using operator-supplied model aliases, and per-project AI
+// credential writes are refused. The credential itself rides the
+// existing env fallback the agent already honors (LLM_API_KEY /
+// EMBEDDING_API_KEY), so nothing is persisted in the project document.
+//
+// This is a generic capability: the gateway URL, the model aliases, and
+// the credential all come from the environment. There is nothing
+// DecisionBox-Cloud–specific in this package — a self-hosted operator
+// pointing AI_GATEWAY_URL at any OpenAI-compatible gateway gets the same
+// behavior. With AI_GATEWAY_URL unset the whole package is inert and
+// provider choice is unchanged.
+//
+// The design leans on a property of every inference call site (community
+// and plugin): they resolve the provider from the *stored* project
+// document (project.LLM / BlurbLLM / Embedding) and fall back to the
+// env credential when no per-project secret exists. Canonicalizing the
+// stored document on the write path therefore routes all downstream
+// inference through the gateway with no read-path changes.
+package managedai
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	goembedding "github.com/decisionbox-io/decisionbox/libs/go-common/embedding"
+	"github.com/decisionbox-io/decisionbox/services/api/models"
+)
+
+// Environment variables that drive managed mode. AI_GATEWAY_URL is the
+// single activation switch: present ⇒ managed mode ON.
+const (
+	EnvGatewayURL      = "AI_GATEWAY_URL"
+	EnvAnalysisModel   = "AI_GATEWAY_ANALYSIS_MODEL"
+	EnvBlurbModel      = "AI_GATEWAY_BLURB_MODEL"
+	EnvEmbedModel      = "AI_GATEWAY_EMBED_MODEL"
+	EnvEmbedDimensions = "AI_GATEWAY_EMBED_DIMENSIONS"
+
+	// Credential env vars — the same ones the agent's resolveCredential
+	// already falls back to. Managed mode requires both to be present so
+	// analysis, blurb, and embedding all authenticate against the gateway.
+	// These are the NAMES of the environment variables, not secrets.
+	envLLMAPIKey       = "LLM_API_KEY"       //nolint:gosec // G101: env var name, not a credential
+	envEmbeddingAPIKey = "EMBEDDING_API_KEY" //nolint:gosec // G101: env var name, not a credential
+
+	// managedProvider is the provider all three roles are pinned to in
+	// managed mode. The gateway speaks the OpenAI-compatible wire, which
+	// the openai LLM and embedding providers already dispatch over.
+	managedProvider = "openai"
+)
+
+// managedSecretKeys are the per-project secret keys that must NOT be
+// writable in managed mode: a stored per-project AI credential would
+// shadow the env-fallback gateway key in resolveCredential and let a
+// crafted secret write route inference somewhere else.
+var managedSecretKeys = map[string]struct{}{
+	"llm-credentials":       {},
+	"embedding-credentials": {},
+	"blurb-llm-credentials": {},
+}
+
+// config is the resolved, immutable managed-mode configuration for the
+// process. Built once from the environment via load().
+type config struct {
+	enabled         bool
+	baseURL         string // normalized gateway base URL, includes /v1, no trailing slash
+	analysisModel   string
+	blurbModel      string
+	embedModel      string
+	embedDimensions string // optional; empty ⇒ let the agent probe (#282)
+}
+
+var (
+	mu     sync.RWMutex
+	loaded *config
+)
+
+// Load reads the AI_GATEWAY_* environment and installs the process-wide
+// managed-mode configuration. Call once during startup (before serving
+// traffic). Safe to call again — it simply re-reads the environment,
+// which tests rely on after t.Setenv.
+func Load() {
+	c := fromEnv()
+	mu.Lock()
+	loaded = c
+	mu.Unlock()
+}
+
+// current returns the installed configuration, deriving one from the
+// environment on demand if Load has not run yet (keeps unit tests that
+// exercise the package functions directly honest without forcing a Load
+// call, and makes a missing startup Load fail safe rather than panic).
+func current() *config {
+	mu.RLock()
+	c := loaded
+	mu.RUnlock()
+	if c != nil {
+		return c
+	}
+	return fromEnv()
+}
+
+func fromEnv() *config {
+	raw := strings.TrimSpace(os.Getenv(EnvGatewayURL))
+	if raw == "" {
+		return &config{enabled: false}
+	}
+	return &config{
+		enabled:         true,
+		baseURL:         strings.TrimRight(raw, "/"),
+		analysisModel:   strings.TrimSpace(os.Getenv(EnvAnalysisModel)),
+		blurbModel:      strings.TrimSpace(os.Getenv(EnvBlurbModel)),
+		embedModel:      strings.TrimSpace(os.Getenv(EnvEmbedModel)),
+		embedDimensions: strings.TrimSpace(os.Getenv(EnvEmbedDimensions)),
+	}
+}
+
+// Enabled reports whether managed mode is active (AI_GATEWAY_URL set).
+func Enabled() bool { return current().enabled }
+
+// Validate returns a non-nil error when managed mode is on but its
+// configuration is incomplete or malformed. Call at startup and fail
+// fast (the auth/policy plugins use the same log-fatal-on-bad-config
+// pattern) — a half-configured gateway would silently mis-route or fail
+// every inference call at run time with a far less obvious error.
+func Validate() error { return current().validate() }
+
+// Apply overwrites p's analysis LLM, blurb LLM, and embedding config
+// with the gateway preset when managed mode is on. It is a no-op when
+// managed mode is off or p is nil. Whole objects (and their Config maps)
+// are replaced, not field-patched, so a crafted Config["credentials_json"]
+// / ["base_url"] / custom key in the request body cannot survive.
+func Apply(p *models.Project) { current().apply(p) }
+
+// IsManagedSecretKey reports whether a per-project secret key is one of
+// the AI credential slots that must not be written in managed mode.
+// Always false when managed mode is off.
+func IsManagedSecretKey(key string) bool { return current().isManagedSecretKey(key) }
+
+func (c *config) validate() error {
+	if !c.enabled {
+		return nil
+	}
+
+	u, err := url.Parse(c.baseURL)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("managedai: %s must be an absolute URL (got %q)", EnvGatewayURL, c.baseURL)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("managedai: %s must use http or https (got %q)", EnvGatewayURL, c.baseURL)
+	}
+	// Require the OpenAI-compatible /v1 path: the openai providers append
+	// /chat/completions and /embeddings to base_url, so a bare host would
+	// POST to the wrong path. Catching it here beats a 404 at run time.
+	if !strings.HasSuffix(strings.TrimRight(u.Path, "/"), "/v1") {
+		return fmt.Errorf("managedai: %s must include the /v1 path, e.g. https://host/v1 (got %q)", EnvGatewayURL, c.baseURL)
+	}
+
+	var missing []string
+	if c.analysisModel == "" {
+		missing = append(missing, EnvAnalysisModel)
+	}
+	if c.blurbModel == "" {
+		missing = append(missing, EnvBlurbModel)
+	}
+	if c.embedModel == "" {
+		missing = append(missing, EnvEmbedModel)
+	}
+	// The gateway credential rides the existing agent env fallback; both
+	// keys must be present so analysis/blurb and embedding can authenticate.
+	if strings.TrimSpace(os.Getenv(envLLMAPIKey)) == "" {
+		missing = append(missing, envLLMAPIKey)
+	}
+	if strings.TrimSpace(os.Getenv(envEmbeddingAPIKey)) == "" {
+		missing = append(missing, envEmbeddingAPIKey)
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("managedai: %s is set but required vars are missing: %s", EnvGatewayURL, strings.Join(missing, ", "))
+	}
+
+	if c.embedDimensions != "" {
+		if n, err := strconv.Atoi(c.embedDimensions); err != nil || n <= 0 {
+			return fmt.Errorf("managedai: %s must be a positive integer when set (got %q)", EnvEmbedDimensions, c.embedDimensions)
+		}
+	}
+	return nil
+}
+
+func (c *config) apply(p *models.Project) {
+	if !c.enabled || p == nil {
+		return
+	}
+
+	p.LLM = models.LLMConfig{
+		Provider: managedProvider,
+		Model:    c.analysisModel,
+		Config:   map[string]string{"base_url": c.baseURL},
+	}
+	p.BlurbLLM = &models.BlurbLLMConfig{
+		Provider: managedProvider,
+		Model:    c.blurbModel,
+		Config:   map[string]string{"base_url": c.baseURL},
+	}
+
+	embCfg := map[string]string{"base_url": c.baseURL}
+	// Optional fast-path: pin the vector size so the agent skips the live
+	// probe. When unset, the agent auto-detects from a live embedding
+	// (#282), which is the recommended default.
+	if c.embedDimensions != "" {
+		embCfg["dimensions"] = c.embedDimensions
+	}
+	p.Embedding = goembedding.ProjectConfig{
+		Provider: managedProvider,
+		Model:    c.embedModel,
+		Config:   embCfg,
+	}
+}
+
+func (c *config) isManagedSecretKey(key string) bool {
+	if !c.enabled {
+		return false
+	}
+	_, ok := managedSecretKeys[key]
+	return ok
+}

--- a/services/api/internal/managedai/managedai_test.go
+++ b/services/api/internal/managedai/managedai_test.go
@@ -1,0 +1,252 @@
+package managedai
+
+import (
+	"testing"
+
+	"github.com/decisionbox-io/decisionbox/services/api/models"
+)
+
+// setManaged wires a full, valid managed-mode environment for a test and
+// installs it. t.Setenv restores the previous value (and unset-ness) at
+// test end, so each test starts from a clean slate.
+func setManaged(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvGatewayURL, "https://ai.example.com/v1")
+	t.Setenv(EnvAnalysisModel, "decisionbox-analysis-model")
+	t.Setenv(EnvBlurbModel, "decisionbox-blurb-model")
+	t.Setenv(EnvEmbedModel, "decisionbox-embed-model")
+	t.Setenv(envLLMAPIKey, "dbx-live-abc")
+	t.Setenv(envEmbeddingAPIKey, "dbx-live-abc")
+	Load()
+}
+
+func TestDisabledByDefault(t *testing.T) {
+	// No AI_GATEWAY_URL in the environment.
+	t.Setenv(EnvGatewayURL, "")
+	Load()
+
+	if Enabled() {
+		t.Fatal("Enabled() = true with AI_GATEWAY_URL unset; want false")
+	}
+	if err := Validate(); err != nil {
+		t.Fatalf("Validate() = %v with managed mode off; want nil", err)
+	}
+	if IsManagedSecretKey("llm-credentials") {
+		t.Fatal("IsManagedSecretKey should be false when managed mode is off")
+	}
+}
+
+func TestApplyNoOpWhenDisabled(t *testing.T) {
+	t.Setenv(EnvGatewayURL, "")
+	Load()
+
+	p := &models.Project{
+		LLM: models.LLMConfig{Provider: "anthropic", Model: "claude", Config: map[string]string{"x": "y"}},
+	}
+	Apply(p)
+
+	if p.LLM.Provider != "anthropic" || p.LLM.Model != "claude" {
+		t.Fatalf("Apply mutated project with managed mode off: %+v", p.LLM)
+	}
+}
+
+func TestApplyOverridesAllThreeRoles(t *testing.T) {
+	setManaged(t)
+
+	// A hostile request body: different providers, and — critically — a
+	// crafted credentials_json/base_url smuggled into Config that must NOT
+	// survive the whole-object replacement.
+	p := &models.Project{
+		LLM: models.LLMConfig{
+			Provider: "anthropic",
+			Model:    "claude-attacker",
+			Config:   map[string]string{"credentials_json": "sk-attacker", "base_url": "https://evil.example.com"},
+		},
+		BlurbLLM: &models.BlurbLLMConfig{
+			Provider: "google",
+			Model:    "gemini-attacker",
+			Config:   map[string]string{"credentials_json": "sk-attacker"},
+		},
+	}
+	p.Embedding.Provider = "cohere"
+	p.Embedding.Model = "embed-attacker"
+	p.Embedding.Config = map[string]string{"credentials_json": "sk-attacker"}
+
+	Apply(p)
+
+	if p.LLM.Provider != "openai" || p.LLM.Model != "decisionbox-analysis-model" {
+		t.Errorf("analysis LLM = %+v; want openai/decisionbox-analysis-model", p.LLM)
+	}
+	if got := p.LLM.Config["base_url"]; got != "https://ai.example.com/v1" {
+		t.Errorf("analysis base_url = %q; want the gateway URL", got)
+	}
+	if _, leaked := p.LLM.Config["credentials_json"]; leaked {
+		t.Error("crafted credentials_json survived Apply on the analysis LLM")
+	}
+
+	if p.BlurbLLM == nil || p.BlurbLLM.Provider != "openai" || p.BlurbLLM.Model != "decisionbox-blurb-model" {
+		t.Errorf("blurb LLM = %+v; want openai/decisionbox-blurb-model", p.BlurbLLM)
+	}
+	if _, leaked := p.BlurbLLM.Config["credentials_json"]; leaked {
+		t.Error("crafted credentials_json survived Apply on the blurb LLM")
+	}
+
+	if p.Embedding.Provider != "openai" || p.Embedding.Model != "decisionbox-embed-model" {
+		t.Errorf("embedding = %+v; want openai/decisionbox-embed-model", p.Embedding)
+	}
+	if _, leaked := p.Embedding.Config["credentials_json"]; leaked {
+		t.Error("crafted credentials_json survived Apply on the embedding")
+	}
+	// No dimensions env set ⇒ let the agent probe; no dimensions key.
+	if _, ok := p.Embedding.Config["dimensions"]; ok {
+		t.Error("dimensions should be absent when AI_GATEWAY_EMBED_DIMENSIONS is unset")
+	}
+}
+
+func TestApplyEmbedDimensionsFastPath(t *testing.T) {
+	setManaged(t)
+	t.Setenv(EnvEmbedDimensions, "3072")
+	Load()
+
+	p := &models.Project{}
+	Apply(p)
+
+	if got := p.Embedding.Config["dimensions"]; got != "3072" {
+		t.Errorf("embedding dimensions = %q; want 3072", got)
+	}
+}
+
+func TestApplyIsIdempotent(t *testing.T) {
+	setManaged(t)
+	p := &models.Project{}
+	Apply(p)
+	firstProvider, firstModel, firstBase := p.LLM.Provider, p.LLM.Model, p.LLM.Config["base_url"]
+	Apply(p)
+	if p.LLM.Provider != firstProvider || p.LLM.Model != firstModel || p.LLM.Config["base_url"] != firstBase {
+		t.Errorf("Apply not idempotent: %s/%s/%s then %s/%s/%s",
+			firstProvider, firstModel, firstBase, p.LLM.Provider, p.LLM.Model, p.LLM.Config["base_url"])
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			env: map[string]string{
+				EnvGatewayURL: "https://ai.example.com/v1", EnvAnalysisModel: "a",
+				EnvBlurbModel: "b", EnvEmbedModel: "e",
+				envLLMAPIKey: "k", envEmbeddingAPIKey: "k",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing analysis alias",
+			env: map[string]string{
+				EnvGatewayURL: "https://ai.example.com/v1", EnvBlurbModel: "b",
+				EnvEmbedModel: "e", envLLMAPIKey: "k", envEmbeddingAPIKey: "k",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing llm api key",
+			env: map[string]string{
+				EnvGatewayURL: "https://ai.example.com/v1", EnvAnalysisModel: "a",
+				EnvBlurbModel: "b", EnvEmbedModel: "e", envEmbeddingAPIKey: "k",
+			},
+			wantErr: true,
+		},
+		{
+			name: "url missing /v1 path",
+			env: map[string]string{
+				EnvGatewayURL: "https://ai.example.com", EnvAnalysisModel: "a",
+				EnvBlurbModel: "b", EnvEmbedModel: "e",
+				envLLMAPIKey: "k", envEmbeddingAPIKey: "k",
+			},
+			wantErr: true,
+		},
+		{
+			name: "url not absolute",
+			env: map[string]string{
+				EnvGatewayURL: "ai.example.com/v1", EnvAnalysisModel: "a",
+				EnvBlurbModel: "b", EnvEmbedModel: "e",
+				envLLMAPIKey: "k", envEmbeddingAPIKey: "k",
+			},
+			wantErr: true,
+		},
+		{
+			name: "url wrong scheme",
+			env: map[string]string{
+				EnvGatewayURL: "ftp://ai.example.com/v1", EnvAnalysisModel: "a",
+				EnvBlurbModel: "b", EnvEmbedModel: "e",
+				envLLMAPIKey: "k", envEmbeddingAPIKey: "k",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad dimensions",
+			env: map[string]string{
+				EnvGatewayURL: "https://ai.example.com/v1", EnvAnalysisModel: "a",
+				EnvBlurbModel: "b", EnvEmbedModel: "e", EnvEmbedDimensions: "-1",
+				envLLMAPIKey: "k", envEmbeddingAPIKey: "k",
+			},
+			wantErr: true,
+		},
+	}
+
+	// Every var this package reads — cleared per-case, then set from the
+	// case map, so a case that omits a var truly tests its absence.
+	allVars := []string{
+		EnvGatewayURL, EnvAnalysisModel, EnvBlurbModel, EnvEmbedModel,
+		EnvEmbedDimensions, envLLMAPIKey, envEmbeddingAPIKey,
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, v := range allVars {
+				t.Setenv(v, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			Load()
+			err := Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() err = %v; wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestURLTrailingSlashNormalized(t *testing.T) {
+	setManaged(t)
+	t.Setenv(EnvGatewayURL, "https://ai.example.com/v1/")
+	Load()
+
+	if err := Validate(); err != nil {
+		t.Fatalf("Validate() = %v; want nil (trailing slash should normalize)", err)
+	}
+	p := &models.Project{}
+	Apply(p)
+	if got := p.LLM.Config["base_url"]; got != "https://ai.example.com/v1" {
+		t.Errorf("base_url = %q; want trailing slash trimmed", got)
+	}
+}
+
+func TestIsManagedSecretKey(t *testing.T) {
+	setManaged(t)
+
+	managed := []string{"llm-credentials", "embedding-credentials", "blurb-llm-credentials"}
+	for _, k := range managed {
+		if !IsManagedSecretKey(k) {
+			t.Errorf("IsManagedSecretKey(%q) = false; want true", k)
+		}
+	}
+	for _, k := range []string{"warehouse-credentials", "random-key", ""} {
+		if IsManagedSecretKey(k) {
+			t.Errorf("IsManagedSecretKey(%q) = true; want false", k)
+		}
+	}
+}

--- a/services/api/internal/runner/env.go
+++ b/services/api/internal/runner/env.go
@@ -42,6 +42,16 @@ var agentForwardedEnvKeys = []string{
 	"SECRET_GCP_PROJECT_ID",
 	"QDRANT_URL",
 	"QDRANT_API_KEY",
+	// Inference-credential env fallback. resolveCredential (agentserver /
+	// index_schema) reads these INSIDE the agent when no per-project
+	// secret exists — the managed-inference gateway mode relies on exactly
+	// that fallback (nothing AI-related is stored per project), and a
+	// self-hosted operator may set them as a global default too. Forwarded
+	// only when set, so the per-project-secret model is unaffected when
+	// they're absent.
+	"LLM_API_KEY",
+	"EMBEDDING_API_KEY",
+	"BLURB_LLM_API_KEY",
 	// DISCOVERY_MAX_DURATION caps the outer agent ctx — it lives on the
 	// agent side (not the API), so it has to be forwarded for container
 	// runs. Subprocess runs already inherit it from the API process env.

--- a/services/api/internal/runner/env_test.go
+++ b/services/api/internal/runner/env_test.go
@@ -1,0 +1,31 @@
+package runner
+
+import "testing"
+
+// TestForwardedEnv_InferenceCredentials pins that the managed-inference
+// gateway credential env vars are forwarded to spawned agents when set —
+// the managed mode has no per-project AI secret, so the agent's
+// resolveCredential env fallback must find these inside the agent
+// container. Absent vars must not be forwarded (per-project-secret model
+// stays clean for self-hosted).
+func TestForwardedEnv_InferenceCredentials(t *testing.T) {
+	t.Setenv("LLM_API_KEY", "dbx-live-analysis")
+	t.Setenv("EMBEDDING_API_KEY", "dbx-live-embed")
+	// BLURB_LLM_API_KEY deliberately left unset — it must NOT appear.
+
+	got := collectForwardedEnv(agentForwardedEnvKeys)
+	found := map[string]string{}
+	for _, kv := range got {
+		found[kv.Key] = kv.Value
+	}
+
+	if found["LLM_API_KEY"] != "dbx-live-analysis" {
+		t.Errorf("LLM_API_KEY not forwarded: %q", found["LLM_API_KEY"])
+	}
+	if found["EMBEDDING_API_KEY"] != "dbx-live-embed" {
+		t.Errorf("EMBEDDING_API_KEY not forwarded: %q", found["EMBEDDING_API_KEY"])
+	}
+	if _, present := found["BLURB_LLM_API_KEY"]; present {
+		t.Error("BLURB_LLM_API_KEY should not be forwarded when unset")
+	}
+}

--- a/services/api/internal/server/server.go
+++ b/services/api/internal/server/server.go
@@ -183,6 +183,11 @@ func NewWithRouteGroups(db *database.DB, healthHandler *health.Handler, secretPr
 	// from the systeminfo registry; the handler holds no component list.
 	mux.HandleFunc("GET /api/v1/system", withRole(viewer, handler.SystemInfo))
 
+	// Deployment capability flags for the dashboard (viewer). Currently
+	// carries ai_config_managed so the UI hides AI-config surfaces when
+	// inference is routed through a managed gateway.
+	mux.HandleFunc("GET /api/v1/config", withRole(viewer, handler.AppConfig))
+
 	// Providers — viewer
 	mux.HandleFunc("GET /api/v1/providers/llm", withRole(viewer, providers.ListLLMProviders))
 	mux.HandleFunc("POST /api/v1/providers/llm/{id}/models/live", withRole(viewer, providers.ListLiveLLMModels))

--- a/ui/dashboard/src/app/projects/[id]/settings/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/settings/page.tsx
@@ -50,6 +50,13 @@ export default function ProjectSettingsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // When the deployment routes inference through a managed gateway, the
+  // AI/Embedding + Blurb config is preset and immutable server-side, so we
+  // hide those tabs. Default false (self-hosted / full provider choice);
+  // the flag is fetched alongside the project and the whole Tabs block is
+  // gated on `loading`, so there is no flash either way.
+  const [aiConfigManaged, setAiConfigManaged] = useState(false);
+
   // General tab state
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -77,8 +84,13 @@ export default function ProjectSettingsPage() {
   const [savingValidation, setSavingValidation] = useState(false);
 
   // Tab routing — honor `location.hash` so deep-links like
-  // `/projects/:id/settings#advanced` open the right tab.
-  const validTabs = ['general', 'warehouse', 'ai', 'blurb', 'profile', 'advanced'];
+  // `/projects/:id/settings#advanced` open the right tab. The AI/Blurb
+  // tabs drop out of the valid set in managed mode.
+  const validTabs = [
+    'general', 'warehouse',
+    ...(aiConfigManaged ? [] : ['ai', 'blurb']),
+    'profile', 'advanced',
+  ];
   const [activeTab, setActiveTab] = useState<string>('general');
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -99,10 +111,18 @@ export default function ProjectSettingsPage() {
   }, [id]);
 
   useEffect(() => {
-    Promise.all([api.getProject(id), api.listLLMProviders()])
-      .then(([proj, llmProvs]) => {
+    Promise.all([
+      api.getProject(id),
+      api.listLLMProviders(),
+      // Never let the capability probe break the settings page: managed
+      // mode and this endpoint ship together, so a failure means an older
+      // API without it — treat that as unmanaged (show config).
+      api.getAppConfig().catch(() => ({ ai_config_managed: false })),
+    ])
+      .then(([proj, llmProvs, appConfig]) => {
         setProject(proj);
         setLlmProviders(llmProvs);
+        setAiConfigManaged(appConfig.ai_config_managed);
         setName(proj.name);
         setDescription(proj.description || '');
         setLanguage(proj.language || 'English');
@@ -244,15 +264,19 @@ export default function ProjectSettingsPage() {
 
   return (
     <Shell breadcrumb={breadcrumb}>
-      <Tabs value={activeTab} onChange={(v) => { if (v) setActiveTab(v); }} styles={{
-        tab: { fontSize: 13, fontWeight: 500, padding: '8px 16px' },
-        panel: { paddingTop: 20 },
-      }}>
+      <Tabs
+        value={validTabs.includes(activeTab) ? activeTab : 'general'}
+        onChange={(v) => { if (v) setActiveTab(v); }}
+        styles={{
+          tab: { fontSize: 13, fontWeight: 500, padding: '8px 16px' },
+          panel: { paddingTop: 20 },
+        }}
+      >
         <Tabs.List>
           <Tabs.Tab value="general">General</Tabs.Tab>
           <Tabs.Tab value="warehouse">Data Warehouse</Tabs.Tab>
-          <Tabs.Tab value="ai">AI &amp; Embedding</Tabs.Tab>
-          <Tabs.Tab value="blurb">Blurb Model</Tabs.Tab>
+          {!aiConfigManaged && <Tabs.Tab value="ai">AI &amp; Embedding</Tabs.Tab>}
+          {!aiConfigManaged && <Tabs.Tab value="blurb">Blurb Model</Tabs.Tab>}
           {profileSchema && <Tabs.Tab value="profile">Profile</Tabs.Tab>}
           <Tabs.Tab value="advanced">Advanced</Tabs.Tab>
         </Tabs.List>
@@ -284,10 +308,13 @@ export default function ProjectSettingsPage() {
           <WarehouseConfigPanel projectId={id} variant="page" onSaved={() => { void refreshProject(); }} />
         </Tabs.Panel>
 
+        {!aiConfigManaged && (
         <Tabs.Panel value="ai">
           <ProvidersPanel projectId={id} variant="page" onSaved={() => { void refreshProject(); }} />
         </Tabs.Panel>
+        )}
 
+        {!aiConfigManaged && (
         <Tabs.Panel value="blurb">
           <SettingsSection>
             <Text size="sm" fw={500}>Blurb Model</Text>
@@ -309,6 +336,7 @@ export default function ProjectSettingsPage() {
             </Group>
           </SettingsSection>
         </Tabs.Panel>
+        )}
 
         {profileSchema && (
           <Tabs.Panel value="profile">

--- a/ui/dashboard/src/app/projects/new/page.tsx
+++ b/ui/dashboard/src/app/projects/new/page.tsx
@@ -19,6 +19,13 @@ export default function NewProjectPage() {
   const [active, setActive] = useState(0);
   const [loading, setLoading] = useState(false);
 
+  // Managed-inference deployments preset AI config server-side, so the AI,
+  // Embedding, and Blurb wizard steps are skipped entirely. Default false
+  // (self-hosted); fetched with the rest of the config before the stepper
+  // renders, so the step set is fixed for the whole flow (no flash, no
+  // shifting indices mid-wizard).
+  const [aiConfigManaged, setAiConfigManaged] = useState(false);
+
   // Data from API (dynamic)
   const [domains, setDomains] = useState<Domain[]>([]);
   const [warehouseProviders, setWarehouseProviders] = useState<ProviderMeta[]>([]);
@@ -61,12 +68,16 @@ export default function NewProjectPage() {
       api.listWarehouseProviders(),
       api.listLLMProviders(),
       api.listEmbeddingProviders(),
+      // Capability probe — a failure means an older API without it, which
+      // is definitionally unmanaged, so default to showing the AI steps.
+      api.getAppConfig().catch(() => ({ ai_config_managed: false })),
     ])
-      .then(([domainsData, whProviders, llmProvs, embProvs]) => {
+      .then(([domainsData, whProviders, llmProvs, embProvs, appConfig]) => {
         setDomains(domainsData);
         setWarehouseProviders(whProviders);
         setLlmProviders(llmProvs);
         setEmbeddingProviders(embProvs || []);
+        setAiConfigManaged(appConfig.ai_config_managed);
         // Pre-select the first embedding provider (usually OpenAI per
         // the spike winners). The user can change it, but the field
         // starts populated so the common case is one click.
@@ -133,28 +144,39 @@ export default function NewProjectPage() {
   const llmSelectedAuthMethod = llmAuthMethods.find((m) => m.id === llm.authMethod);
   const llmNeedsCredential = (llmSelectedAuthMethod?.fields || []).some((f) => f.type === 'credential');
 
-  const canProceed = [
-    () => name && domain && category,
-    () => warehouse.provider && warehouse.config['dataset'] && (whAuthMethods.length === 0 || warehouse.authMethod) && (!authNeedsCredential || warehouse.credential),
+  // Wizard steps, in order. In managed-inference mode the AI, Embedding,
+  // and Blurb steps drop out — their config is preset server-side. The
+  // set is fixed at load (aiConfigManaged is resolved before the stepper
+  // renders), so `active` indexes a stable list for the whole flow.
+  const stepIds = aiConfigManaged
+    ? ['basics', 'warehouse']
+    : ['basics', 'warehouse', 'ai', 'embedding', 'blurb'];
+
+  // Per-step "can advance" predicate, keyed by step id rather than by
+  // position so dropping the AI steps can't shift the wrong guard onto a
+  // remaining step.
+  const canProceedById: Record<string, () => boolean> = {
+    basics: () => Boolean(name && domain && category),
+    warehouse: () => Boolean(warehouse.provider && warehouse.config['dataset'] && (whAuthMethods.length === 0 || warehouse.authMethod) && (!authNeedsCredential || warehouse.credential)),
     // AI step: must be in the "model" phase (models loaded) and have a
     // model selected. The credentials phase uses its own "Load models"
     // button instead of Next. A user-deployed endpoint is the exception:
     // it has no model picker, so the credentials phase alone is complete
     // once the endpoint ID is filled.
-    () => llm.provider && (
+    ai: () => Boolean(llm.provider && (
       llm.config['endpoint_id']?.trim()
         ? ((llmAuthMethods.length === 0 || llm.authMethod) && (!llmNeedsCredential || llm.apiKey))
         : (aiPhase === 'model' && llm.config['model'])
-    ),
+    )),
     // Embedding step: mandatory — schema indexing won't start without
     // a provider + model. API key required when the provider asks for
     // one (OpenAI, Voyage, etc); cloud-creds providers (Bedrock,
     // Vertex) skip that check.
-    () => Boolean(embedding.provider) && Boolean(embedding.model) && (!embNeedsKey || Boolean(embedding.apiKey)),
+    embedding: () => Boolean(embedding.provider) && Boolean(embedding.model) && (!embNeedsKey || Boolean(embedding.apiKey)),
     // Blurb step: valid when the user either chose "use analysis LLM"
     // (blurb.enabled === false) or picked a model.
-    () => !blurb.enabled || (blurb.provider && blurb.model),
-  ];
+    blurb: () => Boolean(!blurb.enabled || (blurb.provider && blurb.model)),
+  };
 
   // Monotonic request id so a stale response from an in-flight fetch
   // (e.g. user clicked Load models twice, or switched provider mid-
@@ -211,6 +233,10 @@ export default function NewProjectPage() {
             ...(warehouse.authMethod ? { auth_method: warehouse.authMethod } : {}),
           },
         },
+        // In managed mode the server presets llm/embedding/blurb_llm from
+        // the gateway config and ignores anything sent here, so omit them
+        // entirely — the wizard never collected them.
+        ...(aiConfigManaged ? {} : {
         llm: {
           provider: llm.provider,
           // A user-deployed endpoint identifies its own model, so persist
@@ -260,6 +286,7 @@ export default function NewProjectPage() {
               },
             }
           : {}),
+        }),
       });
       // Save secrets in parallel — sequential awaits left a ~1s race
       // window between project creation (which sets
@@ -271,17 +298,22 @@ export default function NewProjectPage() {
       // interval, so in practice the race no longer fires.
       if (project.id) {
         const writes: Promise<unknown>[] = [];
-        if (llm.apiKey) writes.push(api.setSecret(project.id, 'llm-credentials', llm.apiKey));
         if (warehouse.credential) writes.push(api.setSecret(project.id, 'warehouse-credentials', warehouse.credential));
-        // Blurb-LLM credentials are stored separately. Only written when
-        // the user supplied one — otherwise the agent falls back to
-        // `llm-credentials`.
-        if (blurb.enabled && blurb.apiKey) writes.push(api.setSecret(project.id, 'blurb-llm-credentials', blurb.apiKey));
-        // Embedding credentials — required by the worker pre-flight if
-        // the provider exposes a credential field. Safe to save
-        // conditionally on user input (empty → skip, preserves an
-        // existing stored key on re-creates).
-        if (embedding.apiKey) writes.push(api.setSecret(project.id, 'embedding-credentials', embedding.apiKey));
+        // AI credentials are never written in managed mode — the gateway
+        // key rides the deployment env fallback, and the server refuses
+        // per-project AI credential writes anyway.
+        if (!aiConfigManaged) {
+          if (llm.apiKey) writes.push(api.setSecret(project.id, 'llm-credentials', llm.apiKey));
+          // Blurb-LLM credentials are stored separately. Only written when
+          // the user supplied one — otherwise the agent falls back to
+          // `llm-credentials`.
+          if (blurb.enabled && blurb.apiKey) writes.push(api.setSecret(project.id, 'blurb-llm-credentials', blurb.apiKey));
+          // Embedding credentials — required by the worker pre-flight if
+          // the provider exposes a credential field. Safe to save
+          // conditionally on user input (empty → skip, preserves an
+          // existing stored key on re-creates).
+          if (embedding.apiKey) writes.push(api.setSecret(project.id, 'embedding-credentials', embedding.apiKey));
+        }
         await Promise.all(writes);
       }
 
@@ -337,6 +369,11 @@ export default function NewProjectPage() {
                 </Card>
               </Stepper.Step>
 
+              {/* AI / Embedding / Blurb steps are hidden in managed-inference
+                  mode — their config is preset server-side. Mantine's Stepper
+                  filters out these `false` children, so the remaining step
+                  indices collapse cleanly. */}
+              {!aiConfigManaged && (
               <Stepper.Step label="AI" description="Provider + model">
                 <Card withBorder p="lg" mt="md">
                   <LLMFormFields
@@ -358,7 +395,9 @@ export default function NewProjectPage() {
                   />
                 </Card>
               </Stepper.Step>
+              )}
 
+              {!aiConfigManaged && (
               <Stepper.Step label="Embedding" description="Vector model">
                 <Card withBorder p="lg" mt="md">
                   <Stack>
@@ -374,7 +413,9 @@ export default function NewProjectPage() {
                   </Stack>
                 </Card>
               </Stepper.Step>
+              )}
 
+              {!aiConfigManaged && (
               <Stepper.Step label="Blurb Model" description="Schema-index LLM">
                 <Card withBorder p="lg" mt="md">
                   <Stack>
@@ -389,6 +430,7 @@ export default function NewProjectPage() {
                   </Stack>
                 </Card>
               </Stepper.Step>
+              )}
 
               <Stepper.Completed>
                 <Card withBorder p="lg" mt="md">
@@ -397,17 +439,23 @@ export default function NewProjectPage() {
                     <Text><strong>Name:</strong> {name}</Text>
                     <Text><strong>Domain:</strong> {domain} / {category}</Text>
                     <Text><strong>Warehouse:</strong> {selectedWarehouse?.name} / {warehouse.config['dataset']}</Text>
-                    <Text><strong>LLM:</strong> {selectedLLM?.name} / {llm.config['endpoint_id']?.trim() ? `endpoint ${llm.config['endpoint_id']}` : llm.config['model']}</Text>
-                    <Text>
-                      <strong>Embedding:</strong>{' '}
-                      {embProviderMeta?.name || embedding.provider} / {embedding.model}
-                    </Text>
-                    <Text>
-                      <strong>Blurb model:</strong>{' '}
-                      {blurb.enabled && blurb.model
-                        ? `${llmProviders.find((p) => p.id === blurb.provider)?.name || blurb.provider} / ${blurb.model}`
-                        : 'same as analysis LLM'}
-                    </Text>
+                    {aiConfigManaged ? (
+                      <Text c="dimmed"><strong>AI:</strong> managed by DecisionBox (analysis, blurb, and embedding preset)</Text>
+                    ) : (
+                      <>
+                        <Text><strong>LLM:</strong> {selectedLLM?.name} / {llm.config['endpoint_id']?.trim() ? `endpoint ${llm.config['endpoint_id']}` : llm.config['model']}</Text>
+                        <Text>
+                          <strong>Embedding:</strong>{' '}
+                          {embProviderMeta?.name || embedding.provider} / {embedding.model}
+                        </Text>
+                        <Text>
+                          <strong>Blurb model:</strong>{' '}
+                          {blurb.enabled && blurb.model
+                            ? `${llmProviders.find((p) => p.id === blurb.provider)?.name || blurb.provider} / ${blurb.model}`
+                            : 'same as analysis LLM'}
+                        </Text>
+                      </>
+                    )}
                     <Button onClick={handleCreate} loading={loading} fullWidth mt="md">Create Project</Button>
                   </Stack>
                 </Card>
@@ -416,7 +464,7 @@ export default function NewProjectPage() {
 
             <Group justify="flex-end">
               {active > 0 && <Button variant="default" onClick={() => setActive((c) => c - 1)}>Back</Button>}
-              {active < 5 && <Button onClick={() => setActive((c) => c + 1)} disabled={!canProceed[active]?.()}>Next</Button>}
+              {active < stepIds.length && <Button onClick={() => setActive((c) => c + 1)} disabled={!canProceedById[stepIds[active]]?.()}>Next</Button>}
             </Group>
           </>
         )}

--- a/ui/dashboard/src/lib/api.ts
+++ b/ui/dashboard/src/lib/api.ts
@@ -1032,6 +1032,17 @@ export interface SystemInfo {
   components: SystemComponent[];
 }
 
+// AppConfig carries deployment-level capability flags the dashboard reads
+// once at load. ai_config_managed is true when this deployment routes all
+// inference through a managed gateway (server-side AI_GATEWAY_URL set): the
+// AI/Embedding + Blurb settings tabs and the AI/embedding/blurb new-project
+// wizard steps are hidden because the config is preset and immutable
+// server-side. The server, not the UI, is authoritative — this only drives
+// what we bother rendering.
+export interface AppConfig {
+  ai_config_managed: boolean;
+}
+
 // --- API Functions ---
 
 export const api = {
@@ -1055,6 +1066,9 @@ export const api = {
 
   // System inventory — component + worker versions (System page)
   getSystemInfo: () => request<SystemInfo>('/api/v1/system'),
+
+  // Deployment capability flags (drives which config surfaces the UI renders)
+  getAppConfig: () => request<AppConfig>('/api/v1/config'),
 
   // Domain Packs (CRUD)
   listDomainPacks: () => request<DomainPack[]>('/api/v1/domain-packs'),


### PR DESCRIPTION
Part of the cross-repo **managed AI gateway** change (decisionbox-cloud-enterprise-tenant#16). Targets the `bridge/ai-gateway-only` integration branch pattern; merges to `main` once the whole set is verified end-to-end.

## What
Community half of issue #16 — activated by `AI_GATEWAY_URL`, **off by default**:

- **`managedai` package** — loaded once at startup with strict validation. `Apply` replaces the whole `LLM`/`BlurbLLM`/`Embedding` objects (fresh Config maps) with the gateway preset, so a crafted `Config["credentials_json"]`/`base_url` can't survive.
- **Write-path enforcement** — `projects.go` Create/Update call `managedai.Apply` after decode; a crafted `POST`/`PUT` is overridden, never honored. `secrets.go` refuses per-project AI credential writes (403).
- **`GET /api/v1/config`** → `{ai_config_managed}` for the dashboard.
- **UI hide** — settings AI/Blurb tabs + new-project wizard AI/embedding/blurb steps hidden when managed (fail-open, no flash).
- **Agent-env forward** — the k8s/Docker runner now forwards `LLM_API_KEY`/`EMBEDDING_API_KEY`/`BLURB_LLM_API_KEY` to spawned agents (managed mode has no per-project AI secret, so the agent's env-fallback needs them).

Builds on the merged #282 (embedding-dimension probe) — no dimension work here.

## Verified
`go build ./...`, `go test ./internal/managedai/... ./internal/handler/... ./internal/runner/...`, `golangci-lint`, dashboard `tsc --noEmit` + `eslint` + `jest` (323 pass).

— Co-coded with Jale 🤖