### PR TITLE
chore(release): v0.20.0 — realign versions across the fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-28
+
+### Changed
+
+- **Version realigned to 0.20.0** so the community platform, enterprise, the enterprise Helm chart and the cloud tenant images all carry one number. 0.18.0 and 0.19.0 are superseded; nothing functional changed between them and this.
+
 ## [0.18.0] - 2026-07-28
 
 ### Fixed


### PR DESCRIPTION
Realigns to **0.20.0** so the community platform, enterprise, the enterprise Helm chart and the cloud tenant images all carry one number.

v0.18.0 shipped from here already; 0.18.0/0.19.0 are superseded and nothing functional changed between them and this. The driver was the enterprise repo: its chart had drifted to 0.19.0 while the release tag was v0.18.0, and `helm-publish` enforces tag == chart version, so the two could not both be right. Picking a fresh number ahead of both fixes it everywhere at once.

Merge first — enterprise and cloud-enterprise-tenant build from this repo's `main`.

— Co-coded with Jale 🤖