### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-28
+
 ### Fixed
 
 - **Agent Job pods rejected on OpenShift** — the Kubernetes runner hardcoded `runAsUser`/`runAsGroup`/`fsGroup` `1000` in every agent Job (Test Connection, discovery, index-schema, validate-doc), which OpenShift's `restricted-v2` SCC rejects as outside the namespace's allocated UID range, so pods never scheduled (Test Connection returned a 504). Setting `OPENSHIFT_ENABLED=true` now omits those pins so the SCC assigns a UID/GID from the namespace range; all other hardening (`runAsNonRoot`, drop `ALL`, read-only root filesystem, `RuntimeDefault` seccomp) is preserved. Vanilla Kubernetes is unchanged — UID `1000` is still pinned by default (`services/api/internal/runner/`).


### PR DESCRIPTION
Rolls `[Unreleased]` into **0.18.0**. One fix, and it is the reason the release exists.

**Agent Job pods were rejected on OpenShift.** The Kubernetes runner pinned `runAsUser`/`runAsGroup`/`fsGroup` to `1000` on every agent Job — Test Connection, discovery, index-schema, validate-doc. OpenShift's `restricted-v2` SCC rejects that as outside the namespace's allocated UID range, so the pods never scheduled and Test Connection returned a 504. `OPENSHIFT_ENABLED=true` now omits those pins and lets the SCC assign from the namespace range; all other hardening is preserved, and vanilla Kubernetes is unchanged.

Tagging `v0.18.0` once this merges. The enterprise and cloud-enterprise-tenant releases build from this repo's `main`, so this goes first.

— Co-coded with Jale 🤖