### PR TITLE
feat(policy): add file_ingestion_enabled feature flag

### DIFF
--- a/libs/go-common/policy/checker.go
+++ b/libs/go-common/policy/checker.go
@@ -124,6 +124,7 @@ const (
 	// enterprise DataSourceCount sums warehouses across projects).
 	FeatureMultiWarehouse = "multi_warehouse_enabled"
 	FeatureConnectors     = "connectors_enabled"
+	FeatureFileIngestion  = "file_ingestion_enabled"
 )
 
 // AllFeatures is the canonical, ordered list of wire flag names.
@@ -146,6 +147,7 @@ var AllFeatures = []string{
 	FeatureAskCharts,
 	FeatureMultiWarehouse,
 	FeatureConnectors,
+	FeatureFileIngestion,
 }
 
 // Reservation kinds used in the /internal/deployments/{id}/usage/reserve/{kind}

--- a/libs/go-common/policy/policy_test.go
+++ b/libs/go-common/policy/policy_test.go
@@ -241,6 +241,7 @@ func TestAllFeatures_ContainsEveryConstant(t *testing.T) {
 		FeatureAskCharts,
 		FeatureMultiWarehouse,
 		FeatureConnectors,
+		FeatureFileIngestion,
 	}
 	if len(AllFeatures) != len(want) {
 		t.Fatalf("AllFeatures length = %d, want %d", len(AllFeatures), len(want))


### PR DESCRIPTION
Adds `FeatureFileIngestion = "file_ingestion_enabled"` to the policy checker's wire vocabulary + `AllFeatures`.

## Why
The enterprise file-ingestion plugin gates its routes at request time via `policy.GetChecker().FeatureEnabled(ctx, "", "file_ingestion_enabled")`, but the flag string wasn't in the policy package's canonical list — a documented gap (`decisionbox-enterprise/docs/design/file-ingestion.md §7`). Registering it here lets community/enterprise/cloud checkers recognize the flag uniformly, which the cloud **free self-serve PoC funnel** (control-plane #117) needs so the cloud tenant honors the plan's `file_ingestion_enabled`.

## Change
- `FeatureFileIngestion` const + `AllFeatures` entry.
- Updated `TestAllFeatures_ContainsEveryConstant`'s want-list.

The community policy hook doesn't implement the feature — it only knows the name (same as the other enterprise-feature flags already listed). `go test ./policy/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Co-coded with Jale 🤖