### PR TITLE
feat(llm): schema-constrained structured output across providers

### DIFF
--- a/libs/go-common/llm/openaicompat/format.go
+++ b/libs/go-common/llm/openaicompat/format.go
@@ -41,6 +41,32 @@ type RequestBody struct {
 	// always did.
 	Tools      []Tool      `json:"tools,omitempty"`
 	ToolChoice interface{} `json:"tool_choice,omitempty"`
+
+	// ResponseFormat is populated only when the caller supplies
+	// ChatRequest.ResponseFormat. Omitted otherwise so requests that
+	// don't ask for structured output keep exactly the shape they always
+	// had.
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+}
+
+// ResponseFormat is the OpenAI `response_format` object. Only the
+// json_schema variant is emitted here (Type == "json_schema"); the
+// json_object and text variants have no consumer.
+type ResponseFormat struct {
+	Type       string      `json:"type"`
+	JSONSchema *JSONSchema `json:"json_schema,omitempty"`
+}
+
+// JSONSchema is the inner object of a json_schema response_format.
+// Strict is intentionally left false for schemas that use open-ended
+// (dynamic-key) objects: OpenAI strict mode forbids them (it requires
+// additionalProperties:false and every property required), which would
+// drop such fields. Non-strict json_schema still steers the model to a
+// single conforming object while keeping open maps expressible.
+type JSONSchema struct {
+	Name   string                 `json:"name"`
+	Schema map[string]interface{} `json:"schema"`
+	Strict bool                   `json:"strict"`
 }
 
 // Tool is one entry in the `tools` array. OpenAI distinguishes tool type
@@ -65,7 +91,7 @@ type ToolFunction struct {
 type Message struct {
 	Role       string     `json:"role"`
 	Content    string     `json:"content"`
-	Name       string     `json:"name,omitempty"`        // legacy function-call naming
+	Name       string     `json:"name,omitempty"`         // legacy function-call naming
 	ToolCallID string     `json:"tool_call_id,omitempty"` // only on role=tool
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 }
@@ -86,10 +112,10 @@ type ToolCallFunction struct {
 
 // ResponseBody is the OpenAI /chat/completions response body.
 type ResponseBody struct {
-	ID      string   `json:"id"`
-	Model   string   `json:"model"`
-	Choices []Choice `json:"choices"`
-	Usage   Usage    `json:"usage"`
+	ID      string    `json:"id"`
+	Model   string    `json:"model"`
+	Choices []Choice  `json:"choices"`
+	Usage   Usage     `json:"usage"`
 	Error   *APIError `json:"error,omitempty"`
 }
 
@@ -228,6 +254,20 @@ func BuildRequestBody(model string, req gollm.ChatRequest) RequestBody {
 	}
 	if tc := translateToolChoice(req.ToolChoice); tc != nil {
 		body.ToolChoice = tc
+	}
+	if rf := req.ResponseFormat; rf != nil && len(rf.Schema) > 0 {
+		name := rf.Name
+		if name == "" {
+			name = "response"
+		}
+		body.ResponseFormat = &ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &JSONSchema{
+				Name:   name,
+				Schema: rf.Schema,
+				Strict: rf.Strict,
+			},
+		}
 	}
 	return body
 }

--- a/libs/go-common/llm/openaicompat/format_test.go
+++ b/libs/go-common/llm/openaicompat/format_test.go
@@ -371,3 +371,80 @@ func TestAPIError_ErrorString(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildRequestBody_ResponseFormatJSONSchema verifies a ChatRequest
+// ResponseFormat is rendered as an OpenAI response_format json_schema
+// object carrying the caller's schema, and that Strict is threaded
+// through (kept false by callers whose schema has open-ended maps).
+func TestBuildRequestBody_ResponseFormatJSONSchema(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"slug": map[string]interface{}{"type": "string"},
+		},
+		// Open-ended object — must survive verbatim into the wire schema.
+		"categories": map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": map[string]interface{}{"type": "string"},
+		},
+	}
+	body := BuildRequestBody("gpt-4o", gollm.ChatRequest{
+		Messages:       []gollm.Message{{Role: "user", Content: "go"}},
+		ResponseFormat: &gollm.ResponseFormat{Name: "domain_pack", Schema: schema},
+	})
+	if body.ResponseFormat == nil {
+		t.Fatal("response_format not set")
+	}
+	if body.ResponseFormat.Type != "json_schema" {
+		t.Errorf("type = %q, want json_schema", body.ResponseFormat.Type)
+	}
+	js := body.ResponseFormat.JSONSchema
+	if js == nil || js.Name != "domain_pack" {
+		t.Fatalf("json_schema = %+v", js)
+	}
+	if js.Strict {
+		t.Error("strict should default to false so open-ended maps stay expressible")
+	}
+	cats, ok := js.Schema["categories"].(map[string]interface{})
+	if !ok || cats["additionalProperties"] == nil {
+		t.Errorf("open-ended 'categories' object dropped from wire schema: %v", js.Schema)
+	}
+
+	// Round-trips to the OpenAI wire shape.
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"response_format"`) || !strings.Contains(string(raw), `"json_schema"`) {
+		t.Errorf("wire body missing response_format/json_schema: %s", raw)
+	}
+}
+
+// TestBuildRequestBody_NoResponseFormatOmitted locks the non-regression
+// contract: a request without ResponseFormat carries no response_format
+// key on the wire, so existing (non-structured) calls are unchanged.
+func TestBuildRequestBody_NoResponseFormatOmitted(t *testing.T) {
+	body := BuildRequestBody("gpt-4o", gollm.ChatRequest{
+		Messages: []gollm.Message{{Role: "user", Content: "hi"}},
+	})
+	if body.ResponseFormat != nil {
+		t.Fatal("response_format should be nil when unset")
+	}
+	raw, _ := json.Marshal(body)
+	if strings.Contains(string(raw), "response_format") {
+		t.Errorf("response_format must be omitted from the wire when unset: %s", raw)
+	}
+}
+
+// TestBuildRequestBody_EmptySchemaResponseFormatOmitted — a ResponseFormat
+// with no schema is ignored (nothing to constrain), keeping the request
+// identical to the unset case.
+func TestBuildRequestBody_EmptySchemaResponseFormatOmitted(t *testing.T) {
+	body := BuildRequestBody("gpt-4o", gollm.ChatRequest{
+		Messages:       []gollm.Message{{Role: "user", Content: "hi"}},
+		ResponseFormat: &gollm.ResponseFormat{Name: "x"},
+	})
+	if body.ResponseFormat != nil {
+		t.Error("response_format should be omitted when schema is empty")
+	}
+}

--- a/libs/go-common/llm/provider.go
+++ b/libs/go-common/llm/provider.go
@@ -80,6 +80,14 @@ type ChatRequest struct {
 	// set the caller's Tools win and ResponseFormat is ignored, so an
 	// existing tool-using flow can never be disturbed by this field.
 	ResponseFormat *ResponseFormat
+
+	// DisableParallelToolUse asks providers whose tool calling is parallel
+	// by default (Anthropic) to emit AT MOST ONE tool call. It is set
+	// automatically when a ResponseFormat is satisfied by a forced
+	// synthetic tool (see ApplyResponseFormatAsTool), so the structured
+	// answer comes back as exactly one object rather than several partial
+	// tool calls. Providers without a parallel-tool-use control ignore it.
+	DisableParallelToolUse bool
 }
 
 // ResponseFormat constrains a chat response to a JSON Schema. Providers

--- a/libs/go-common/llm/provider.go
+++ b/libs/go-common/llm/provider.go
@@ -58,6 +58,52 @@ type ChatRequest struct {
 	// provider rollout never errors on a value an older caller can't
 	// know to omit.
 	ReasoningEffort string
+
+	// ResponseFormat, when non-nil, asks the provider to constrain the
+	// model's output to the given JSON Schema using its native
+	// structured-output mode: OpenAI-compatible `response_format` with a
+	// json_schema, Ollama's `format` field (a llama.cpp grammar), or —
+	// for the Anthropic wire, which has no response_format — a single
+	// forced tool whose input schema is the requested schema, with the
+	// tool result normalised back into ChatResponse.Content so callers
+	// parse output uniformly regardless of provider.
+	//
+	// Unlike Tools (which errors when unsupported, so a caller learns a
+	// relied-upon capability is missing), ResponseFormat is advisory: a
+	// provider whose ProviderMeta.SupportsStructuredOutput is false
+	// ignores it. Callers should gate on that flag and fall back to
+	// tolerant parsing when it is not set.
+	//
+	// ResponseFormat is orthogonal to Tools. A provider that satisfies
+	// ResponseFormat by forcing an internal tool must do so ONLY when the
+	// caller supplied no Tools of its own (len(Tools) == 0); when both are
+	// set the caller's Tools win and ResponseFormat is ignored, so an
+	// existing tool-using flow can never be disturbed by this field.
+	ResponseFormat *ResponseFormat
+}
+
+// ResponseFormat constrains a chat response to a JSON Schema. Providers
+// translate it to their native structured-output control; see the
+// ChatRequest.ResponseFormat doc for the per-wire mapping.
+type ResponseFormat struct {
+	// Name is a short identifier for the schema (e.g. "domain_pack").
+	// Required by the OpenAI json_schema wire and used as the forced
+	// tool name on the Anthropic wire; ignored by Ollama.
+	Name string
+
+	// Schema is the JSON Schema (draft 2020-12) object the output must
+	// conform to. Open-ended objects (`additionalProperties` with a value
+	// schema and dynamic keys) are honoured by the Ollama grammar and the
+	// Anthropic tool input_schema; the OpenAI wire therefore uses
+	// non-strict json_schema so such shapes remain expressible.
+	Schema map[string]interface{}
+
+	// Strict requests strict adherence where the provider supports it.
+	// Left false by callers whose schema uses open-ended maps, because
+	// OpenAI strict mode forbids them (it requires additionalProperties
+	// false and every key required). Providers that cannot honour strict
+	// simply treat it as best-effort.
+	Strict bool
 }
 
 // ReasoningEffort* are the documented values for

--- a/libs/go-common/llm/registry.go
+++ b/libs/go-common/llm/registry.go
@@ -296,6 +296,16 @@ type ProviderMeta struct {
 	// different provider or skip tools.
 	SupportsTools bool `json:"supports_tools"`
 
+	// SupportsStructuredOutput declares whether the provider's Chat
+	// method honours ChatRequest.ResponseFormat by constraining output to
+	// the supplied JSON Schema (OpenAI response_format, Ollama format, or
+	// Anthropic forced tool-use). When false the field is ignored and
+	// callers must fall back to tolerant parsing. A provider advertises
+	// this only on a mode that can represent every field of the caller's
+	// schema — including open-ended (dynamic-key) objects — so setting a
+	// ResponseFormat never silently drops part of the requested shape.
+	SupportsStructuredOutput bool `json:"supports_structured_output"`
+
 	// DispatchAnyModelID declares that this provider's Chat method
 	// accepts ANY non-empty model ID through one SDK path, with no
 	// wire dispatch step that needs the ID classified. Today only
@@ -509,15 +519,16 @@ type AuthMethod struct {
 // shape stays "{...meta, models: [...]}", but with one row per
 // canonical ID and aliases hidden.
 type providerMetaJSON struct {
-	ID                     string        `json:"id"`
-	Name                   string        `json:"name"`
-	Description            string        `json:"description"`
-	ConfigFields           []ConfigField `json:"config_fields"`
-	AuthMethods            []AuthMethod  `json:"auth_methods,omitempty"`
-	Models                 []ModelInfo   `json:"models,omitempty"`
-	DefaultMaxOutputTokens int           `json:"default_max_output_tokens,omitempty"`
-	DefaultMaxInputTokens  int           `json:"default_max_input_tokens,omitempty"`
-	SupportsTools          bool          `json:"supports_tools"`
+	ID                       string        `json:"id"`
+	Name                     string        `json:"name"`
+	Description              string        `json:"description"`
+	ConfigFields             []ConfigField `json:"config_fields"`
+	AuthMethods              []AuthMethod  `json:"auth_methods,omitempty"`
+	Models                   []ModelInfo   `json:"models,omitempty"`
+	DefaultMaxOutputTokens   int           `json:"default_max_output_tokens,omitempty"`
+	DefaultMaxInputTokens    int           `json:"default_max_input_tokens,omitempty"`
+	SupportsTools            bool          `json:"supports_tools"`
+	SupportsStructuredOutput bool          `json:"supports_structured_output"`
 }
 
 // MarshalJSON renders ProviderMeta with the catalog flattened to
@@ -527,15 +538,16 @@ type providerMetaJSON struct {
 // the combobox.
 func (m ProviderMeta) MarshalJSON() ([]byte, error) {
 	return json.Marshal(providerMetaJSON{
-		ID:                     m.ID,
-		Name:                   m.Name,
-		Description:            m.Description,
-		ConfigFields:           m.ConfigFields,
-		AuthMethods:            m.AuthMethods,
-		Models:                 m.CatalogModels(),
-		DefaultMaxOutputTokens: m.DefaultMaxOutputTokens,
-		DefaultMaxInputTokens:  m.DefaultMaxInputTokens,
-		SupportsTools:          m.SupportsTools,
+		ID:                       m.ID,
+		Name:                     m.Name,
+		Description:              m.Description,
+		ConfigFields:             m.ConfigFields,
+		AuthMethods:              m.AuthMethods,
+		Models:                   m.CatalogModels(),
+		DefaultMaxOutputTokens:   m.DefaultMaxOutputTokens,
+		DefaultMaxInputTokens:    m.DefaultMaxInputTokens,
+		SupportsTools:            m.SupportsTools,
+		SupportsStructuredOutput: m.SupportsStructuredOutput,
 	})
 }
 

--- a/libs/go-common/llm/registry_test.go
+++ b/libs/go-common/llm/registry_test.go
@@ -459,8 +459,9 @@ func TestProviderMeta_MarshalJSON(t *testing.T) {
 					Pricing:         TokenPricing{InputPerMillion: 1, OutputPerMillion: 2},
 				},
 			},
-			DefaultMaxOutputTokens: 999,
-			SupportsTools:          true,
+			DefaultMaxOutputTokens:   999,
+			SupportsTools:            true,
+			SupportsStructuredOutput: true,
 		})
 	})
 	meta, _ := GetProviderMeta(name)
@@ -485,6 +486,10 @@ func TestProviderMeta_MarshalJSON(t *testing.T) {
 	// supports_tools serialised.
 	if !strings.Contains(got, `"supports_tools":true`) {
 		t.Errorf("supports_tools missing in %q", got)
+	}
+	// supports_structured_output serialised.
+	if !strings.Contains(got, `"supports_structured_output":true`) {
+		t.Errorf("supports_structured_output missing in %q", got)
 	}
 }
 

--- a/libs/go-common/llm/structured_output.go
+++ b/libs/go-common/llm/structured_output.go
@@ -74,4 +74,8 @@ func NormalizeStructuredToolResponse(resp *ChatResponse, injected bool) {
 	}
 	resp.Content = string(b)
 	resp.ToolCalls = nil
+	// The synthetic tool call is now hidden, so the upstream "tool_use"
+	// stop reason would violate the invariant that tool_use implies there
+	// are tool calls to execute. Present it as a normal terminal turn.
+	resp.StopReason = "end_turn"
 }

--- a/libs/go-common/llm/structured_output.go
+++ b/libs/go-common/llm/structured_output.go
@@ -56,19 +56,22 @@ func ApplyResponseFormatAsTool(req ChatRequest) (ChatRequest, bool) {
 // under a forced tool_choice), Content is left as-is so the caller's own
 // parser still sees whatever was produced.
 func NormalizeStructuredToolResponse(resp *ChatResponse, injected bool) {
-	if !injected || resp == nil {
+	if !injected || resp == nil || len(resp.ToolCalls) == 0 {
 		return
 	}
-	for _, tc := range resp.ToolCalls {
-		if len(tc.Input) == 0 {
-			continue
-		}
-		b, err := json.Marshal(tc.Input)
-		if err != nil {
-			continue
-		}
-		resp.Content = string(b)
-		resp.ToolCalls = nil
+	// The forced tool is the model's structured answer. Fold its input back
+	// into Content even when it is an empty object ({} — valid for a schema
+	// whose fields are all optional), so the caller never sees the
+	// synthetic tool call and always gets a parseable JSON string. A nil
+	// input map marshals to "null", so normalise it to an empty object.
+	input := resp.ToolCalls[0].Input
+	if input == nil {
+		input = map[string]interface{}{}
+	}
+	b, err := json.Marshal(input)
+	if err != nil {
 		return
 	}
+	resp.Content = string(b)
+	resp.ToolCalls = nil
 }

--- a/libs/go-common/llm/structured_output.go
+++ b/libs/go-common/llm/structured_output.go
@@ -1,6 +1,9 @@
 package llm
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // defaultStructuredToolName is the synthetic tool name used when a
 // ResponseFormat carries no Name. Providers on the Anthropic wire (which
@@ -32,8 +35,13 @@ func ApplyResponseFormatAsTool(req ChatRequest) (ChatRequest, bool) {
 	if rf == nil || len(rf.Schema) == 0 || len(req.Tools) > 0 {
 		return req, false
 	}
+	// The name doubles as ToolChoice below, which providers interpret via
+	// their tool-choice mapping. A name that collides with a reserved
+	// tool-choice token ("auto"/"any"/"required"/"none") would be read as a
+	// MODE (e.g. "none" → don't call any tool) and silently disable forced
+	// tool use, so fall back to the default synthetic name in that case.
 	name := rf.Name
-	if name == "" {
+	if name == "" || isReservedToolChoice(name) {
 		name = defaultStructuredToolName
 	}
 	req.Tools = []ToolDefinition{{
@@ -43,6 +51,17 @@ func ApplyResponseFormatAsTool(req ChatRequest) (ChatRequest, bool) {
 	}}
 	req.ToolChoice = name
 	return req, true
+}
+
+// isReservedToolChoice reports whether s is one of the wire-neutral
+// tool-choice mode tokens (see ChatRequest.ToolChoice). A tool named like
+// one of these must not be used as a forced tool name.
+func isReservedToolChoice(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "auto", "any", "required", "none":
+		return true
+	}
+	return false
 }
 
 // NormalizeStructuredToolResponse folds a forced-tool reply back into

--- a/libs/go-common/llm/structured_output.go
+++ b/libs/go-common/llm/structured_output.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -69,14 +70,24 @@ func isReservedToolChoice(s string) bool {
 // to know a tool was used to satisfy their ResponseFormat.
 //
 // It only acts when injected is true (i.e. ApplyResponseFormatAsTool
-// injected the synthetic tool). If the model called the tool, its Input
-// map is marshalled to JSON and written to Content, and ToolCalls is
-// cleared. If the model returned text instead of calling the tool (rare
-// under a forced tool_choice), Content is left as-is so the caller's own
-// parser still sees whatever was produced.
-func NormalizeStructuredToolResponse(resp *ChatResponse, injected bool) {
+// injected the synthetic tool). If the model called the tool exactly once,
+// its Input map is marshalled to JSON and written to Content, ToolCalls is
+// cleared, and the "tool_use" stop reason is normalised to a terminal turn.
+// If the model returned text instead of calling the tool (rare under a
+// forced tool_choice), Content is left as-is so the caller's own parser
+// still sees whatever was produced.
+//
+// It returns an error if the model produced MORE than one tool call for the
+// forced tool (possible on the Anthropic wire, where parallel tool use is
+// on by default): folding only the first would silently drop the rest, so
+// the caller must surface the failure and retry rather than persist a
+// partial object.
+func NormalizeStructuredToolResponse(resp *ChatResponse, injected bool) error {
 	if !injected || resp == nil || len(resp.ToolCalls) == 0 {
-		return
+		return nil
+	}
+	if len(resp.ToolCalls) > 1 {
+		return fmt.Errorf("structured output: model returned %d tool calls for the forced schema tool; expected exactly one", len(resp.ToolCalls))
 	}
 	// The forced tool is the model's structured answer. Fold its input back
 	// into Content even when it is an empty object ({} — valid for a schema
@@ -89,7 +100,7 @@ func NormalizeStructuredToolResponse(resp *ChatResponse, injected bool) {
 	}
 	b, err := json.Marshal(input)
 	if err != nil {
-		return
+		return fmt.Errorf("structured output: marshal tool input: %w", err)
 	}
 	resp.Content = string(b)
 	resp.ToolCalls = nil
@@ -97,4 +108,5 @@ func NormalizeStructuredToolResponse(resp *ChatResponse, injected bool) {
 	// stop reason would violate the invariant that tool_use implies there
 	// are tool calls to execute. Present it as a normal terminal turn.
 	resp.StopReason = "end_turn"
+	return nil
 }

--- a/libs/go-common/llm/structured_output.go
+++ b/libs/go-common/llm/structured_output.go
@@ -1,0 +1,74 @@
+package llm
+
+import "encoding/json"
+
+// defaultStructuredToolName is the synthetic tool name used when a
+// ResponseFormat carries no Name. Providers on the Anthropic wire (which
+// has no response_format field) satisfy ResponseFormat by forcing a
+// single tool whose input schema is the requested schema; this is the
+// tool's name when the caller did not supply one.
+const defaultStructuredToolName = "json_response"
+
+// ApplyResponseFormatAsTool rewrites req so that a ResponseFormat is
+// expressed as a single forced tool. It exists for wires that cannot take
+// a native response_format (the Anthropic Messages API): forcing a tool
+// whose input_schema is the requested schema is Anthropic's supported way
+// to get a guaranteed-shape JSON object out of the model.
+//
+// It is a no-op — returning the request unchanged and injected=false —
+// when any of these hold, so it can be called unconditionally at the top
+// of an Anthropic-wire Chat:
+//   - req.ResponseFormat is nil (no structured output requested);
+//   - req.Tools is non-empty (the caller's own tools win — ResponseFormat
+//     must never disturb an existing tool-using flow);
+//   - the schema is empty.
+//
+// When it does inject, it sets req.Tools to the single synthetic tool and
+// req.ToolChoice to that tool's name (forcing the model to call it), and
+// returns injected=true so the caller pairs it with
+// NormalizeStructuredToolResponse on the reply.
+func ApplyResponseFormatAsTool(req ChatRequest) (ChatRequest, bool) {
+	rf := req.ResponseFormat
+	if rf == nil || len(rf.Schema) == 0 || len(req.Tools) > 0 {
+		return req, false
+	}
+	name := rf.Name
+	if name == "" {
+		name = defaultStructuredToolName
+	}
+	req.Tools = []ToolDefinition{{
+		Name:        name,
+		Description: "Return the response as a single JSON object that conforms to the input schema. Call this tool exactly once with the complete object.",
+		InputSchema: rf.Schema,
+	}}
+	req.ToolChoice = name
+	return req, true
+}
+
+// NormalizeStructuredToolResponse folds a forced-tool reply back into
+// ChatResponse.Content so callers parse output uniformly and never have
+// to know a tool was used to satisfy their ResponseFormat.
+//
+// It only acts when injected is true (i.e. ApplyResponseFormatAsTool
+// injected the synthetic tool). If the model called the tool, its Input
+// map is marshalled to JSON and written to Content, and ToolCalls is
+// cleared. If the model returned text instead of calling the tool (rare
+// under a forced tool_choice), Content is left as-is so the caller's own
+// parser still sees whatever was produced.
+func NormalizeStructuredToolResponse(resp *ChatResponse, injected bool) {
+	if !injected || resp == nil {
+		return
+	}
+	for _, tc := range resp.ToolCalls {
+		if len(tc.Input) == 0 {
+			continue
+		}
+		b, err := json.Marshal(tc.Input)
+		if err != nil {
+			continue
+		}
+		resp.Content = string(b)
+		resp.ToolCalls = nil
+		return
+	}
+}

--- a/libs/go-common/llm/structured_output.go
+++ b/libs/go-common/llm/structured_output.go
@@ -51,6 +51,11 @@ func ApplyResponseFormatAsTool(req ChatRequest) (ChatRequest, bool) {
 		InputSchema: rf.Schema,
 	}}
 	req.ToolChoice = name
+	// The structured answer is a single object, so forbid parallel tool use
+	// where the provider supports it (Anthropic) — otherwise Claude could
+	// legally return several calls to the synthetic tool and the fold-back
+	// would have to reject them.
+	req.DisableParallelToolUse = true
 	return req, true
 }
 

--- a/libs/go-common/llm/structured_output_test.go
+++ b/libs/go-common/llm/structured_output_test.go
@@ -116,6 +116,33 @@ func TestNormalizeStructuredToolResponse_FoldsToolInputToContent(t *testing.T) {
 	}
 }
 
+// An empty object {} is a valid structured response (schema with only
+// optional fields / empty dynamic maps) and must still be folded into
+// Content — not left as an exposed tool call with empty Content.
+func TestNormalizeStructuredToolResponse_EmptyObjectFolded(t *testing.T) {
+	resp := &ChatResponse{
+		StopReason: "tool_use",
+		ToolCalls:  []ToolCall{{ID: "t1", Name: "domain_pack", Input: map[string]interface{}{}}},
+	}
+	NormalizeStructuredToolResponse(resp, true)
+	if resp.Content != "{}" {
+		t.Errorf("Content = %q, want %q", resp.Content, "{}")
+	}
+	if resp.ToolCalls != nil {
+		t.Error("ToolCalls should be cleared")
+	}
+}
+
+// A nil input map (no arguments captured) normalises to {} rather than
+// "null".
+func TestNormalizeStructuredToolResponse_NilInputBecomesEmptyObject(t *testing.T) {
+	resp := &ChatResponse{ToolCalls: []ToolCall{{ID: "t1", Name: "domain_pack"}}}
+	NormalizeStructuredToolResponse(resp, true)
+	if resp.Content != "{}" {
+		t.Errorf("Content = %q, want %q", resp.Content, "{}")
+	}
+}
+
 func TestNormalizeStructuredToolResponse_NotInjectedIsNoop(t *testing.T) {
 	resp := &ChatResponse{Content: "hello", ToolCalls: []ToolCall{{Name: "x", Input: map[string]interface{}{"a": 1}}}}
 	NormalizeStructuredToolResponse(resp, false)

--- a/libs/go-common/llm/structured_output_test.go
+++ b/libs/go-common/llm/structured_output_test.go
@@ -1,0 +1,135 @@
+package llm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func sampleSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"slug": map[string]interface{}{"type": "string"},
+		},
+		// An open-ended (dynamic-key) object — the exact shape strict
+		// OpenAI json_schema forbids but Ollama grammar and Anthropic tool
+		// input schemas accept. Kept here so the helper is exercised with
+		// the shape the feature must preserve.
+		"categories": map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": map[string]interface{}{"type": "string"},
+		},
+	}
+}
+
+func TestApplyResponseFormatAsTool_NoResponseFormat(t *testing.T) {
+	req := ChatRequest{Model: "m"}
+	got, injected := ApplyResponseFormatAsTool(req)
+	if injected {
+		t.Fatal("injected=true with no ResponseFormat")
+	}
+	if len(got.Tools) != 0 || got.ToolChoice != "" {
+		t.Errorf("request mutated: tools=%v toolChoice=%q", got.Tools, got.ToolChoice)
+	}
+}
+
+func TestApplyResponseFormatAsTool_EmptySchemaNoop(t *testing.T) {
+	req := ChatRequest{ResponseFormat: &ResponseFormat{Name: "x"}}
+	_, injected := ApplyResponseFormatAsTool(req)
+	if injected {
+		t.Fatal("injected=true with empty schema")
+	}
+}
+
+func TestApplyResponseFormatAsTool_InjectsForcedTool(t *testing.T) {
+	req := ChatRequest{ResponseFormat: &ResponseFormat{Name: "domain_pack", Schema: sampleSchema()}}
+	got, injected := ApplyResponseFormatAsTool(req)
+	if !injected {
+		t.Fatal("injected=false, want true")
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("want 1 tool, got %d", len(got.Tools))
+	}
+	if got.Tools[0].Name != "domain_pack" {
+		t.Errorf("tool name = %q, want domain_pack", got.Tools[0].Name)
+	}
+	if got.ToolChoice != "domain_pack" {
+		t.Errorf("tool_choice = %q, want domain_pack (forced)", got.ToolChoice)
+	}
+	// The open-ended object must survive into the tool input schema.
+	cats, ok := got.Tools[0].InputSchema["categories"].(map[string]interface{})
+	if !ok || cats["additionalProperties"] == nil {
+		t.Errorf("open-ended 'categories' object dropped from tool schema: %v", got.Tools[0].InputSchema)
+	}
+}
+
+func TestApplyResponseFormatAsTool_DefaultName(t *testing.T) {
+	req := ChatRequest{ResponseFormat: &ResponseFormat{Schema: sampleSchema()}}
+	got, _ := ApplyResponseFormatAsTool(req)
+	if got.Tools[0].Name != defaultStructuredToolName {
+		t.Errorf("tool name = %q, want %q", got.Tools[0].Name, defaultStructuredToolName)
+	}
+}
+
+// The caller's own tools must always win — ResponseFormat can never
+// disturb an existing tool-using flow (e.g. /ask function calling).
+func TestApplyResponseFormatAsTool_CallerToolsWin(t *testing.T) {
+	req := ChatRequest{
+		ResponseFormat: &ResponseFormat{Name: "domain_pack", Schema: sampleSchema()},
+		Tools:          []ToolDefinition{{Name: "search"}},
+		ToolChoice:     "auto",
+	}
+	got, injected := ApplyResponseFormatAsTool(req)
+	if injected {
+		t.Fatal("injected=true despite caller-supplied tools")
+	}
+	if len(got.Tools) != 1 || got.Tools[0].Name != "search" {
+		t.Errorf("caller tools mutated: %v", got.Tools)
+	}
+	if got.ToolChoice != "auto" {
+		t.Errorf("caller tool_choice mutated: %q", got.ToolChoice)
+	}
+}
+
+func TestNormalizeStructuredToolResponse_FoldsToolInputToContent(t *testing.T) {
+	resp := &ChatResponse{
+		StopReason: "tool_use",
+		ToolCalls: []ToolCall{{
+			ID:    "t1",
+			Name:  "domain_pack",
+			Input: map[string]interface{}{"slug": "acme"},
+		}},
+	}
+	NormalizeStructuredToolResponse(resp, true)
+	if resp.Content == "" {
+		t.Fatal("content not populated from tool input")
+	}
+	var got map[string]string
+	if err := json.Unmarshal([]byte(resp.Content), &got); err != nil {
+		t.Fatalf("content is not valid JSON: %v (%q)", err, resp.Content)
+	}
+	if got["slug"] != "acme" {
+		t.Errorf("content = %q, want slug=acme", resp.Content)
+	}
+	if resp.ToolCalls != nil {
+		t.Error("ToolCalls should be cleared after folding")
+	}
+}
+
+func TestNormalizeStructuredToolResponse_NotInjectedIsNoop(t *testing.T) {
+	resp := &ChatResponse{Content: "hello", ToolCalls: []ToolCall{{Name: "x", Input: map[string]interface{}{"a": 1}}}}
+	NormalizeStructuredToolResponse(resp, false)
+	if resp.Content != "hello" || resp.ToolCalls == nil {
+		t.Error("no-op expected when injected=false")
+	}
+}
+
+// When the model returned plain text (rare under a forced tool_choice)
+// the caller's own parser must still see it — Content is left untouched.
+func TestNormalizeStructuredToolResponse_TextResponseLeftIntact(t *testing.T) {
+	resp := &ChatResponse{Content: `{"slug":"acme"}`}
+	NormalizeStructuredToolResponse(resp, true)
+	if resp.Content != `{"slug":"acme"}` {
+		t.Errorf("content mutated: %q", resp.Content)
+	}
+}

--- a/libs/go-common/llm/structured_output_test.go
+++ b/libs/go-common/llm/structured_output_test.go
@@ -63,6 +63,22 @@ func TestApplyResponseFormatAsTool_InjectsForcedTool(t *testing.T) {
 	}
 }
 
+// A ResponseFormat.Name that collides with a reserved tool-choice token
+// must not be used as the forced tool name (it would serialise as a mode
+// like {type:"none"} and disable forced tool use).
+func TestApplyResponseFormatAsTool_ReservedNameFallsBack(t *testing.T) {
+	for _, reserved := range []string{"none", "auto", "any", "required", "NONE"} {
+		req := ChatRequest{ResponseFormat: &ResponseFormat{Name: reserved, Schema: sampleSchema()}}
+		got, injected := ApplyResponseFormatAsTool(req)
+		if !injected {
+			t.Fatalf("%s: injected=false", reserved)
+		}
+		if got.ToolChoice != defaultStructuredToolName || got.Tools[0].Name != defaultStructuredToolName {
+			t.Errorf("reserved name %q: tool/tool_choice = %q/%q, want default %q", reserved, got.Tools[0].Name, got.ToolChoice, defaultStructuredToolName)
+		}
+	}
+}
+
 func TestApplyResponseFormatAsTool_DefaultName(t *testing.T) {
 	req := ChatRequest{ResponseFormat: &ResponseFormat{Schema: sampleSchema()}}
 	got, _ := ApplyResponseFormatAsTool(req)

--- a/libs/go-common/llm/structured_output_test.go
+++ b/libs/go-common/llm/structured_output_test.go
@@ -116,7 +116,9 @@ func TestNormalizeStructuredToolResponse_FoldsToolInputToContent(t *testing.T) {
 			Input: map[string]interface{}{"slug": "acme"},
 		}},
 	}
-	NormalizeStructuredToolResponse(resp, true)
+	if err := NormalizeStructuredToolResponse(resp, true); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
 	if resp.Content == "" {
 		t.Fatal("content not populated from tool input")
 	}
@@ -145,7 +147,9 @@ func TestNormalizeStructuredToolResponse_EmptyObjectFolded(t *testing.T) {
 		StopReason: "tool_use",
 		ToolCalls:  []ToolCall{{ID: "t1", Name: "domain_pack", Input: map[string]interface{}{}}},
 	}
-	NormalizeStructuredToolResponse(resp, true)
+	if err := NormalizeStructuredToolResponse(resp, true); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
 	if resp.Content != "{}" {
 		t.Errorf("Content = %q, want %q", resp.Content, "{}")
 	}
@@ -158,7 +162,9 @@ func TestNormalizeStructuredToolResponse_EmptyObjectFolded(t *testing.T) {
 // "null".
 func TestNormalizeStructuredToolResponse_NilInputBecomesEmptyObject(t *testing.T) {
 	resp := &ChatResponse{ToolCalls: []ToolCall{{ID: "t1", Name: "domain_pack"}}}
-	NormalizeStructuredToolResponse(resp, true)
+	if err := NormalizeStructuredToolResponse(resp, true); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
 	if resp.Content != "{}" {
 		t.Errorf("Content = %q, want %q", resp.Content, "{}")
 	}
@@ -166,9 +172,27 @@ func TestNormalizeStructuredToolResponse_NilInputBecomesEmptyObject(t *testing.T
 
 func TestNormalizeStructuredToolResponse_NotInjectedIsNoop(t *testing.T) {
 	resp := &ChatResponse{Content: "hello", ToolCalls: []ToolCall{{Name: "x", Input: map[string]interface{}{"a": 1}}}}
-	NormalizeStructuredToolResponse(resp, false)
+	if err := NormalizeStructuredToolResponse(resp, false); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
 	if resp.Content != "hello" || resp.ToolCalls == nil {
 		t.Error("no-op expected when injected=false")
+	}
+}
+
+// More than one tool call for the forced schema tool (possible under
+// Anthropic parallel tool use) must error rather than silently folding the
+// first and dropping the rest.
+func TestNormalizeStructuredToolResponse_MultipleToolCallsError(t *testing.T) {
+	resp := &ChatResponse{
+		StopReason: "tool_use",
+		ToolCalls: []ToolCall{
+			{ID: "t1", Name: "domain_pack", Input: map[string]interface{}{"a": 1}},
+			{ID: "t2", Name: "domain_pack", Input: map[string]interface{}{"b": 2}},
+		},
+	}
+	if err := NormalizeStructuredToolResponse(resp, true); err == nil {
+		t.Fatal("want error for multiple tool calls, got nil")
 	}
 }
 
@@ -176,7 +200,9 @@ func TestNormalizeStructuredToolResponse_NotInjectedIsNoop(t *testing.T) {
 // the caller's own parser must still see it — Content is left untouched.
 func TestNormalizeStructuredToolResponse_TextResponseLeftIntact(t *testing.T) {
 	resp := &ChatResponse{Content: `{"slug":"acme"}`}
-	NormalizeStructuredToolResponse(resp, true)
+	if err := NormalizeStructuredToolResponse(resp, true); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
 	if resp.Content != `{"slug":"acme"}` {
 		t.Errorf("content mutated: %q", resp.Content)
 	}

--- a/libs/go-common/llm/structured_output_test.go
+++ b/libs/go-common/llm/structured_output_test.go
@@ -79,6 +79,19 @@ func TestApplyResponseFormatAsTool_ReservedNameFallsBack(t *testing.T) {
 	}
 }
 
+// Injecting the forced structured tool must also request single-tool-use
+// so a parallel-tool-use provider (Anthropic) returns exactly one object.
+func TestApplyResponseFormatAsTool_DisablesParallelToolUse(t *testing.T) {
+	req := ChatRequest{ResponseFormat: &ResponseFormat{Name: "domain_pack", Schema: sampleSchema()}}
+	got, injected := ApplyResponseFormatAsTool(req)
+	if !injected {
+		t.Fatal("injected=false")
+	}
+	if !got.DisableParallelToolUse {
+		t.Error("DisableParallelToolUse should be set when forcing the structured tool")
+	}
+}
+
 func TestApplyResponseFormatAsTool_DefaultName(t *testing.T) {
 	req := ChatRequest{ResponseFormat: &ResponseFormat{Schema: sampleSchema()}}
 	got, _ := ApplyResponseFormatAsTool(req)

--- a/libs/go-common/llm/structured_output_test.go
+++ b/libs/go-common/llm/structured_output_test.go
@@ -114,6 +114,11 @@ func TestNormalizeStructuredToolResponse_FoldsToolInputToContent(t *testing.T) {
 	if resp.ToolCalls != nil {
 		t.Error("ToolCalls should be cleared after folding")
 	}
+	// The tool_use stop reason must be normalised — a hidden tool call must
+	// not leave callers thinking there is a tool to execute.
+	if resp.StopReason == "tool_use" {
+		t.Errorf("StopReason should be normalised away from tool_use, got %q", resp.StopReason)
+	}
 }
 
 // An empty object {} is a valid structured response (schema with only

--- a/providers/llm/azure-foundry/openai.go
+++ b/providers/llm/azure-foundry/openai.go
@@ -20,6 +20,10 @@ import (
 //
 //	https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
 func (p *AzureFoundryProvider) openaiChat(ctx context.Context, req gollm.ChatRequest) (*gollm.ChatResponse, error) {
+	// Azure Foundry does not advertise SupportsStructuredOutput, so honour
+	// the ResponseFormat contract ("unsupported providers ignore it")
+	// rather than forwarding response_format to a backend that may reject it.
+	req.ResponseFormat = nil
 	body := openaicompat.BuildRequestBody(req.Model, req)
 
 	jsonBody, err := json.Marshal(body)

--- a/providers/llm/bedrock/anthropic.go
+++ b/providers/llm/bedrock/anthropic.go
@@ -56,6 +56,11 @@ func (p *BedrockProvider) chatAnthropic(ctx context.Context, req gollm.ChatReque
 		body["tools"] = buildAnthropicTools(req.Tools)
 	}
 	if tc := buildAnthropicToolChoice(req.ToolChoice); tc != nil {
+		if req.DisableParallelToolUse {
+			if t, _ := tc["type"].(string); t == "tool" || t == "any" {
+				tc["disable_parallel_tool_use"] = true
+			}
+		}
 		body["tool_choice"] = tc
 	}
 

--- a/providers/llm/bedrock/anthropic.go
+++ b/providers/llm/bedrock/anthropic.go
@@ -55,20 +55,14 @@ func (p *BedrockProvider) chatAnthropic(ctx context.Context, req gollm.ChatReque
 	if len(req.Tools) > 0 {
 		body["tools"] = buildAnthropicTools(req.Tools)
 	}
-	tc := buildAnthropicToolChoice(req.ToolChoice)
-	// disable_parallel_tool_use is only honoured inside a tool_choice object
-	// (including {type:"auto"}). Synthesize the auto choice when the caller
-	// asked for single-tool-use but left tool_choice at the default, so the
-	// flag is applied. Only meaningful with tools; no-op without the flag.
-	if req.DisableParallelToolUse && len(req.Tools) > 0 {
-		if tc == nil {
-			tc = map[string]interface{}{"type": "auto"}
+	if tc := buildAnthropicToolChoice(req.ToolChoice); tc != nil {
+		// Forcing the synthetic structured-output tool asks for a single
+		// object, so disable parallel tool use on it.
+		if req.DisableParallelToolUse {
+			if t, _ := tc["type"].(string); t == "tool" || t == "any" {
+				tc["disable_parallel_tool_use"] = true
+			}
 		}
-		if t, _ := tc["type"].(string); t == "tool" || t == "any" || t == "auto" {
-			tc["disable_parallel_tool_use"] = true
-		}
-	}
-	if tc != nil {
 		body["tool_choice"] = tc
 	}
 

--- a/providers/llm/bedrock/anthropic.go
+++ b/providers/llm/bedrock/anthropic.go
@@ -23,6 +23,11 @@ import (
 // format — they talk the same Anthropic Messages API, just at different
 // endpoints.
 func (p *BedrockProvider) chatAnthropic(ctx context.Context, req gollm.ChatRequest) (*gollm.ChatResponse, error) {
+	// Structured output: the Anthropic wire has no response_format field,
+	// so a ResponseFormat becomes a single forced tool. No-op when unset
+	// or the caller supplied its own tools.
+	req, structured := gollm.ApplyResponseFormatAsTool(req)
+
 	messages, err := buildAnthropicMessages(req.Messages)
 	if err != nil {
 		return nil, fmt.Errorf("bedrock/anthropic: %w", err)
@@ -110,7 +115,7 @@ func (p *BedrockProvider) chatAnthropic(ctx context.Context, req gollm.ChatReque
 		}
 	}
 
-	return &gollm.ChatResponse{
+	resp := &gollm.ChatResponse{
 		Content:    content,
 		Model:      anthropicResp.Model,
 		StopReason: anthropicResp.StopReason,
@@ -119,7 +124,9 @@ func (p *BedrockProvider) chatAnthropic(ctx context.Context, req gollm.ChatReque
 			OutputTokens: anthropicResp.Usage.OutputTokens,
 		},
 		ToolCalls: toolCalls,
-	}, nil
+	}
+	gollm.NormalizeStructuredToolResponse(resp, structured)
+	return resp, nil
 }
 
 // buildAnthropicMessages translates the neutral Message shape into

--- a/providers/llm/bedrock/anthropic.go
+++ b/providers/llm/bedrock/anthropic.go
@@ -125,7 +125,9 @@ func (p *BedrockProvider) chatAnthropic(ctx context.Context, req gollm.ChatReque
 		},
 		ToolCalls: toolCalls,
 	}
-	gollm.NormalizeStructuredToolResponse(resp, structured)
+	if err := gollm.NormalizeStructuredToolResponse(resp, structured); err != nil {
+		return nil, fmt.Errorf("bedrock/anthropic: %w", err)
+	}
 	return resp, nil
 }
 

--- a/providers/llm/bedrock/anthropic.go
+++ b/providers/llm/bedrock/anthropic.go
@@ -55,12 +55,20 @@ func (p *BedrockProvider) chatAnthropic(ctx context.Context, req gollm.ChatReque
 	if len(req.Tools) > 0 {
 		body["tools"] = buildAnthropicTools(req.Tools)
 	}
-	if tc := buildAnthropicToolChoice(req.ToolChoice); tc != nil {
-		if req.DisableParallelToolUse {
-			if t, _ := tc["type"].(string); t == "tool" || t == "any" {
-				tc["disable_parallel_tool_use"] = true
-			}
+	tc := buildAnthropicToolChoice(req.ToolChoice)
+	// disable_parallel_tool_use is only honoured inside a tool_choice object
+	// (including {type:"auto"}). Synthesize the auto choice when the caller
+	// asked for single-tool-use but left tool_choice at the default, so the
+	// flag is applied. Only meaningful with tools; no-op without the flag.
+	if req.DisableParallelToolUse && len(req.Tools) > 0 {
+		if tc == nil {
+			tc = map[string]interface{}{"type": "auto"}
 		}
+		if t, _ := tc["type"].(string); t == "tool" || t == "any" || t == "auto" {
+			tc["disable_parallel_tool_use"] = true
+		}
+	}
+	if tc != nil {
 		body["tool_choice"] = tc
 	}
 

--- a/providers/llm/bedrock/provider.go
+++ b/providers/llm/bedrock/provider.go
@@ -105,6 +105,11 @@ func init() {
 		// function calling reliably varies, but the catalog flag is
 		// per-provider not per-model.
 		SupportsTools: true,
+		// Both Bedrock wires honour ChatRequest.ResponseFormat: the
+		// OpenAI-compat path via response_format json_schema, the
+		// Anthropic path via a forced tool. Both accept open-ended
+		// schemas, so the full requested shape is representable.
+		SupportsStructuredOutput: true,
 	})
 }
 
@@ -229,4 +234,3 @@ func (p *BedrockProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*gol
 	}
 	return p.dispatch(ctx, req)
 }
-

--- a/providers/llm/bedrock/provider_test.go
+++ b/providers/llm/bedrock/provider_test.go
@@ -444,3 +444,10 @@ func TestFactory_StashesAwsCfg_AccessKeys(t *testing.T) {
 		t.Errorf("Region = %q, want us-east-1", bp.awsCfg.Region)
 	}
 }
+
+func TestBedrockProvider_SupportsStructuredOutput(t *testing.T) {
+	meta, _ := gollm.GetProviderMeta("bedrock")
+	if !meta.SupportsStructuredOutput {
+		t.Error("bedrock should advertise SupportsStructuredOutput (both wires)")
+	}
+}

--- a/providers/llm/claude/provider.go
+++ b/providers/llm/claude/provider.go
@@ -191,6 +191,11 @@ func (p *ClaudeProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*goll
 		apiReq.Tools = convertToolsForClaude(req.Tools)
 	}
 	if tc := convertToolChoiceForClaude(req.ToolChoice); tc != nil {
+		if req.DisableParallelToolUse {
+			if t, _ := tc["type"].(string); t == "tool" || t == "any" {
+				tc["disable_parallel_tool_use"] = true
+			}
+		}
 		apiReq.ToolChoice = tc
 	}
 

--- a/providers/llm/claude/provider.go
+++ b/providers/llm/claude/provider.go
@@ -198,7 +198,9 @@ func (p *ClaudeProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*goll
 	for attempt := 1; attempt <= p.maxRetries; attempt++ {
 		resp, err := p.sendRequest(ctx, &apiReq)
 		if err == nil {
-			gollm.NormalizeStructuredToolResponse(resp, structured)
+			if nerr := gollm.NormalizeStructuredToolResponse(resp, structured); nerr != nil {
+				return nil, fmt.Errorf("claude: %w", nerr)
+			}
 			return resp, nil
 		}
 		lastErr = err

--- a/providers/llm/claude/provider.go
+++ b/providers/llm/claude/provider.go
@@ -77,6 +77,11 @@ func init() {
 		// Claude supports tool_use natively. Enables function-calling on
 		// /ask and any other tool-dependent flow.
 		SupportsTools: true,
+		// Chat honours ChatRequest.ResponseFormat by forcing a single
+		// tool whose input schema is the requested schema (the Anthropic
+		// wire has no response_format field). Tool input schemas accept
+		// open-ended objects, so the full shape is representable.
+		SupportsStructuredOutput: true,
 	})
 }
 
@@ -165,6 +170,12 @@ func (p *ClaudeProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*goll
 		maxTokens = 4096
 	}
 
+	// Structured output: the Anthropic Messages API has no response_format
+	// field, so a ResponseFormat is satisfied by forcing a single tool
+	// whose input schema is the requested schema. This is a no-op when no
+	// ResponseFormat was set or the caller supplied its own tools.
+	req, structured := gollm.ApplyResponseFormatAsTool(req)
+
 	claudeMessages, err := convertMessagesForClaude(req.Messages)
 	if err != nil {
 		return nil, fmt.Errorf("claude: %w", err)
@@ -187,6 +198,7 @@ func (p *ClaudeProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*goll
 	for attempt := 1; attempt <= p.maxRetries; attempt++ {
 		resp, err := p.sendRequest(ctx, &apiReq)
 		if err == nil {
+			gollm.NormalizeStructuredToolResponse(resp, structured)
 			return resp, nil
 		}
 		lastErr = err
@@ -324,10 +336,10 @@ func convertMessagesForClaude(msgs []gollm.Message) ([]claudeMessage, error) {
 					input = map[string]interface{}{}
 				}
 				blocks = append(blocks, claudeContentBlock{
-					Type:       "tool_use",
-					ID:         call.ID,
-					Name:       call.Name,
-					Input:      input,
+					Type:  "tool_use",
+					ID:    call.ID,
+					Name:  call.Name,
+					Input: input,
 				})
 			}
 			out = append(out, claudeMessage{Role: m.Role, Content: blocks})

--- a/providers/llm/claude/provider.go
+++ b/providers/llm/claude/provider.go
@@ -190,21 +190,15 @@ func (p *ClaudeProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*goll
 	if len(req.Tools) > 0 {
 		apiReq.Tools = convertToolsForClaude(req.Tools)
 	}
-	tc := convertToolChoiceForClaude(req.ToolChoice)
-	// disable_parallel_tool_use is only honoured by Anthropic inside a
-	// tool_choice object, including {type:"auto"}. When the caller asks for
-	// single-tool-use but left tool_choice at the default, synthesize the
-	// auto choice so the flag is applied (only meaningful when tools are
-	// present). Existing callers that don't set the flag are unchanged.
-	if req.DisableParallelToolUse && len(req.Tools) > 0 {
-		if tc == nil {
-			tc = map[string]interface{}{"type": "auto"}
+	if tc := convertToolChoiceForClaude(req.ToolChoice); tc != nil {
+		// Forcing the synthetic structured-output tool asks for a single
+		// object, so disable parallel tool use on it (Anthropic honours the
+		// flag inside the tool_choice object).
+		if req.DisableParallelToolUse {
+			if t, _ := tc["type"].(string); t == "tool" || t == "any" {
+				tc["disable_parallel_tool_use"] = true
+			}
 		}
-		if t, _ := tc["type"].(string); t == "tool" || t == "any" || t == "auto" {
-			tc["disable_parallel_tool_use"] = true
-		}
-	}
-	if tc != nil {
 		apiReq.ToolChoice = tc
 	}
 

--- a/providers/llm/claude/provider.go
+++ b/providers/llm/claude/provider.go
@@ -190,12 +190,21 @@ func (p *ClaudeProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*goll
 	if len(req.Tools) > 0 {
 		apiReq.Tools = convertToolsForClaude(req.Tools)
 	}
-	if tc := convertToolChoiceForClaude(req.ToolChoice); tc != nil {
-		if req.DisableParallelToolUse {
-			if t, _ := tc["type"].(string); t == "tool" || t == "any" {
-				tc["disable_parallel_tool_use"] = true
-			}
+	tc := convertToolChoiceForClaude(req.ToolChoice)
+	// disable_parallel_tool_use is only honoured by Anthropic inside a
+	// tool_choice object, including {type:"auto"}. When the caller asks for
+	// single-tool-use but left tool_choice at the default, synthesize the
+	// auto choice so the flag is applied (only meaningful when tools are
+	// present). Existing callers that don't set the flag are unchanged.
+	if req.DisableParallelToolUse && len(req.Tools) > 0 {
+		if tc == nil {
+			tc = map[string]interface{}{"type": "auto"}
 		}
+		if t, _ := tc["type"].(string); t == "tool" || t == "any" || t == "auto" {
+			tc["disable_parallel_tool_use"] = true
+		}
+	}
+	if tc != nil {
 		apiReq.ToolChoice = tc
 	}
 

--- a/providers/llm/claude/provider_test.go
+++ b/providers/llm/claude/provider_test.go
@@ -430,3 +430,10 @@ func stringContains(s, substr string) bool {
 	}
 	return false
 }
+
+func TestClaudeProvider_SupportsStructuredOutput(t *testing.T) {
+	meta, _ := gollm.GetProviderMeta("claude")
+	if !meta.SupportsStructuredOutput {
+		t.Error("claude should advertise SupportsStructuredOutput (forced tool-use)")
+	}
+}

--- a/providers/llm/claude/tooluse_test.go
+++ b/providers/llm/claude/tooluse_test.go
@@ -291,3 +291,29 @@ func TestChat_StructuredOutput_ForcesToolAndFolds(t *testing.T) {
 		t.Errorf("want 1 forced tool on the wire, got %d", len(tools))
 	}
 }
+
+// TestChat_DisableParallelToolUse_AutoChoice verifies the exported flag is
+// honoured even when the caller leaves tool_choice at the default: a
+// {type:"auto"} choice is synthesized carrying disable_parallel_tool_use.
+func TestChat_DisableParallelToolUse_AutoChoice(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = w.Write([]byte(`{"model":"claude-sonnet-4-6","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestClaudeWithServer(t, srv.URL)
+	_, err := p.Chat(context.Background(), gollm.ChatRequest{
+		Messages:               []gollm.Message{{Role: "user", Content: "go"}},
+		Tools:                  []gollm.ToolDefinition{{Name: "search", InputSchema: map[string]interface{}{"type": "object"}}},
+		DisableParallelToolUse: true,
+	})
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	tc, _ := body["tool_choice"].(map[string]interface{})
+	if tc == nil || tc["type"] != "auto" || tc["disable_parallel_tool_use"] != true {
+		t.Errorf("tool_choice = %v, want {type:auto, disable_parallel_tool_use:true}", body["tool_choice"])
+	}
+}

--- a/providers/llm/claude/tooluse_test.go
+++ b/providers/llm/claude/tooluse_test.go
@@ -291,29 +291,3 @@ func TestChat_StructuredOutput_ForcesToolAndFolds(t *testing.T) {
 		t.Errorf("want 1 forced tool on the wire, got %d", len(tools))
 	}
 }
-
-// TestChat_DisableParallelToolUse_AutoChoice verifies the exported flag is
-// honoured even when the caller leaves tool_choice at the default: a
-// {type:"auto"} choice is synthesized carrying disable_parallel_tool_use.
-func TestChat_DisableParallelToolUse_AutoChoice(t *testing.T) {
-	var body map[string]interface{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		_, _ = w.Write([]byte(`{"model":"claude-sonnet-4-6","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
-	}))
-	defer srv.Close()
-
-	p := newTestClaudeWithServer(t, srv.URL)
-	_, err := p.Chat(context.Background(), gollm.ChatRequest{
-		Messages:               []gollm.Message{{Role: "user", Content: "go"}},
-		Tools:                  []gollm.ToolDefinition{{Name: "search", InputSchema: map[string]interface{}{"type": "object"}}},
-		DisableParallelToolUse: true,
-	})
-	if err != nil {
-		t.Fatalf("chat: %v", err)
-	}
-	tc, _ := body["tool_choice"].(map[string]interface{})
-	if tc == nil || tc["type"] != "auto" || tc["disable_parallel_tool_use"] != true {
-		t.Errorf("tool_choice = %v, want {type:auto, disable_parallel_tool_use:true}", body["tool_choice"])
-	}
-}

--- a/providers/llm/claude/tooluse_test.go
+++ b/providers/llm/claude/tooluse_test.go
@@ -249,3 +249,45 @@ func TestChat_WithoutTools_UnchangedBehavior(t *testing.T) {
 		t.Error("tools should be omitted when empty")
 	}
 }
+
+// TestChat_StructuredOutput_ForcesToolAndFolds is an end-to-end wire test:
+// a ChatRequest.ResponseFormat must go out as a forced tool with
+// disable_parallel_tool_use set, and the tool_use reply must be folded back
+// into Content so the caller sees a bare JSON object.
+func TestChat_StructuredOutput_ForcesToolAndFolds(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"claude-sonnet-4-6","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1","name":"domain_pack","input":{"slug":"acme"}}],"usage":{"input_tokens":5,"output_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestClaudeWithServer(t, srv.URL)
+	resp, err := p.Chat(context.Background(), gollm.ChatRequest{
+		Messages:       []gollm.Message{{Role: "user", Content: "go"}},
+		ResponseFormat: &gollm.ResponseFormat{Name: "domain_pack", Schema: map[string]interface{}{"type": "object"}},
+	})
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	// The reply folded into Content, tool call hidden.
+	if resp.Content != `{"slug":"acme"}` {
+		t.Errorf("Content = %q, want the folded object", resp.Content)
+	}
+	if len(resp.ToolCalls) != 0 {
+		t.Errorf("ToolCalls should be cleared, got %d", len(resp.ToolCalls))
+	}
+	// The request forced the synthetic tool with parallel use disabled.
+	tc, _ := body["tool_choice"].(map[string]interface{})
+	if tc == nil || tc["type"] != "tool" || tc["name"] != "domain_pack" {
+		t.Fatalf("tool_choice not a forced tool: %v", body["tool_choice"])
+	}
+	if tc["disable_parallel_tool_use"] != true {
+		t.Errorf("tool_choice missing disable_parallel_tool_use: %v", tc)
+	}
+	tools, _ := body["tools"].([]interface{})
+	if len(tools) != 1 {
+		t.Errorf("want 1 forced tool on the wire, got %d", len(tools))
+	}
+}

--- a/providers/llm/litellm/provider.go
+++ b/providers/llm/litellm/provider.go
@@ -96,6 +96,12 @@ func init() {
 		// function calling; whether a given proxied model implements it
 		// reliably varies, as with the bare openai provider.
 		SupportsTools: true,
+		// LiteLLM honours ChatRequest.ResponseFormat via the OpenAI
+		// response_format json_schema field; the proxy forwards it to the
+		// backend's native structured-output mode (e.g. Ollama's grammar
+		// `format`), which is how a self-hosted qwen quant gets a
+		// guaranteed single object.
+		SupportsStructuredOutput: true,
 	})
 }
 

--- a/providers/llm/litellm/provider_test.go
+++ b/providers/llm/litellm/provider_test.go
@@ -206,3 +206,10 @@ func TestChat_APIErrorSanitised(t *testing.T) {
 		t.Errorf("error leaked a secret-looking token: %v", err)
 	}
 }
+
+func TestLiteLLMProvider_SupportsStructuredOutput(t *testing.T) {
+	meta, _ := gollm.GetProviderMeta("litellm")
+	if !meta.SupportsStructuredOutput {
+		t.Error("litellm should advertise SupportsStructuredOutput (response_format forwarded to backend)")
+	}
+}

--- a/providers/llm/ollama/provider.go
+++ b/providers/llm/ollama/provider.go
@@ -14,6 +14,7 @@ package ollama
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -116,6 +117,11 @@ func init() {
 		// because the catalog row's aliases include the tagged forms,
 		// so max-tokens enrichment still resolves.
 		PreferLiveModelID: true,
+		// Chat honours ChatRequest.ResponseFormat by driving llama.cpp
+		// grammar-constrained decoding from the schema (`format` field).
+		// The grammar supports open-ended objects, so the full requested
+		// shape is representable.
+		SupportsStructuredOutput: true,
 		// Clamp the input window budgeting call-sites see to the
 		// operator-configured num_ctx when it's lower than the
 		// catalog. Without this, /ask would assemble prompts up to
@@ -298,12 +304,28 @@ func (p *OllamaProvider) Chat(ctx context.Context, req gollm.ChatRequest) (*goll
 	// at either end produces malformed output without any signal to
 	// the caller.
 	truncate := false
+
+	// Structured output: Ollama accepts a JSON Schema in the `format`
+	// field and drives llama.cpp's grammar-constrained decoding from it,
+	// so the model can only emit a value matching the schema. The schema
+	// may contain open-ended objects (additionalProperties with dynamic
+	// keys); the grammar honours them, so nothing in the requested shape
+	// is dropped. A marshal failure falls back to an unconstrained call
+	// rather than erroring — the caller still has its own parsing net.
+	var format json.RawMessage
+	if rf := req.ResponseFormat; rf != nil && len(rf.Schema) > 0 {
+		if b, err := json.Marshal(rf.Schema); err == nil {
+			format = b
+		}
+	}
+
 	ollamaReq := &ollamaapi.ChatRequest{
 		Model:    model,
 		Messages: messages,
 		Stream:   &stream,
 		Options:  options,
 		Truncate: &truncate,
+		Format:   format,
 		Think:    reasoningEffortToThinkValue(req.ReasoningEffort, gollm.IsReasoningModel("ollama", model)),
 	}
 

--- a/providers/llm/ollama/provider_test.go
+++ b/providers/llm/ollama/provider_test.go
@@ -2,6 +2,9 @@ package ollama
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -213,5 +216,87 @@ func TestNewOllamaProvider_InvalidURL(t *testing.T) {
 	_, err := NewOllamaProvider("://invalid", "model", 0, 0)
 	if err == nil {
 		t.Error("should error on invalid URL")
+	}
+}
+
+func TestOllamaProvider_SupportsStructuredOutput(t *testing.T) {
+	meta, _ := gollm.GetProviderMeta("ollama")
+	if !meta.SupportsStructuredOutput {
+		t.Error("ollama should advertise SupportsStructuredOutput (grammar-constrained decoding via `format`)")
+	}
+}
+
+// TestOllamaProvider_Chat_SetsFormatFromResponseFormat drives a real
+// (hermetic) Ollama /api/chat round-trip against an httptest server and
+// asserts the request carries the ResponseFormat schema in the `format`
+// field — that is how llama.cpp grammar-constrained decoding is engaged.
+// The schema includes an open-ended (additionalProperties) object to
+// prove dynamic-key maps survive onto the wire.
+func TestOllamaProvider_Chat_SetsFormatFromResponseFormat(t *testing.T) {
+	var capturedFormat json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Format json.RawMessage `json:"format"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		capturedFormat = body.Format
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		// A single terminal NDJSON line is a complete non-streamed reply.
+		_, _ = w.Write([]byte(`{"model":"qwen3","done":true,"message":{"role":"assistant","content":"{}"}}` + "\n"))
+	}))
+	defer srv.Close()
+
+	p, err := NewOllamaProvider(srv.URL, "qwen3", 0, 0)
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	schema := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{"slug": map[string]interface{}{"type": "string"}},
+		"categories": map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": map[string]interface{}{"type": "string"},
+		},
+	}
+	_, err = p.Chat(context.Background(), gollm.ChatRequest{
+		Messages:       []gollm.Message{{Role: "user", Content: "go"}},
+		ResponseFormat: &gollm.ResponseFormat{Name: "domain_pack", Schema: schema},
+	})
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if len(capturedFormat) == 0 {
+		t.Fatal("format field not sent to Ollama")
+	}
+	var gotSchema map[string]interface{}
+	if err := json.Unmarshal(capturedFormat, &gotSchema); err != nil {
+		t.Fatalf("format is not a JSON schema object: %v", err)
+	}
+	cats, ok := gotSchema["categories"].(map[string]interface{})
+	if !ok || cats["additionalProperties"] == nil {
+		t.Errorf("open-ended 'categories' object dropped from format: %v", gotSchema)
+	}
+}
+
+// TestOllamaProvider_Chat_NoFormatWhenUnset locks the non-regression:
+// without a ResponseFormat, no `format` field is sent.
+func TestOllamaProvider_Chat_NoFormatWhenUnset(t *testing.T) {
+	sawFormat := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]json.RawMessage
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, sawFormat = body["format"]
+		_, _ = w.Write([]byte(`{"model":"qwen3","done":true,"message":{"role":"assistant","content":"hi"}}` + "\n"))
+	}))
+	defer srv.Close()
+
+	p, _ := NewOllamaProvider(srv.URL, "qwen3", 0, 0)
+	if _, err := p.Chat(context.Background(), gollm.ChatRequest{
+		Messages: []gollm.Message{{Role: "user", Content: "go"}},
+	}); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if sawFormat {
+		t.Error("format field must be omitted when no ResponseFormat is set")
 	}
 }

--- a/providers/llm/openai/provider.go
+++ b/providers/llm/openai/provider.go
@@ -91,6 +91,10 @@ func init() {
 		// function calling today — tool-dependent callers must pick a
 		// non-reasoning model or accept a no-tool fallback.
 		SupportsTools: true,
+		// Chat honours ChatRequest.ResponseFormat via OpenAI's
+		// response_format json_schema (non-strict, so open-ended objects
+		// in the schema stay expressible).
+		SupportsStructuredOutput: true,
 	})
 }
 

--- a/providers/llm/openai/provider_test.go
+++ b/providers/llm/openai/provider_test.go
@@ -390,3 +390,10 @@ func TestProviderFactory_DefaultModel(t *testing.T) {
 		t.Error("provider should not be nil")
 	}
 }
+
+func TestOpenAIProvider_SupportsStructuredOutput(t *testing.T) {
+	meta, _ := gollm.GetProviderMeta("openai")
+	if !meta.SupportsStructuredOutput {
+		t.Error("openai should advertise SupportsStructuredOutput (response_format json_schema)")
+	}
+}

--- a/providers/llm/vertex-ai/openaicompat.go
+++ b/providers/llm/vertex-ai/openaicompat.go
@@ -36,6 +36,10 @@ import (
 //
 // Both shapes authenticate with the same GCP bearer token as Gemini.
 func (p *VertexAIProvider) chatOpenAICompat(ctx context.Context, req gollm.ChatRequest) (*gollm.ChatResponse, error) {
+	// Vertex does not advertise SupportsStructuredOutput, so honour the
+	// ResponseFormat contract ("unsupported providers ignore it") rather
+	// than forwarding response_format to a MaaS backend that may reject it.
+	req.ResponseFormat = nil
 	body := openaicompat.BuildRequestBody(req.Model, req)
 
 	reqBody, err := json.Marshal(body)


### PR DESCRIPTION
## Summary

Adds an optional, wire-neutral **structured-output** capability to the LLM provider layer: a caller can attach a JSON Schema to a `ChatRequest` and get back a guaranteed-shape single JSON object, using each provider's native mechanism. This is the platform half of a coordinated change (the enterprise domain-pack generator is the first consumer; a self-hosted qwen quant behind LiteLLM→Ollama was wrapping its output in a JSON array, which schema-constrained decoding makes impossible).

## What changed

**Wire-neutral contract (`libs/go-common/llm`)**
- `ChatRequest.ResponseFormat *ResponseFormat` (`{Name, Schema, Strict}`) — advisory; providers that don't support it ignore it.
- `ProviderMeta.SupportsStructuredOutput bool` — per-provider capability, surfaced in `/api/v1/providers/llm`. `GetProviderMeta` lets callers gate on it.
- `ApplyResponseFormatAsTool` / `NormalizeStructuredToolResponse` — shared helpers for the Anthropic wire (which has no `response_format`): translate a `ResponseFormat` into a single **forced tool** and fold the tool result back into `Content` so callers parse uniformly.

**Per-provider translation**
- **OpenAI-compatible wire** (`openai`, `litellm`, and OpenAI models on `bedrock`): `response_format: {type: json_schema, …}` via the shared `openaicompat.BuildRequestBody`.
- **Ollama**: the `format` field (llama.cpp grammar-constrained decoding).
- **Anthropic wire** (`claude`, Claude models on `bedrock`): forced tool-use via the shared helper.

**Enabled** for `ollama`, `litellm`, `openai`, `claude`, `bedrock`. `azure-foundry` and `vertex-ai` keep the flag **off** for now — their Claude/Gemini wires don't implement the tool plumbing needed to honour it, and advertising a per-provider flag that only some of a provider's wires satisfy would over-promise. Callers fall back to their own parsing there.

## Non-regression (important)

- `ResponseFormat` is **orthogonal to `Tools`**: the synthetic tool is injected only when the caller supplied **no** tools of its own, so existing tool-using flows (e.g. `/ask` function calling) are byte-for-byte unchanged.
- A request **without** `ResponseFormat` produces an identical wire body to before (tests assert `response_format` and Ollama `format` are omitted when unset).
- **Open-ended (dynamic-key) objects are preserved**: the OpenAI wire uses **non-strict** `json_schema` (strict mode forbids `additionalProperties` maps), and the Ollama grammar + Anthropic tool schema accept them natively. Tests assert an `additionalProperties` object survives onto the wire on all three paths.

## Tests

- `structured_output_test.go` — the forced-tool helper (inject / no-op / caller-tools-win / normalize / text-left-intact).
- `openaicompat/format_test.go` — `response_format` json_schema wiring + omitted-when-unset + open-map preservation.
- `ollama/provider_test.go` — hermetic httptest round-trip asserting `format` is set (and omitted when unset).
- `registry_test.go` — `supports_structured_output` serialises.
- Per-provider `SupportsStructuredOutput` flag assertions.
- `go build` + `go test` + `golangci-lint` green across every touched module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Co-coded with Jale 🤖