### PR TITLE
refactor(secrets): shared secrets.ResolveCredential (dashboard secret → env fallback)

### DIFF
--- a/libs/go-common/secrets/resolve.go
+++ b/libs/go-common/secrets/resolve.go
@@ -1,0 +1,64 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"os"
+)
+
+// Credential sources returned by ResolveCredential, describing where a
+// resolved value came from. Callers log this so operators can see which
+// path supplied a credential.
+const (
+	// SourceDashboard — the per-project secret stored via the dashboard.
+	SourceDashboard = "dashboard"
+	// SourceEnv — the process environment fallback (managed-inference
+	// gateway mode, or a self-hosted global default).
+	SourceEnv = "env"
+	// SourceNone — neither a secret nor an env value was present.
+	SourceNone = "none"
+)
+
+// ResolveCredential applies the platform credential-resolution order to a
+// single slot: the per-project dashboard secret wins, and the named
+// environment variable is the fallback. It returns the resolved value and
+// its source (SourceDashboard, SourceEnv, or SourceNone).
+//
+// Managed-inference gateway mode (AI_GATEWAY_URL set) stores no per-project
+// AI secret by design, so every inference call site relies on the env
+// fallback to reach the gateway; on-prem / BYO-key deployments set no such
+// env var, so the per-project secret continues to win. This single helper
+// is the one place that order lives — the agent, the API, and the
+// enterprise plugins all call it so the resolution can't drift between
+// surfaces.
+//
+// A missing secret is not an error: ErrNotFound — including the wrapped
+// form the gcp/aws/azure backends return via %w — falls through to the env
+// var silently. An *unexpected* secret-store error (a transport failure,
+// say) is returned in err so the caller can log it, but resolution still
+// falls through to the env var: an env-only or managed deployment must keep
+// working through a transient secret-backend blip rather than hard-fail.
+// A nil provider is tolerated (env-only resolution), which keeps call sites
+// that may not have wired a secret provider honest.
+func ResolveCredential(ctx context.Context, provider Provider, projectID, secretKey, envVar string) (value, source string, err error) {
+	if provider != nil {
+		v, gerr := provider.Get(ctx, projectID, secretKey)
+		switch {
+		case gerr == nil && v != "":
+			return v, SourceDashboard, nil
+		case gerr == nil:
+			// Empty value stored — treat as unset and fall through to env.
+		case errors.Is(gerr, ErrNotFound):
+			// Not set — fall through to env silently. Use errors.Is because
+			// the cloud backends wrap the sentinel with %w.
+		default:
+			// Unexpected read failure — remember it for the caller to log,
+			// but still try the env fallback below.
+			err = gerr
+		}
+	}
+	if v := os.Getenv(envVar); v != "" {
+		return v, SourceEnv, err
+	}
+	return "", SourceNone, err
+}

--- a/libs/go-common/secrets/resolve_test.go
+++ b/libs/go-common/secrets/resolve_test.go
@@ -1,0 +1,131 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// fakeProvider is a minimal Provider whose Get returns a fixed value/error.
+type fakeProvider struct {
+	value string
+	err   error
+}
+
+func (f fakeProvider) Get(_ context.Context, _, _ string) (string, error) {
+	return f.value, f.err
+}
+func (fakeProvider) Set(_ context.Context, _, _, _ string) error { return nil }
+func (fakeProvider) List(_ context.Context, _ string) ([]SecretEntry, error) {
+	return nil, nil
+}
+
+func TestResolveCredential(t *testing.T) {
+	const (
+		envVar    = "TEST_RESOLVE_API_KEY"
+		secretVal = "from-secret"
+		envVal    = "from-env"
+	)
+	backendErr := errors.New("boom: connection refused")
+
+	tests := []struct {
+		name       string
+		provider   Provider // nil means no provider wired
+		env        string   // "" means env var unset
+		wantValue  string
+		wantSource string
+		wantErr    error
+	}{
+		{
+			name:       "secret wins over env",
+			provider:   fakeProvider{value: secretVal},
+			env:        envVal,
+			wantValue:  secretVal,
+			wantSource: SourceDashboard,
+		},
+		{
+			name:       "empty secret falls back to env",
+			provider:   fakeProvider{value: ""},
+			env:        envVal,
+			wantValue:  envVal,
+			wantSource: SourceEnv,
+		},
+		{
+			name:       "ErrNotFound falls back to env",
+			provider:   fakeProvider{err: ErrNotFound},
+			env:        envVal,
+			wantValue:  envVal,
+			wantSource: SourceEnv,
+		},
+		{
+			name:       "wrapped ErrNotFound falls back to env",
+			provider:   fakeProvider{err: fmt.Errorf("gcp: %w", ErrNotFound)},
+			env:        envVal,
+			wantValue:  envVal,
+			wantSource: SourceEnv,
+		},
+		{
+			name:       "neither secret nor env",
+			provider:   fakeProvider{value: ""},
+			env:        "",
+			wantValue:  "",
+			wantSource: SourceNone,
+		},
+		{
+			name:       "backend error still falls back to env, surfacing err",
+			provider:   fakeProvider{err: backendErr},
+			env:        envVal,
+			wantValue:  envVal,
+			wantSource: SourceEnv,
+			wantErr:    backendErr,
+		},
+		{
+			name:       "backend error, no env, surfaces err",
+			provider:   fakeProvider{err: backendErr},
+			env:        "",
+			wantValue:  "",
+			wantSource: SourceNone,
+			wantErr:    backendErr,
+		},
+		{
+			name:       "nil provider uses env",
+			provider:   nil,
+			env:        envVal,
+			wantValue:  envVal,
+			wantSource: SourceEnv,
+		},
+		{
+			name:       "nil provider, no env",
+			provider:   nil,
+			env:        "",
+			wantValue:  "",
+			wantSource: SourceNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != "" {
+				t.Setenv(envVar, tt.env)
+			} else {
+				// Ensure a leaked value from the environment can't taint the case.
+				t.Setenv(envVar, "")
+			}
+			value, source, err := ResolveCredential(context.Background(), tt.provider, "proj", "some-credentials", envVar)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected err = %v", err)
+			}
+			if value != tt.wantValue {
+				t.Errorf("value = %q, want %q", value, tt.wantValue)
+			}
+			if source != tt.wantSource {
+				t.Errorf("source = %q, want %q", source, tt.wantSource)
+			}
+		})
+	}
+}

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -346,22 +346,19 @@ func initQdrant(ctx context.Context, cfg *config.Config) (vectorstore.Provider, 
 // last. The returned source string is one of "dashboard", "env", or
 // "none" and is logged so operators can see where the credential came
 // from.
+//
+// The order itself lives in the shared gosecrets.ResolveCredential helper
+// so the agent, the API, and the enterprise plugins can't drift apart;
+// this wrapper only adds the agent's warn-on-unexpected-error logging.
 func resolveCredential(ctx context.Context, secretProvider gosecrets.Provider, projectID, secretKey, envVar string) (value, source string) {
-	if v, err := secretProvider.Get(ctx, projectID, secretKey); err == nil && v != "" {
-		return v, "dashboard"
-	} else if err != nil && !errors.Is(err, gosecrets.ErrNotFound) {
-		// Use errors.Is — gcp/aws/azure secret providers wrap their
-		// backend errors with %w, so a wrapped ErrNotFound would not
-		// compare equal via `!=`. Mongo returns the sentinel directly,
-		// which is why both forms appear correct in unit tests; only
-		// the wrapped path matters in production for the cloud
-		// backends.
+	value, source, err := gosecrets.ResolveCredential(ctx, secretProvider, projectID, secretKey, envVar)
+	if err != nil {
+		// gcp/aws/azure backends wrap their errors with %w; ResolveCredential
+		// already treats a (wrapped) ErrNotFound as "not set" and only
+		// returns genuinely unexpected read failures here.
 		applog.WithError(err).WithField("secret_key", secretKey).Warn("Failed to read credential from secret provider")
 	}
-	if v := os.Getenv(envVar); v != "" {
-		return v, "env"
-	}
-	return "", "none"
+	return value, source
 }
 
 func initEmbeddingProvider(ctx context.Context, project *models.Project, secretProvider gosecrets.Provider, projectID string) (goembedding.Provider, error) {

--- a/services/api/internal/handler/search.go
+++ b/services/api/internal/handler/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -217,18 +216,6 @@ func (h *SearchHandler) Search(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// credentialWithEnvFallback resolves an inference credential the way the
-// agent's resolveCredential does: the per-project secret wins, else the
-// named environment variable. Managed-inference gateway mode writes no
-// per-project AI secret, so the API-side inference paths (search/ask) rely
-// on this env fallback to reach the gateway.
-func credentialWithEnvFallback(secret, envVar string) string {
-	if secret != "" {
-		return secret
-	}
-	return os.Getenv(envVar)
-}
-
 // createEmbeddingProvider creates an embedding provider for a project.
 // The projectConfig map carries non-credential provider settings the
 // dashboard saved (auth_method, project_id, location, region, role_arn,
@@ -241,18 +228,14 @@ func (h *SearchHandler) createEmbeddingProvider(ctx context.Context, providerNam
 	for k, v := range projectConfig {
 		cfg[k] = v
 	}
-	secret := ""
-	if h.secretProvider != nil {
-		if key, err := h.secretProvider.Get(ctx, projectID, "embedding-credentials"); err == nil {
-			secret = key
-		}
-	}
-	// Env fallback, mirroring the agent's resolveCredential order (secret
-	// wins, env next). The managed-inference gateway mode stores no
-	// per-project AI secret, so this API-side search path (which embeds the
-	// query) must fall back to EMBEDDING_API_KEY or it would build a
-	// credential-less provider and fail.
-	if cred := credentialWithEnvFallback(secret, "EMBEDDING_API_KEY"); cred != "" {
+	// Per-project secret wins, else the EMBEDDING_API_KEY env fallback:
+	// managed-inference gateway mode stores no per-project AI secret, so
+	// this API-side search path (which embeds the query) must reach the
+	// gateway via env or it would build a credential-less provider and
+	// fail. The resolution order lives in gosecrets.ResolveCredential,
+	// shared with the agent and the enterprise plugins.
+	cred, _, _ := gosecrets.ResolveCredential(ctx, h.secretProvider, projectID, "embedding-credentials", "EMBEDDING_API_KEY")
+	if cred != "" {
 		cfg["credentials_json"] = cred
 	}
 	return goembedding.NewProvider(providerName, cfg)
@@ -853,16 +836,11 @@ func chunkCitationID(c gosources.Chunk) string {
 
 // createLLMProvider creates an LLM provider for a project's RAG answer synthesis.
 func (h *SearchHandler) createLLMProvider(ctx context.Context, project *models.Project, projectID string) (gollm.Provider, error) {
-	secret := ""
-	if h.secretProvider != nil {
-		if key, err := h.secretProvider.Get(ctx, projectID, "llm-credentials"); err == nil {
-			secret = key
-		}
-	}
-	// Env fallback, mirroring the agent's resolveCredential order. Managed
+	// Per-project secret wins, else the LLM_API_KEY env fallback: managed
 	// mode stores no per-project AI secret, so Ask's RAG synthesis (which
-	// runs in the API process) must fall back to LLM_API_KEY.
-	apiKey := credentialWithEnvFallback(secret, "LLM_API_KEY")
+	// runs in the API process) must reach the gateway via env. Resolution
+	// order shared with the agent via gosecrets.ResolveCredential.
+	apiKey, _, _ := gosecrets.ResolveCredential(ctx, h.secretProvider, projectID, "llm-credentials", "LLM_API_KEY")
 
 	cfg := gollm.ProviderConfig{
 		"credentials_json": apiKey,

--- a/services/api/internal/handler/search_credential_test.go
+++ b/services/api/internal/handler/search_credential_test.go
@@ -1,31 +1,67 @@
 package handler
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
 
-// TestCredentialWithEnvFallback pins the resolution order the API-side
-// search/ask providers use: a per-project secret wins, and when it's empty
-// (managed-inference gateway mode stores no per-project AI secret) the
-// named env var is the fallback. Without the fallback, managed-mode Ask and
-// semantic search build credential-less providers and fail.
-func TestCredentialWithEnvFallback(t *testing.T) {
-	t.Run("secret wins over env", func(t *testing.T) {
-		t.Setenv("LLM_API_KEY", "from-env")
-		if got := credentialWithEnvFallback("from-secret", "LLM_API_KEY"); got != "from-secret" {
-			t.Errorf("got %q, want from-secret", got)
+	gosecrets "github.com/decisionbox-io/decisionbox/libs/go-common/secrets"
+	"github.com/decisionbox-io/decisionbox/services/api/models"
+)
+
+// notFoundSecretProvider models managed-inference gateway mode: no
+// per-project AI secret is stored, so every Get is ErrNotFound.
+type notFoundSecretProvider struct{}
+
+func (notFoundSecretProvider) Get(_ context.Context, _, _ string) (string, error) {
+	return "", gosecrets.ErrNotFound
+}
+func (notFoundSecretProvider) Set(_ context.Context, _, _, _ string) error { return nil }
+func (notFoundSecretProvider) List(_ context.Context, _ string) ([]gosecrets.SecretEntry, error) {
+	return nil, nil
+}
+
+// TestCreateEmbeddingProvider_EnvFallback pins the API-side search/ask
+// resolution order (now via the shared gosecrets.ResolveCredential): with
+// no per-project embedding secret, EMBEDDING_API_KEY is the fallback, so
+// the provider builds; with neither, the openai factory fails as before.
+func TestCreateEmbeddingProvider_EnvFallback(t *testing.T) {
+	h := &SearchHandler{secretProvider: notFoundSecretProvider{}}
+
+	t.Run("env fallback builds the provider", func(t *testing.T) {
+		t.Setenv("EMBEDDING_API_KEY", "sk-env-embed")
+		if _, err := h.createEmbeddingProvider(context.Background(), "openai", "text-embedding-3-small", "proj-1", nil); err != nil {
+			t.Fatalf("expected provider built from env credential, got err: %v", err)
 		}
 	})
 
-	t.Run("env fallback when no secret", func(t *testing.T) {
-		t.Setenv("EMBEDDING_API_KEY", "dbx-live-embed")
-		if got := credentialWithEnvFallback("", "EMBEDDING_API_KEY"); got != "dbx-live-embed" {
-			t.Errorf("got %q, want dbx-live-embed", got)
+	t.Run("no secret and no env fails at the factory", func(t *testing.T) {
+		t.Setenv("EMBEDDING_API_KEY", "")
+		_, err := h.createEmbeddingProvider(context.Background(), "openai", "text-embedding-3-small", "proj-1", nil)
+		if err == nil || !strings.Contains(err.Error(), "API key is required") {
+			t.Fatalf("expected 'API key is required', got: %v", err)
+		}
+	})
+}
+
+// TestCreateLLMProvider_EnvFallback is the LLM-slot counterpart: managed
+// mode's RAG synthesis reaches the gateway via LLM_API_KEY.
+func TestCreateLLMProvider_EnvFallback(t *testing.T) {
+	h := &SearchHandler{secretProvider: notFoundSecretProvider{}}
+	project := &models.Project{LLM: models.LLMConfig{Provider: "openai", Model: "gpt-4o-mini"}}
+
+	t.Run("env fallback builds the provider", func(t *testing.T) {
+		t.Setenv("LLM_API_KEY", "sk-env-llm")
+		if _, err := h.createLLMProvider(context.Background(), project, "proj-1"); err != nil {
+			t.Fatalf("expected provider built from env credential, got err: %v", err)
 		}
 	})
 
-	t.Run("empty when neither", func(t *testing.T) {
+	t.Run("no secret and no env fails at the factory", func(t *testing.T) {
 		t.Setenv("LLM_API_KEY", "")
-		if got := credentialWithEnvFallback("", "LLM_API_KEY"); got != "" {
-			t.Errorf("got %q, want empty", got)
+		_, err := h.createLLMProvider(context.Background(), project, "proj-1")
+		if err == nil || !strings.Contains(err.Error(), "API key is required") {
+			t.Fatalf("expected 'API key is required', got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Extract the inference-credential resolution order — **per-project dashboard secret wins, else env-var fallback** — into a single shared, exported helper `secrets.ResolveCredential` in `libs/go-common/secrets`, and have the agent and the API adopt it. This removes the two divergent copies that existed:

- `services/agent/agentserver/agentserver.go` — `resolveCredential` (used by discovery + `--mode index-schema`)
- `services/api/internal/handler/search.go` — `credentialWithEnvFallback` (used by search / Ask RAG synthesis)

The enterprise plugins import the same helper (companion PR [decisionbox-io/decisionbox-enterprise#141](https://github.com/decisionbox-io/decisionbox-enterprise/pull/141)), so managed-inference gateway mode (`LLM_API_KEY` / `EMBEDDING_API_KEY`) resolves identically on every surface and can't drift — which is what let the enterprise `sources-worker` silently skip the env fallback (the bug that motivated this: enterprise #140, cloud-infra [#62](https://github.com/decisionbox-io/decisionbox-cloud-infra/issues/62)).

## What changed

- **`libs/go-common/secrets/resolve.go` (new)** — `ResolveCredential(ctx, provider, projectID, secretKey, envVar) (value, source, err)` + `SourceDashboard`/`SourceEnv`/`SourceNone` constants. Secret wins; a (wrapped) `ErrNotFound` falls through to env silently; an unexpected secret-store error is surfaced in `err` **but resolution still falls through to env** so an env-only / managed deployment keeps working through a transient backend blip; a nil provider is tolerated (env-only).
- **`agentserver.go`** — `resolveCredential` is now a thin wrapper that delegates to the shared helper and keeps the agent's warn-on-unexpected-error log + `(value, source)` signature. **No behavior change**; call sites untouched.
- **`search.go`** — `createEmbeddingProvider` / `createLLMProvider` call the shared helper; the duplicate `credentialWithEnvFallback` is deleted (and the now-unused `os` import).

## Behavior

Unchanged for every existing path. Verified by the existing agent tests (`resolve_credential_test.go`: dashboard-wins, env-fallback, transport-error→env, wrapped-`ErrNotFound`→env-silently, empty-dashboard→env) and a rewritten API-side test (`search_credential_test.go`) that now exercises the real `createEmbeddingProvider`/`createLLMProvider` env fallback through the openai factories.

## Test plan

- [x] `go test ./secrets/...` (go-common) — new table-driven helper tests (secret-wins / empty→env / (wrapped) not-found→env / neither / backend-error→env+err / nil-provider).
- [x] `go test ./agentserver/...` (agent) — existing resolveCredential suite green (no behavior change).
- [x] `go test ./internal/handler/...` (api) — search/ask credential tests green.
- [x] `golangci-lint run` on all three packages — 0 issues.

## Coordination

Companion enterprise PR [decisionbox-io/decisionbox-enterprise#141](https://github.com/decisionbox-io/decisionbox-enterprise/pull/141) imports `secrets.ResolveCredential` at its 8 credential sites (its CI pins to this branch by matching name). **Merge this PR first**, then the enterprise PR. No API/schema/behavior change here.

— Co-coded with Jale 🤖
