### PR TITLE
feat(sources,vectorstore,ui): platform support for documents-only knowledge-source search

### DIFF
--- a/libs/go-common/sources/provider.go
+++ b/libs/go-common/sources/provider.go
@@ -55,6 +55,24 @@ type RetrieveOpts struct {
 	Limit int
 	// MinScore is the minimum cosine similarity. Chunks below this are dropped.
 	MinScore float64
+	// DocumentsOnly restricts retrieval to document chunks, excluding
+	// inline notes.
+	//
+	// The default (false) suits prompt-context assembly, where an
+	// implementation may inject operator-authored notes ahead of — and
+	// in addition to — semantic matches, so that pinned guidance always
+	// reaches the model. Those note passes are deliberately not bound by
+	// Limit, and they consume the budget before documents are searched.
+	//
+	// That is wrong for a caller exposing retrieval as a document-search
+	// tool: it returns content the tool never advertised, and cannot
+	// honour the result cap it promised. Such callers set this to true,
+	// which makes Limit an exact upper bound and the result set purely
+	// semantic.
+	//
+	// Implementations that have no note concept may ignore this field:
+	// their results already contain only documents.
+	DocumentsOnly bool
 }
 
 // Dependencies bundles infrastructure handles needed by Provider implementations.

--- a/libs/go-common/vectorstore/provider.go
+++ b/libs/go-common/vectorstore/provider.go
@@ -59,6 +59,17 @@ type SearchOpts struct {
 	AnalysisArea   string   // optional: filter by area
 	Limit          int      // max results to return
 	MinScore       float64  // optional: minimum similarity threshold
+
+	// ExcludeSourceTypes drops points whose `source_type` payload is in
+	// this list.
+	//
+	// Knowledge-source chunks all share one `type` ("source_chunk") and
+	// distinguish note from document only by `source_type`, so Types
+	// cannot separate them. Filtering here rather than after the search
+	// matters: excluded points would otherwise occupy the top-K window
+	// and be discarded by the caller, silently returning fewer results
+	// than Limit while matching points sat just below the cut.
+	ExcludeSourceTypes []string
 }
 
 // SearchResult represents a single vector search match.

--- a/libs/go-common/vectorstore/qdrant/provider.go
+++ b/libs/go-common/vectorstore/qdrant/provider.go
@@ -354,6 +354,7 @@ func (p *Provider) Close() error {
 func buildFilter(opts vectorstore.SearchOpts) *pb.Filter {
 	var must []*pb.Condition
 	var should []*pb.Condition
+	var mustNot []*pb.Condition
 
 	// Project ID filter (required for scoped search).
 	if len(opts.ProjectIDs) == 1 {
@@ -386,13 +387,23 @@ func buildFilter(opts vectorstore.SearchOpts) *pb.Filter {
 		must = append(must, pb.NewMatch("analysis_area", opts.AnalysisArea))
 	}
 
-	if len(must) == 0 && len(should) == 0 {
+	// Source-type exclusions. Applied server-side so excluded points
+	// never consume the top-K window.
+	for _, st := range opts.ExcludeSourceTypes {
+		if st == "" {
+			continue
+		}
+		mustNot = append(mustNot, pb.NewMatch("source_type", st))
+	}
+
+	if len(must) == 0 && len(should) == 0 && len(mustNot) == 0 {
 		return nil
 	}
 
 	return &pb.Filter{
-		Must:   must,
-		Should: should,
+		Must:    must,
+		Should:  should,
+		MustNot: mustNot,
 	}
 }
 

--- a/libs/go-common/vectorstore/qdrant/provider_test.go
+++ b/libs/go-common/vectorstore/qdrant/provider_test.go
@@ -607,6 +607,55 @@ func TestBuildFilter(t *testing.T) {
 	}
 }
 
+func TestBuildFilterExcludeSourceTypes(t *testing.T) {
+	// Exclusions become must_not so the excluded points never occupy the
+	// top-K window — filtering them out after the search would silently
+	// return fewer results than the caller's Limit.
+	filter := buildFilter(vectorstore.SearchOpts{
+		ProjectIDs:         []string{"proj-1"},
+		Types:              []string{"source_chunk"},
+		ExcludeSourceTypes: []string{"note"},
+	})
+	if filter == nil {
+		t.Fatal("expected non-nil filter")
+	}
+	if len(filter.Must) != 2 { // project_id + type
+		t.Fatalf("expected 2 must conditions, got %d", len(filter.Must))
+	}
+	if len(filter.MustNot) != 1 {
+		t.Fatalf("expected 1 must_not condition, got %d", len(filter.MustNot))
+	}
+
+	// Several exclusions all apply.
+	filter = buildFilter(vectorstore.SearchOpts{
+		ProjectIDs:         []string{"proj-1"},
+		ExcludeSourceTypes: []string{"note", "scratch"},
+	})
+	if len(filter.MustNot) != 2 {
+		t.Fatalf("expected 2 must_not conditions, got %d", len(filter.MustNot))
+	}
+
+	// Empty strings are ignored rather than matching an empty payload value.
+	filter = buildFilter(vectorstore.SearchOpts{
+		ProjectIDs:         []string{"proj-1"},
+		ExcludeSourceTypes: []string{"", "note", ""},
+	})
+	if len(filter.MustNot) != 1 {
+		t.Fatalf("expected 1 must_not condition, got %d", len(filter.MustNot))
+	}
+
+	// An exclusion on its own is still a filter — it must not collapse to nil.
+	filter = buildFilter(vectorstore.SearchOpts{ExcludeSourceTypes: []string{"note"}})
+	if filter == nil || len(filter.MustNot) != 1 {
+		t.Fatal("exclusion-only opts must still produce a filter")
+	}
+
+	// All-empty exclusions contribute nothing, so the filter stays nil.
+	if got := buildFilter(vectorstore.SearchOpts{ExcludeSourceTypes: []string{"", ""}}); got != nil {
+		t.Fatal("expected nil filter when every exclusion is empty")
+	}
+}
+
 func TestUpsertError(t *testing.T) {
 	ctx := context.Background()
 	mock := newMockClient()

--- a/ui/dashboard/src/__tests__/CitationsFooter.test.tsx
+++ b/ui/dashboard/src/__tests__/CitationsFooter.test.tsx
@@ -53,6 +53,21 @@ describe('sourceHref', () => {
     const src = makeSource({ id: 'r-4', type: 'recommendation', discovery_id: '' });
     expect(sourceHref('p-1', src)).toBe('/projects/p-1/recommendations');
   });
+
+  test('routes knowledge-source citations to the project sources page', () => {
+    // A source_chunk citation is a document, not a discovery finding. Without
+    // an explicit branch it falls through to the recommendations page, which
+    // is not where the cited document lives.
+    const src = makeSource({ id: 'src-9', type: 'source_chunk', discovery_id: '' });
+    expect(sourceHref('p-1', src)).toBe('/projects/p-1/sources');
+  });
+
+  test('ignores discovery_id on knowledge-source citations', () => {
+    // Nothing populates discovery_id for a document citation, but a stale or
+    // echoed value must not send the user to a discovery detail route.
+    const src = makeSource({ id: 'src-9', type: 'source_chunk', discovery_id: 'd-7' });
+    expect(sourceHref('p-1', src)).toBe('/projects/p-1/sources');
+  });
 });
 
 describe('numberSources', () => {

--- a/ui/dashboard/src/__tests__/searchNav.test.ts
+++ b/ui/dashboard/src/__tests__/searchNav.test.ts
@@ -72,3 +72,24 @@ describe('searchResultHref', () => {
     );
   });
 });
+
+describe('searchResultHref with non-discovery results', () => {
+  test('routes a knowledge-source result to the project sources page', () => {
+    // source_chunk has no discovery run, so the detail route it would
+    // otherwise build (/discoveries/…/undefined/…) cannot exist.
+    expect(
+      searchResultHref(
+        {
+          id: 'src-1',
+          type: 'source_chunk',
+          score: 0.5,
+          name: 'runbook.docx',
+          description: '',
+          discovery_id: '',
+          discovered_at: '2026-05-01T00:00:00Z',
+        },
+        'p-fallback',
+      ),
+    ).toBe('/projects/p-fallback/sources');
+  });
+});

--- a/ui/dashboard/src/components/citations/CitationsFooter.tsx
+++ b/ui/dashboard/src/components/citations/CitationsFooter.tsx
@@ -16,6 +16,14 @@ import type { SearchResultItem } from '@/lib/api';
  * clicks through.
  */
 export function sourceHref(projectId: string, src: SearchResultItem): string {
+  // A knowledge-source citation is not a discovery finding: it has no
+  // discovery run and no detail page, so it links to the project's
+  // knowledge sources. That route ships in the enterprise overlay, which
+  // is also the only build that can produce this citation type —
+  // knowledge sources are an enterprise feature.
+  if (src.type === 'source_chunk') {
+    return `/projects/${projectId}/sources`;
+  }
   const type = src.type === 'insight' ? 'insights' : 'recommendations';
   if (src.discovery_id) {
     return `/projects/${projectId}/discoveries/${src.discovery_id}/${type}/${src.id}`;

--- a/ui/dashboard/src/lib/api.ts
+++ b/ui/dashboard/src/lib/api.ts
@@ -842,7 +842,13 @@ export interface CrossProjectSearchRequest {
 
 export interface SearchResultItem {
   id: string;
-  type: 'insight' | 'recommendation';
+  // 'source_chunk' is returned when an answer cites a knowledge-source
+  // document (an upload, URL, or a file synced from external storage)
+  // rather than a discovery finding. Such a citation has no
+  // discovery_id, and links to the project's knowledge sources instead
+  // of an insight or recommendation — callers switching on this field
+  // must handle it rather than defaulting it to a recommendation.
+  type: 'insight' | 'recommendation' | 'source_chunk';
   score: number;
   name: string;
   title?: string;

--- a/ui/dashboard/src/lib/searchNav.ts
+++ b/ui/dashboard/src/lib/searchNav.ts
@@ -2,7 +2,13 @@ import type { SearchResultItem } from '@/lib/api';
 
 // Maps a SearchResultItem's discriminator to the URL segment used by the
 // detail routes under /projects/[id]/discoveries/[runId]/.
-const DETAIL_SEGMENT: Record<SearchResultItem['type'], 'insights' | 'recommendations'> = {
+//
+// 'source_chunk' is absent deliberately: a knowledge-source citation has
+// no discovery run and therefore no detail route under it. Search never
+// returns that type — it queries discovery findings — but the shared
+// result type admits it, so searchResultHref handles it explicitly
+// rather than building a nonsense /discoveries/undefined/... URL.
+const DETAIL_SEGMENT: Partial<Record<SearchResultItem['type'], 'insights' | 'recommendations'>> = {
   insight: 'insights',
   recommendation: 'recommendations',
 };
@@ -28,5 +34,10 @@ export function searchResultHref(
 ): string {
   const projectId = item.project_id || fallbackProjectId;
   const segment = DETAIL_SEGMENT[item.type];
+  if (!segment) {
+    // Not a discovery finding — send the user to the project's knowledge
+    // sources rather than a detail route that cannot exist.
+    return `/projects/${projectId}/sources`;
+  }
   return `/projects/${projectId}/discoveries/${item.discovery_id}/${segment}/${item.id}`;
 }


### PR DESCRIPTION
Platform support for a knowledge-source document-search tool in a downstream plugin. Three related changes; the default path is unchanged throughout.

## 1. `sources.RetrieveOpts.DocumentsOnly`

`RetrieveContext` is shaped for **prompt-context assembly**. An implementation may inject operator-authored notes ahead of — and in addition to — semantic matches, so pinned guidance always reaches the model. Those note passes are deliberately *not* bound by `Limit`, and they consume the budget before documents are searched.

That contract is wrong for a caller exposing retrieval as a **document-search tool**:

- it returns content the tool never advertised (notes, when the tool says "documents"), and
- it cannot honour the result cap it promised, because the pinned pass ignores `Limit`.

`DocumentsOnly` restricts retrieval to document chunks and makes `Limit` an exact upper bound.

## 2. `vectorstore.SearchOpts.ExcludeSourceTypes`

Knowledge-source chunks all carry the same payload `type` (`"source_chunk"`) and distinguish note from document only by `source_type` — so the existing `Types` filter cannot separate them.

Without server-side filtering, a documents-only caller must drop note hits *after* the search, which lets them occupy the top-K window and be discarded — silently returning fewer results than `Limit` while matching documents sat just below the cut. This was a real defect in the first version of the consuming change, caught in review.

Applied as a Qdrant `must_not`. Empty entries are ignored, and an exclusion-only filter is still a filter (it must not collapse to `nil`).

## 3. `SearchResultItem.type` admits `'source_chunk'`

An answer can now cite a knowledge-source document, which the response carries as `type: "source_chunk"` — a value the union did not allow. Widening it surfaced every consumer that assumed two cases:

- **`sourceHref`** treated anything not an insight as a recommendation, so a document citation linked to the **recommendations page** rather than the cited document.
- **`searchResultHref`** indexed a *total* `Record` by type; a knowledge-source result would have built a detail URL under a discovery run that does not exist.

Both now route to the project's knowledge sources. That page ships in the plugin overlay — which is also the only build that can produce such a citation, since knowledge sources are a plugin feature.

## Test plan

- `go build` / `go vet` clean in `libs/go-common`
- `vectorstore/qdrant` tests pass, including a new `TestBuildFilterExcludeSourceTypes` covering must_not construction, multiple exclusions, empty-string handling, exclusion-only filters, and the all-empty → `nil` case
- Dashboard: **28 suites / 336 tests pass**, eslint clean, `next build` type-checks the widened union across the community dashboard and the plugin overlay
- Consuming behaviour is covered downstream by four integration tests against real Mongo, each also asserting the default path still injects notes uncapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)