### PR TITLE
feat(connectors): connector provider registry (libs/go-common/connectors) + connectors_enabled

### DIFF
--- a/libs/go-common/connectors/provider.go
+++ b/libs/go-common/connectors/provider.go
@@ -1,0 +1,95 @@
+// Package connectors is the OSS extension point for external-storage
+// connectors — integrations that let a project attach files/folders from an
+// external account (via the provider's native file picker) and ingest them.
+//
+// It is provider-agnostic: no vendor-specific code lives here. Implementations
+// live out-of-tree and self-register via init() + blank import, exactly like
+// the embedding providers (libs/go-common/embedding). A build with no connector
+// registered links fine — NewConnector simply returns a clear error.
+package connectors
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// Token is an OAuth credential set for a connection. RefreshToken is durable —
+// the caller persists it as a secret — and carries the connection's grant;
+// access tokens are short-lived and minted per use.
+type Token struct {
+	AccessToken  string
+	RefreshToken string
+	Expiry       time.Time
+	Scope        string
+}
+
+// BrowserToken is a narrow, browser-safe access token for a provider's native
+// picker. It is deliberately distinct from Token so a broad server-side grant is
+// never handed to the browser: an implementation may down-scope the connection's
+// grant to the minimum the picker needs (limiting the blast radius of an XSS
+// token theft).
+type BrowserToken struct {
+	AccessToken string
+	Expiry      time.Time
+	Scope       string
+}
+
+// PickedItem is one selection returned by a provider's native picker — a single
+// file or a folder.
+type PickedItem struct {
+	ExternalID  string `json:"external_id"`
+	IsFolder    bool   `json:"is_folder"`
+	Name        string `json:"name"`
+	MimeType    string `json:"mime_type"`
+	DriveID     string `json:"drive_id,omitempty"`
+	ResourceKey string `json:"resource_key,omitempty"`
+}
+
+// Item is a concrete, ingestible file resolved by Enumerate (folders expanded,
+// native-document export targets mapped, inaccessible items omitted).
+type Item struct {
+	ExternalID string `json:"external_id"` // stable identity across rename/move
+	Name       string `json:"name"`
+	MimeType   string `json:"mime_type"` // original type in the provider
+	// ExportSourceType is the parser key the downloaded bytes will carry
+	// (docx|xlsx|csv|md|txt) — the same as MimeType's mapping for real
+	// binaries, or the export target for native documents.
+	ExportSourceType string `json:"export_source_type"`
+	ExternalVersion  string `json:"external_version"` // change-detection key (etag / modified time)
+	SizeBytes        int64  `json:"size_bytes"`
+	ParentID         string `json:"parent_id,omitempty"`
+	DriveID          string `json:"drive_id,omitempty"`
+	ResourceKey      string `json:"resource_key,omitempty"`
+	WebViewURL       string `json:"web_view_url,omitempty"` // provenance link back to the original file
+}
+
+// Connector is the provider-agnostic interface an external-storage integration
+// implements. Selection is by kind (Connector.Kind), constructed through the
+// registry (NewConnector).
+type Connector interface {
+	// Kind returns the connector's stable identifier (e.g. "gdrive").
+	Kind() string
+
+	// Exchange completes the OAuth Authorization Code (offline) flow, returning
+	// a Token whose RefreshToken is durable.
+	Exchange(ctx context.Context, code, redirectURI string) (Token, error)
+
+	// Refresh mints a fresh backend access token from the connection's durable
+	// grant. Used server-side for Enumerate/Download.
+	Refresh(ctx context.Context, tok Token) (Token, error)
+
+	// PickerToken mints a least-privilege, browser-safe token for the provider's
+	// native picker, so the browser never holds the broader backend grant.
+	PickerToken(ctx context.Context, tok Token) (BrowserToken, error)
+
+	// Enumerate expands the picked selections into concrete ingestible files —
+	// folders expanded (recursively where the provider allows), native documents
+	// mapped to an export target, inaccessible items omitted.
+	Enumerate(ctx context.Context, tok Token, selections []PickedItem) ([]Item, error)
+
+	// Download returns the file's content stream and the MIME type of the bytes
+	// returned (which may differ from Item.MimeType when a native document is
+	// exported). The caller closes the stream.
+	Download(ctx context.Context, tok Token, item Item) (io.ReadCloser, string, error)
+}

--- a/libs/go-common/connectors/registry.go
+++ b/libs/go-common/connectors/registry.go
@@ -1,0 +1,114 @@
+package connectors
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Config is a generic key-value configuration passed to connector factories —
+// the instance-level app-registration credentials an operator supplies once per
+// deployment (e.g. "client_id", "client_secret", "api_key", "app_id"). Each
+// connector defines which keys it expects.
+type Config map[string]string
+
+// Factory creates a Connector from configuration. Connector packages implement
+// this and register it via RegisterWithMeta().
+type Factory func(cfg Config) (Connector, error)
+
+// ProviderMeta describes a connector for UI rendering (the instance-admin
+// app-registration form).
+type ProviderMeta struct {
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	Description  string        `json:"description"`
+	ConfigFields []ConfigField `json:"config_fields"`
+}
+
+// ConfigField describes a single instance-level configuration field.
+type ConfigField struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Required    bool   `json:"required"`
+	Type        string `json:"type"` // "string" | "credential"
+	Placeholder string `json:"placeholder"`
+	// BrowserSafe marks fields a config endpoint may return to the dashboard at
+	// runtime (e.g. client_id, api_key, app_id — the native picker needs them
+	// client-side). Non-browser-safe fields (client_secret) are backend-only and
+	// must never be returned by a config GET.
+	BrowserSafe bool `json:"browser_safe"`
+}
+
+var (
+	registryMu  sync.RWMutex
+	factories   = make(map[string]Factory)
+	factoryMeta = make(map[string]ProviderMeta)
+)
+
+// Register makes a connector available by name.
+// Connector packages call this in their init() function.
+func Register(name string, factory Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if factory == nil {
+		panic("connectors: Register factory is nil for " + name)
+	}
+	if _, exists := factories[name]; exists {
+		panic("connectors: Register called twice for " + name)
+	}
+	factories[name] = factory
+}
+
+// RegisterWithMeta registers a connector with metadata for UI rendering.
+func RegisterWithMeta(name string, factory Factory, meta ProviderMeta) {
+	Register(name, factory)
+	registryMu.Lock()
+	meta.ID = name
+	factoryMeta[name] = meta
+	registryMu.Unlock()
+}
+
+// NewConnector creates a connector by name using the registered factory.
+// Returns a clear error (not a panic) when no connector of that kind is
+// registered — so a platform-only build, which registers none, degrades
+// gracefully.
+func NewConnector(name string, cfg Config) (Connector, error) {
+	registryMu.RLock()
+	factory, exists := factories[name]
+	registryMu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("connectors: unknown connector %q (registered: %v)", name, RegisteredConnectors())
+	}
+	return factory(cfg)
+}
+
+// RegisteredConnectors returns the names of all registered connectors.
+func RegisteredConnectors() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	names := make([]string, 0, len(factories))
+	for k := range factories {
+		names = append(names, k)
+	}
+	return names
+}
+
+// RegisteredMeta returns metadata for all registered connectors.
+func RegisteredMeta() []ProviderMeta {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	metas := make([]ProviderMeta, 0, len(factoryMeta))
+	for _, m := range factoryMeta {
+		metas = append(metas, m)
+	}
+	return metas
+}
+
+// GetMeta returns metadata for a specific connector.
+func GetMeta(name string) (ProviderMeta, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	m, ok := factoryMeta[name]
+	return m, ok
+}

--- a/libs/go-common/connectors/registry_test.go
+++ b/libs/go-common/connectors/registry_test.go
@@ -1,0 +1,192 @@
+package connectors
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// mockConnector implements Connector for testing.
+type mockConnector struct {
+	kind string
+}
+
+func (m *mockConnector) Kind() string { return m.kind }
+func (m *mockConnector) Exchange(_ context.Context, _, _ string) (Token, error) {
+	return Token{RefreshToken: "rt", Scope: "test"}, nil
+}
+func (m *mockConnector) Refresh(_ context.Context, _ Token) (Token, error) {
+	return Token{AccessToken: "at", Scope: "test"}, nil
+}
+func (m *mockConnector) PickerToken(_ context.Context, _ Token) (BrowserToken, error) {
+	return BrowserToken{AccessToken: "bt", Scope: "narrow"}, nil
+}
+func (m *mockConnector) Enumerate(_ context.Context, _ Token, sel []PickedItem) ([]Item, error) {
+	return make([]Item, len(sel)), nil
+}
+func (m *mockConnector) Download(_ context.Context, _ Token, _ Item) (io.ReadCloser, string, error) {
+	return io.NopCloser(strings.NewReader("data")), "text/plain", nil
+}
+
+// resetRegistry clears the global registry for test isolation.
+func resetRegistry() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	factories = make(map[string]Factory)
+	factoryMeta = make(map[string]ProviderMeta)
+}
+
+func TestRegister(t *testing.T) {
+	resetRegistry()
+
+	Register("test-connector", func(Config) (Connector, error) {
+		return &mockConnector{kind: "test-connector"}, nil
+	})
+
+	names := RegisteredConnectors()
+	if len(names) != 1 || names[0] != "test-connector" {
+		t.Fatalf("expected [test-connector], got %v", names)
+	}
+}
+
+func TestRegisterNilFactory(t *testing.T) {
+	resetRegistry()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for nil factory")
+		}
+		if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "nil") {
+			t.Fatalf("expected panic message about nil, got: %s", msg)
+		}
+	}()
+
+	Register("nil-factory", nil)
+}
+
+func TestRegisterDuplicate(t *testing.T) {
+	resetRegistry()
+
+	factory := func(Config) (Connector, error) { return &mockConnector{}, nil }
+	Register("dup", factory)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for duplicate registration")
+		}
+		if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "twice") {
+			t.Fatalf("expected panic message about twice, got: %s", msg)
+		}
+	}()
+
+	Register("dup", factory)
+}
+
+func TestRegisterWithMeta(t *testing.T) {
+	resetRegistry()
+
+	meta := ProviderMeta{
+		Name:        "Test Drive",
+		Description: "A test connector",
+		ConfigFields: []ConfigField{
+			{Key: "client_id", Label: "Client ID", Required: true, Type: "string", BrowserSafe: true},
+			{Key: "client_secret", Label: "Client Secret", Required: true, Type: "credential"},
+		},
+	}
+	RegisterWithMeta("gdrive-test", func(Config) (Connector, error) {
+		return &mockConnector{kind: "gdrive-test"}, nil
+	}, meta)
+
+	metas := RegisteredMeta()
+	if len(metas) != 1 {
+		t.Fatalf("expected 1 meta, got %d", len(metas))
+	}
+	if metas[0].ID != "gdrive-test" {
+		t.Fatalf("expected ID gdrive-test (set from name), got %s", metas[0].ID)
+	}
+	if metas[0].Name != "Test Drive" {
+		t.Fatalf("expected Name 'Test Drive', got %s", metas[0].Name)
+	}
+
+	got, ok := GetMeta("gdrive-test")
+	if !ok {
+		t.Fatal("expected meta to be found")
+	}
+	// Assert the browser-safe flag survives so a config endpoint can filter on it.
+	var sawBrowserSafe, sawCredential bool
+	for _, f := range got.ConfigFields {
+		if f.Key == "client_id" && f.BrowserSafe {
+			sawBrowserSafe = true
+		}
+		if f.Key == "client_secret" && !f.BrowserSafe {
+			sawCredential = true
+		}
+	}
+	if !sawBrowserSafe || !sawCredential {
+		t.Fatalf("expected client_id browser-safe and client_secret not, got %+v", got.ConfigFields)
+	}
+
+	if _, ok := GetMeta("nonexistent"); ok {
+		t.Fatal("expected meta not found for nonexistent")
+	}
+}
+
+func TestNewConnector(t *testing.T) {
+	resetRegistry()
+
+	Register("test", func(cfg Config) (Connector, error) {
+		if cfg["client_id"] == "" {
+			return nil, fmt.Errorf("client_id is required")
+		}
+		return &mockConnector{kind: "test"}, nil
+	})
+
+	// Success case
+	c, err := NewConnector("test", Config{"client_id": "abc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Kind() != "test" {
+		t.Fatalf("expected kind test, got %s", c.Kind())
+	}
+
+	// Missing config → factory error
+	if _, err = NewConnector("test", Config{}); err == nil {
+		t.Fatal("expected error for missing client_id")
+	}
+
+	// Unknown connector → clear error, no panic (platform-only build path)
+	_, err = NewConnector("unknown", Config{})
+	if err == nil {
+		t.Fatal("expected error for unknown connector")
+	}
+	if !strings.Contains(err.Error(), "unknown connector") {
+		t.Fatalf("expected 'unknown connector' in error, got: %s", err.Error())
+	}
+}
+
+func TestRegisteredConnectors(t *testing.T) {
+	resetRegistry()
+
+	for _, n := range []string{"a", "b", "c"} {
+		Register(n, func(Config) (Connector, error) { return &mockConnector{}, nil })
+	}
+
+	names := RegisteredConnectors()
+	if len(names) != 3 {
+		t.Fatalf("expected 3 connectors, got %d", len(names))
+	}
+	set := make(map[string]bool)
+	for _, n := range names {
+		set[n] = true
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if !set[want] {
+			t.Fatalf("expected connector %q in list", want)
+		}
+	}
+}

--- a/libs/go-common/policy/checker.go
+++ b/libs/go-common/policy/checker.go
@@ -114,6 +114,7 @@ const (
 	FeatureSources        = "sources_enabled"
 	FeaturePackGen        = "pack_gen_enabled"
 	FeatureDataQuery      = "data_query_enabled"
+	FeatureConnectors     = "connectors_enabled"
 )
 
 // AllFeatures is the canonical, ordered list of wire flag names.
@@ -133,6 +134,7 @@ var AllFeatures = []string{
 	FeatureSources,
 	FeaturePackGen,
 	FeatureDataQuery,
+	FeatureConnectors,
 }
 
 // Reservation kinds used in the /internal/deployments/{id}/usage/reserve/{kind}

--- a/libs/go-common/policy/policy_test.go
+++ b/libs/go-common/policy/policy_test.go
@@ -98,7 +98,7 @@ func TestNoopChecker_FeatureEnabled_True(t *testing.T) {
 func TestNoopChecker_SyncCounters_IsNoOp(t *testing.T) {
 	resetRegistry()
 	c := GetChecker()
-	// Must not panic; must return immediately; must not block.
+	// Must not panic; must return immediately; must not block. 
 	c.SyncCounters(context.Background(), "dep1", CounterSnapshot{ProjectsCurrent: 5, DataSourcesCurrent: 3})
 }
 

--- a/libs/go-common/policy/policy_test.go
+++ b/libs/go-common/policy/policy_test.go
@@ -238,6 +238,7 @@ func TestAllFeatures_ContainsEveryConstant(t *testing.T) {
 		FeatureSources,
 		FeaturePackGen,
 		FeatureDataQuery,
+		FeatureConnectors,
 	}
 	if len(AllFeatures) != len(want) {
 		t.Fatalf("AllFeatures length = %d, want %d", len(AllFeatures), len(want))


### PR DESCRIPTION
## Summary

Adds a provider registry for **external-storage connectors** under `libs/go-common/connectors/`, mirroring the existing embedding provider registry (`libs/go-common/embedding/`). Generic extension point — implementations register via `init()` + blank import and live out-of-tree; no implementations ship here.

## What's in it

- `connectors/provider.go` — the `Connector` interface (`Kind` / `Exchange` / `Refresh` / `PickerToken` / `Enumerate` / `Download`) + `Token`, `BrowserToken`, `PickedItem`, `Item`.
  - `PickerToken` returns a **narrow, browser-safe** token distinct from the backend `Token`, so an implementation can hand the browser a least-privilege credential while retaining broader access server-side.
- `connectors/registry.go` — `Config`, `Factory`, `Register` / `RegisterWithMeta` / `NewConnector` / `RegisteredConnectors` / `RegisteredMeta` / `GetMeta`, `RWMutex`-guarded, exactly like `embedding/registry.go`. `ProviderMeta.ConfigField.BrowserSafe` lets a config endpoint decide which instance-level fields may be served to the dashboard at runtime.
- `connectors/registry_test.go` — register / duplicate-panic / nil-panic / unknown-kind / meta round-trip / browser-safe-flag.
- `policy/checker.go` — adds `FeatureConnectors = "connectors_enabled"` to the constant set **and** `AllFeatures` (with the matching `policy_test.go` update).

## Notes

- **Provider-agnostic** — no vendor specifics; a platform-only build links and `NewConnector` on an unknown kind returns a clear error (no NoOp type needed, matching the embedding registry rather than the singleton `sources` NoOp).
- **Cross-repo coordination:** adding `connectors_enabled` to `AllFeatures` means the control plane needs a matching `connectors_enabled` plan-flag field (same coordination as any feature flag). Targeting **`beta`** for exactly this reason.
- Foundation for downstream connector work — no behavior change to existing packages.

## Verification

`go build ./...` (go-common), `go test ./connectors/... ./policy/...` (green), `golangci-lint run ./connectors/... ./policy/...` (0 issues), `gofmt` clean.

Closes #311

— Co-coded with Jale 🤖
