### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-10
+
+### Changed
+
+- Release version bump — no functional changes since v0.14.0 (coordinated re-tag/rebuild across platform, enterprise, and cloud-enterprise-tenant).
+
 ## [0.14.0] - 2026-07-09
 
 ### Changed


### PR DESCRIPTION
Version-bump release **v0.15.0** — rolls CHANGELOG `[Unreleased]` → `[0.15.0]`. No functional changes since v0.14.0 (coordinated re-tag/rebuild across platform, enterprise, tenant). Tag cut from `main` after merge.