### PR TITLE
feat: effort levels + optional OperationCharger seam; hide \$ estimate on cloud (#103)

### DIFF
--- a/libs/go-common/policy/operation.go
+++ b/libs/go-common/policy/operation.go
@@ -1,0 +1,107 @@
+package policy
+
+import "context"
+
+// Effort is the discovery-run intensity a caller picks instead of a raw step
+// count. Each level maps to a max_steps value the agent runs with. The
+// mapping is neutral platform vocabulary; how (or whether) an operation is
+// metered is a deployment-plan concern handled by the OperationCharger below.
+const (
+	EffortLower  = "lower"
+	EffortLow    = "low"
+	EffortMedium = "medium"
+	EffortHigh   = "high"
+	EffortHigher = "higher"
+)
+
+// DefaultEffort is used when a caller does not specify one.
+const DefaultEffort = EffortMedium
+
+// effortSteps maps each effort level to the discovery agent's max_steps.
+var effortSteps = map[string]int{
+	EffortLower:  20,
+	EffortLow:    40,
+	EffortMedium: 60,
+	EffortHigh:   80,
+	EffortHigher: 100,
+}
+
+// ValidEffort reports whether e is a recognised effort level.
+func ValidEffort(e string) bool {
+	_, ok := effortSteps[e]
+	return ok
+}
+
+// StepsForEffort returns the max_steps for an effort level and whether it was
+// recognised. Callers use it to translate a customer-facing effort into the
+// agent's step budget without exposing raw step counts.
+func StepsForEffort(e string) (int, bool) {
+	s, ok := effortSteps[e]
+	return s, ok
+}
+
+// Operation names — the priced product operations a plan may meter. Neutral
+// identifiers shared with the deployment plan; no plan/pricing detail lives
+// in the community codebase.
+const (
+	OpDiscoveryRun         = "discovery_run"
+	OpDomainPackGeneration = "domain_pack_generation"
+	OpExecutiveSummary     = "executive_summary"
+	OpAskMessage           = "ask_message"
+	OpSourcesIndexing      = "sources_indexing"
+)
+
+// Operation describes a single priced product operation to meter at its
+// start. Reference is the caller's idempotency key and the handle a later
+// refund uses. Effort is set only for OpDiscoveryRun.
+type Operation struct {
+	Name      string
+	Effort    string
+	Reference string
+}
+
+// OperationCharge is the receipt of a metered operation. On a self-hosted
+// deployment nothing is metered and Charged is zero.
+type OperationCharge struct {
+	Charged int64
+	Balance int64
+}
+
+// OperationCharger is an OPTIONAL extension a Checker may implement to meter
+// priced product operations (DecisionBox Cloud does; self-hosted does not).
+// It is deliberately NOT part of the Checker interface, so the community
+// NoopChecker and every existing mock stay unchanged — callers reach it only
+// through the ChargeIfMetered / RefundIfMetered helpers below, which no-op
+// when the active checker doesn't implement it.
+type OperationCharger interface {
+	// ChargeOperation meters op at its start. A typed *PolicyError signals
+	// the operation is blocked (e.g. balance exhausted); the caller should
+	// surface it (HTTP 402) and not proceed. Any other error is
+	// infrastructural.
+	ChargeOperation(ctx context.Context, deploymentID string, op Operation) (*OperationCharge, error)
+
+	// RefundOperation reverses a prior ChargeOperation by its reference,
+	// after a defined SYSTEM failure. Idempotent; user/LLM errors are not
+	// refundable and that decision lives at the call site.
+	RefundOperation(ctx context.Context, deploymentID, reference string) error
+}
+
+// ChargeIfMetered meters op against the active checker when it supports
+// metering, otherwise it is a no-op returning a zero charge. Product-boundary
+// callers use this so the community path stays free and the cloud path
+// debits, without either knowing about the other.
+func ChargeIfMetered(ctx context.Context, deploymentID string, op Operation) (*OperationCharge, error) {
+	if ch, ok := GetChecker().(OperationCharger); ok {
+		return ch.ChargeOperation(ctx, deploymentID, op)
+	}
+	return &OperationCharge{}, nil
+}
+
+// RefundIfMetered reverses a prior metered charge when the active checker
+// supports metering; a no-op otherwise. Best-effort: refund failures are the
+// plugin's to log, never the caller's to handle.
+func RefundIfMetered(ctx context.Context, deploymentID, reference string) {
+	if ch, ok := GetChecker().(OperationCharger); ok {
+		_ = ch.RefundOperation(ctx, deploymentID, reference)
+	}
+}

--- a/libs/go-common/policy/operation_test.go
+++ b/libs/go-common/policy/operation_test.go
@@ -1,0 +1,73 @@
+package policy
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStepsForEffort(t *testing.T) {
+	cases := map[string]int{
+		EffortLower:  20,
+		EffortLow:    40,
+		EffortMedium: 60,
+		EffortHigh:   80,
+		EffortHigher: 100,
+	}
+	for effort, want := range cases {
+		got, ok := StepsForEffort(effort)
+		if !ok || got != want {
+			t.Errorf("StepsForEffort(%q) = %d, %v; want %d, true", effort, got, ok, want)
+		}
+		if !ValidEffort(effort) {
+			t.Errorf("ValidEffort(%q) = false, want true", effort)
+		}
+	}
+	if _, ok := StepsForEffort("extreme"); ok {
+		t.Errorf("StepsForEffort(extreme) should be unrecognised")
+	}
+	if ValidEffort("") {
+		t.Errorf("empty effort should be invalid")
+	}
+}
+
+// chargingChecker is a NoopChecker that also implements OperationCharger, to
+// verify ChargeIfMetered/RefundIfMetered route to a metering checker.
+type chargingChecker struct {
+	NoopChecker
+	charged  []Operation
+	refunded []string
+}
+
+func (c *chargingChecker) ChargeOperation(_ context.Context, _ string, op Operation) (*OperationCharge, error) {
+	c.charged = append(c.charged, op)
+	return &OperationCharge{Charged: 42, Balance: 100}, nil
+}
+func (c *chargingChecker) RefundOperation(_ context.Context, _, reference string) error {
+	c.refunded = append(c.refunded, reference)
+	return nil
+}
+
+func TestChargeIfMetered_RoutesToChargerOrNoops(t *testing.T) {
+	// Default (Noop) checker doesn't implement OperationCharger → free no-op.
+	RegisterChecker(NewNoopChecker())
+	t.Cleanup(func() { RegisterChecker(NewNoopChecker()) })
+	ch, err := ChargeIfMetered(context.Background(), "dep", Operation{Name: OpAskMessage, Reference: "r1"})
+	if err != nil || ch == nil || ch.Charged != 0 {
+		t.Fatalf("noop charge = %+v, err=%v; want zero charge", ch, err)
+	}
+
+	// A metering checker receives the operation.
+	cc := &chargingChecker{}
+	RegisterChecker(cc)
+	ch, err = ChargeIfMetered(context.Background(), "dep", Operation{Name: OpDiscoveryRun, Effort: EffortMedium, Reference: "run-1"})
+	if err != nil || ch.Charged != 42 {
+		t.Fatalf("metered charge = %+v, err=%v; want 42", ch, err)
+	}
+	if len(cc.charged) != 1 || cc.charged[0].Name != OpDiscoveryRun || cc.charged[0].Effort != EffortMedium {
+		t.Errorf("charged = %+v", cc.charged)
+	}
+	RefundIfMetered(context.Background(), "dep", "run-1")
+	if len(cc.refunded) != 1 || cc.refunded[0] != "run-1" {
+		t.Errorf("refunded = %+v", cc.refunded)
+	}
+}

--- a/services/api/internal/discoverytrigger/registry.go
+++ b/services/api/internal/discoverytrigger/registry.go
@@ -26,6 +26,12 @@ type Options struct {
 	Areas []string
 	// MaxSteps overrides the exploration-step budget; 0 = agent default.
 	MaxSteps int
+	// Effort is the customer-facing discovery intensity
+	// (lower/low/medium/high/higher). When set it resolves to a max_steps
+	// value (policy.StepsForEffort) that takes precedence over MaxSteps, so
+	// callers can pick an effort without ever handling a raw step count.
+	// Empty means "use MaxSteps / the agent default".
+	Effort string
 	// MinSteps is the floor on exploration steps. nil applies the
 	// default (60% of the effective MaxSteps); a non-nil 0 disables the
 	// floor; >0 sets an explicit floor.

--- a/services/api/internal/handler/discoveries.go
+++ b/services/api/internal/handler/discoveries.go
@@ -373,9 +373,16 @@ func (h *DiscoveriesHandler) StartRun(ctx context.Context, opts discoverytrigger
 	// (typed *PolicyError → HTTP 402) when it is exhausted. The runID is the
 	// idempotency + refund handle. On a block, roll back the cap reservation
 	// and fail the run so nothing is left half-reserved.
+	// Metering prices discovery by effort; default to medium when the caller
+	// didn't pick one (a cloud client always sends an effort, but this keeps
+	// the debit well-formed regardless). No-op on self-hosted.
+	chargeEffort := opts.Effort
+	if chargeEffort == "" {
+		chargeEffort = policy.DefaultEffort
+	}
 	if _, err := policy.ChargeIfMetered(ctx, "", policy.Operation{
 		Name:      policy.OpDiscoveryRun,
-		Effort:    opts.Effort,
+		Effort:    chargeEffort,
 		Reference: runID,
 	}); err != nil {
 		if reservationID != "" {

--- a/services/api/internal/handler/discoveries.go
+++ b/services/api/internal/handler/discoveries.go
@@ -161,6 +161,7 @@ func (h *DiscoveriesHandler) TriggerDiscovery(w http.ResponseWriter, r *http.Req
 	//   *val  > 0  → user-provided floor
 	var body struct {
 		Areas    []string `json:"areas"`               // optional: run only these areas
+		Effort   string   `json:"effort,omitempty"`    // optional: discovery intensity (lower/low/medium/high/higher)
 		MaxSteps int      `json:"max_steps,omitempty"` // optional: override exploration steps (default 100)
 		MinSteps *int     `json:"min_steps,omitempty"` // optional: reject premature completion (default 60% of max_steps)
 	}
@@ -169,6 +170,7 @@ func (h *DiscoveriesHandler) TriggerDiscovery(w http.ResponseWriter, r *http.Req
 	res, err := h.StartRun(r.Context(), discoverytrigger.Options{
 		ProjectID: projectID,
 		Areas:     body.Areas,
+		Effort:    body.Effort,
 		MaxSteps:  body.MaxSteps,
 		MinSteps:  body.MinSteps,
 		Source:    "manual",
@@ -263,6 +265,17 @@ func (h *DiscoveriesHandler) StartRun(ctx context.Context, opts discoverytrigger
 		return discoverytrigger.Result{}, &discoverytrigger.ConflictError{Message: "project has not been indexed yet — trigger POST /api/v1/projects/" + opts.ProjectID + "/reindex first"}
 	}
 
+	// An effort level (cloud's customer-facing intensity) resolves to a
+	// max_steps budget that takes precedence over a raw MaxSteps — cloud never
+	// exposes step counts. Self-hosted callers may still pass MaxSteps.
+	if opts.Effort != "" {
+		steps, ok := policy.StepsForEffort(opts.Effort)
+		if !ok {
+			return discoverytrigger.Result{}, &discoverytrigger.InvalidParamsError{Message: "invalid effort level: " + opts.Effort}
+		}
+		opts.MaxSteps = steps
+	}
+
 	// Resolve MaxSteps for the min-steps default computation below. The
 	// agent CLI enforces its own default (100) when zero reaches it, so we
 	// mirror that here to keep the on-the-wire default and the computed
@@ -355,6 +368,27 @@ func (h *DiscoveriesHandler) StartRun(ctx context.Context, opts discoverytrigger
 		}
 	}
 
+	// Meter the run at its effort price. Free on self-hosted (no metering
+	// checker); on cloud this debits the plan's credit balance and blocks
+	// (typed *PolicyError → HTTP 402) when it is exhausted. The runID is the
+	// idempotency + refund handle. On a block, roll back the cap reservation
+	// and fail the run so nothing is left half-reserved.
+	if _, err := policy.ChargeIfMetered(ctx, "", policy.Operation{
+		Name:      policy.OpDiscoveryRun,
+		Effort:    opts.Effort,
+		Reference: runID,
+	}); err != nil {
+		if reservationID != "" {
+			if relErr := ck.Release(ctx, reservationID); relErr != nil {
+				apilog.WithError(relErr).Warn("failed to release reservation after metering block")
+			}
+		}
+		if failErr := h.runRepo.Fail(ctx, runID, "metering denied: "+err.Error()); failErr != nil {
+			apilog.WithError(failErr).Warn("failed to mark metering-denied run as failed")
+		}
+		return discoverytrigger.Result{}, err
+	}
+
 	// Spawn the agent via the configured runner (subprocess, docker, or K8s Job)
 	runErr := h.agentRunner.Run(ctx, runner.RunOptions{
 		ProjectID: opts.ProjectID,
@@ -384,6 +418,10 @@ func (h *DiscoveriesHandler) StartRun(ctx context.Context, opts discoverytrigger
 		if err := h.runRepo.Fail(ctx, runID, "failed to start: "+runErr.Error()); err != nil {
 			apilog.WithError(err).Error("failed to mark run as failed")
 		}
+		// The agent never launched — a defined SYSTEM failure, so refund the
+		// run's metered charge (no-op on self-hosted / when nothing was
+		// charged; idempotent on cloud).
+		policy.RefundIfMetered(ctx, "", runID)
 		if reservationID != "" {
 			if relErr := ck.Release(ctx, reservationID); relErr != nil {
 				apilog.WithError(relErr).Warn("failed to release discovery-run reservation after agent spawn failed")

--- a/ui/dashboard/src/app/projects/[id]/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/page.tsx
@@ -20,6 +20,12 @@ import {
   PROJECT_STATE_READY,
 } from '@/lib/api';
 
+// On DecisionBox Cloud, usage is billed in credits (not dollars), so the USD
+// cost-estimate preview is hidden. The cloud tenant sets
+// NEXT_PUBLIC_HIDE_COST_ESTIMATE=1; self-hosted leaves it unset and keeps the
+// dollar estimate.
+const HIDE_COST_ESTIMATE = process.env.NEXT_PUBLIC_HIDE_COST_ESTIMATE === '1';
+
 export default function ProjectPage() {
   const { id } = useParams<{ id: string }>();
   const [project, setProject] = useState<Project | null>(null);
@@ -313,31 +319,42 @@ export default function ProjectPage() {
             </div>
           ) : estimate && (
             <>
-              <div style={{ fontSize: 15, fontWeight: 500, marginBottom: 12 }}>Cost Estimate</div>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 16 }}>
-                <div>
-                  <div style={{ fontSize: 11, color: 'var(--db-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 4 }}>
-                    LLM ({estimate.llm.provider})
-                  </div>
-                  <div style={{ fontSize: 22, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>${estimate.llm.cost_usd.toFixed(4)}</div>
-                  <div style={{ fontSize: 12, color: 'var(--db-text-tertiary)' }}>
-                    ~{(estimate.llm.estimated_input_tokens / 1000).toFixed(0)}K in + {(estimate.llm.estimated_output_tokens / 1000).toFixed(0)}K out
-                  </div>
+              {/* On DecisionBox Cloud usage is billed in credits, not dollars,
+                  so the USD cost estimate is hidden (HIDE_COST_ESTIMATE) — the
+                  managed pricing is the plan's per-operation credit price. */}
+              {HIDE_COST_ESTIMATE ? (
+                <div style={{ fontSize: 13, color: 'var(--db-text-secondary)', marginBottom: 16 }}>
+                  Ready to run discovery for this project.
                 </div>
-                <div>
-                  <div style={{ fontSize: 11, color: 'var(--db-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 4 }}>
-                    Warehouse ({estimate.warehouse.provider})
+              ) : (
+                <>
+                  <div style={{ fontSize: 15, fontWeight: 500, marginBottom: 12 }}>Cost Estimate</div>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 16 }}>
+                    <div>
+                      <div style={{ fontSize: 11, color: 'var(--db-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 4 }}>
+                        LLM ({estimate.llm.provider})
+                      </div>
+                      <div style={{ fontSize: 22, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>${estimate.llm.cost_usd.toFixed(4)}</div>
+                      <div style={{ fontSize: 12, color: 'var(--db-text-tertiary)' }}>
+                        ~{(estimate.llm.estimated_input_tokens / 1000).toFixed(0)}K in + {(estimate.llm.estimated_output_tokens / 1000).toFixed(0)}K out
+                      </div>
+                    </div>
+                    <div>
+                      <div style={{ fontSize: 11, color: 'var(--db-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 4 }}>
+                        Warehouse ({estimate.warehouse.provider})
+                      </div>
+                      <div style={{ fontSize: 22, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>${estimate.warehouse.cost_usd.toFixed(4)}</div>
+                      <div style={{ fontSize: 12, color: 'var(--db-text-tertiary)' }}>
+                        ~{estimate.warehouse.estimated_queries} queries, {(estimate.warehouse.estimated_bytes_scanned / (1024 * 1024)).toFixed(0)} MB
+                      </div>
+                    </div>
+                    <div>
+                      <div style={{ fontSize: 11, color: 'var(--db-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 4 }}>Total</div>
+                      <div style={{ fontSize: 22, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--db-blue-text)' }}>${estimate.total_cost_usd.toFixed(4)}</div>
+                    </div>
                   </div>
-                  <div style={{ fontSize: 22, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>${estimate.warehouse.cost_usd.toFixed(4)}</div>
-                  <div style={{ fontSize: 12, color: 'var(--db-text-tertiary)' }}>
-                    ~{estimate.warehouse.estimated_queries} queries, {(estimate.warehouse.estimated_bytes_scanned / (1024 * 1024)).toFixed(0)} MB
-                  </div>
-                </div>
-                <div>
-                  <div style={{ fontSize: 11, color: 'var(--db-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 4 }}>Total</div>
-                  <div style={{ fontSize: 22, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--db-blue-text)' }}>${estimate.total_cost_usd.toFixed(4)}</div>
-                </div>
-              </div>
+                </>
+              )}
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
                 <GhostButton onClick={() => { setEstimate(null); setPendingAreas(undefined); }}>Cancel</GhostButton>
                 <PrimaryButton onClick={() => handleTrigger(pendingAreas)} disabled={triggering}>


### PR DESCRIPTION
Part of **decisionbox-io/decisionbox-cloud-control-plane#103** — dollars → credits. Rolls `cloud-credits` into `main`.

### This repo's changes
- **Effort-level abstraction** (`lower/low/medium/high/higher` → 20/40/60/80/100 steps) threaded into the discovery trigger + policy checker; cloud never exposes raw step counts.
- **Optional `OperationCharger`** seam (`policy.ChargeIfMetered` / `RefundIfMetered`) — a separate interface so `Checker`/`NoopChecker`/mocks are untouched and credits stay out of community naming (Rule 11).
- Dashboard: hide/reword the USD cost estimate on cloud via `NEXT_PUBLIC_HIDE_COST_ESTIMATE` (client-inlined; baked by the cloud dashboard images).

### Deploy notes
**Merge #4 of 8** — library consumed by the tenant image builds; must be on `main` **before** cloud-tenant / cloud-enterprise-tenant rebuild. Credits stay out of community code paths.

— Co-coded with Jale 🤖
