### PR TITLE
chore(release): v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-28
+
+### Changed
+
+- **Version bumped to 0.21.0** to keep the fleet on one number. 0.20.0's enterprise publish could not complete — our release ECR repositories are IMMUTABLE, so the partial push from a failed run blocked every retry at that version. Nothing functional changed from 0.20.0.
+
 ## [0.20.0] - 2026-07-28
 
 ### Changed


### PR DESCRIPTION
Bumps to **0.21.0** so the fleet stays on one number.

0.20.0 could not be completed on the enterprise side: our release ECR repositories are IMMUTABLE, and a failed run had already pushed four of the images, so every retry was rejected with `tag invalid: ... cannot be overwritten`. A fresh version is the non-destructive way out — the alternative was deleting published tags from prod ECR to unstick CI.

Nothing functional changed from 0.20.0. This repo's own v0.20.0 build succeeded; it is bumped only to stay aligned with enterprise and the cloud tenant images.

Merge first — the other two build from this repo's `main`.

— Co-coded with Jale 🤖