### PR TITLE
feat(ui): collapse discovery run errors to a warning icon (expand on click)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Discovery run errors collapse to a warning icon.** A failed or partial run's raw error (for example a long `bedrock/openai-compat … ValidationException` context-length dump) is no longer rendered in full by default. A compact warning indicator now sits next to the run status on both the project home and the discovery run detail page; clicking it expands the full error(s) in a scrollable, word-wrapped popover, and collapsing hides the detail again while the indicator itself persists across refresh.
 - **Unknown-model token defaults raised.** A model that matches no catalog entry (and no per-provider override) now resolves to **128K input** (was 32K) and **64K output** (`64000`, was 8K), across every LLM provider. Catalogued models still resolve to their exact caps. The five API providers' unknown-model output default (`claude`, `openai`, `bedrock`, `azure-foundry`, `vertex-ai`) rose from 16K to 64K. `64000` (not `65536`) is used because that is the hard `max_tokens` cap on current Bedrock Claude models — a proxied unknown model (LiteLLM → Bedrock) rejects `65536` with a 400.
 
 ### Fixed

--- a/ui/dashboard/src/__tests__/RunErrorIndicator.test.tsx
+++ b/ui/dashboard/src/__tests__/RunErrorIndicator.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { RunErrorIndicator, normalizeRunErrors } from '@/components/common/RunErrorIndicator';
+
+function mount(props: React.ComponentProps<typeof RunErrorIndicator>) {
+  return render(
+    <MantineProvider>
+      <RunErrorIndicator {...props} />
+    </MantineProvider>
+  );
+}
+
+const LONG_ERROR =
+  'bedrock/openai-compat: ValidationException: input length 200000 exceeds context length 128000 ' +
+  'for model glm-5; reduce the number of tokens and retry the request';
+
+describe('normalizeRunErrors', () => {
+  it('returns [] for falsy / blank input', () => {
+    expect(normalizeRunErrors(undefined)).toEqual([]);
+    expect(normalizeRunErrors(null)).toEqual([]);
+    expect(normalizeRunErrors('')).toEqual([]);
+    expect(normalizeRunErrors('   ')).toEqual([]);
+    expect(normalizeRunErrors([])).toEqual([]);
+    expect(normalizeRunErrors(['', '  ', null as unknown as string])).toEqual([]);
+  });
+
+  it('wraps a single string and trims it', () => {
+    expect(normalizeRunErrors('  boom  ')).toEqual(['boom']);
+  });
+
+  it('keeps only non-blank entries from a list, trimmed', () => {
+    expect(normalizeRunErrors(['a', '', '  b  ', '   '])).toEqual(['a', 'b']);
+  });
+});
+
+describe('RunErrorIndicator', () => {
+  it('renders no indicator when there are no errors', () => {
+    mount({ errors: undefined });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders no indicator when the error list is all blanks', () => {
+    mount({ errors: ['', '   '] });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows a compact warning icon (not the raw error) by default', () => {
+    mount({ errors: LONG_ERROR, label: 'Discovery run error' });
+    // The trigger button is present, labelled for a11y...
+    expect(screen.getByRole('button', { name: 'Discovery run error' })).toBeInTheDocument();
+    // ...but the raw error wall is collapsed until the user expands it.
+    expect(screen.queryByText(LONG_ERROR)).not.toBeInTheDocument();
+  });
+
+  it('expands the full error text when the icon is clicked', async () => {
+    mount({ errors: LONG_ERROR, label: 'Discovery run error' });
+    fireEvent.click(screen.getByRole('button', { name: 'Discovery run error' }));
+    await waitFor(() => {
+      expect(screen.getByText(LONG_ERROR)).toBeInTheDocument();
+    });
+  });
+
+  it('derives a singular heading from a one-item error list', () => {
+    mount({ errors: ['area A failed'] });
+    expect(
+      screen.getByRole('button', { name: '1 area failed during analysis' })
+    ).toBeInTheDocument();
+  });
+
+  it('derives a plural heading from a multi-item error list and shows each error on expand', async () => {
+    mount({ errors: ['area A failed', 'area B failed'] });
+    const trigger = screen.getByRole('button', { name: '2 areas failed during analysis' });
+    fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(screen.getByText('area A failed')).toBeInTheDocument();
+      expect(screen.getByText('area B failed')).toBeInTheDocument();
+    });
+  });
+
+  it('toggles the detail closed again without removing the icon', async () => {
+    mount({ errors: LONG_ERROR, label: 'Discovery run error' });
+    const trigger = screen.getByRole('button', { name: 'Discovery run error' });
+    fireEvent.click(trigger);
+    await waitFor(() => expect(screen.getByText(LONG_ERROR)).toBeInTheDocument());
+    fireEvent.click(trigger);
+    // Detail collapses...
+    await waitFor(() => expect(screen.queryByText(LONG_ERROR)).not.toBeInTheDocument());
+    // ...but the indicator itself remains.
+    expect(screen.getByRole('button', { name: 'Discovery run error' })).toBeInTheDocument();
+  });
+});

--- a/ui/dashboard/src/app/projects/[id]/discoveries/[runId]/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/discoveries/[runId]/page.tsx
@@ -7,7 +7,7 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
-  IconAlertCircle, IconBulb, IconChevronDown, IconClipboardX, IconDatabase, IconSearch,
+  IconBulb, IconChevronDown, IconClipboardX, IconDatabase, IconSearch,
 } from '@tabler/icons-react';
 import Link from 'next/link';
 import Shell from '@/components/layout/AppShell';
@@ -15,6 +15,7 @@ import FeedbackButtons from '@/components/common/FeedbackButtons';
 import {
   StatCard, SectionHeader, Th, SeverityBadge, AreaBadge, ConfidenceBar, Pill, EmptyState, normalizeConfidence,
 } from '@/components/common/UIComponents';
+import { RunErrorIndicator } from '@/components/common/RunErrorIndicator';
 import { ValidationLogRow } from '@/components/validation/ValidationLogRow';
 import { InsightValidationBadge } from '@/components/validation/InsightValidationBadge';
 import UnreadDot from '@/components/common/UnreadDot';
@@ -152,6 +153,10 @@ export default function DiscoveryDetailPage() {
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
           <SeverityBadge severity={discovery.run_type === 'partial' ? 'Partial' : 'Complete'}
             type="status" />
+          {/* Analysis-area failures collapse to a compact warning icon next to
+              the run status. Clicking it expands the full error(s) in a
+              scrollable popover instead of dumping the raw text into the page. */}
+          <RunErrorIndicator errors={discovery.summary?.errors} />
           {discovery.areas_requested?.map(a => (
             <span key={a} style={{
               fontSize: 11, padding: '1px 7px', borderRadius: 'var(--db-radius)',
@@ -163,24 +168,6 @@ export default function DiscoveryDetailPage() {
           </span>
         </div>
       </div>
-
-      {/* Errors banner */}
-      {discovery.summary?.errors && discovery.summary.errors.length > 0 && (
-        <div style={{
-          background: 'var(--db-red-bg)', border: '1px solid var(--db-severity-critical-text)',
-          borderRadius: 'var(--db-radius-lg)', padding: '12px 16px', marginBottom: 16,
-        }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-            <IconAlertCircle size={16} color="var(--db-red-text)" />
-            <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--db-red-text)' }}>
-              {discovery.summary.errors.length === 1 ? '1 area failed' : `${discovery.summary.errors.length} areas failed`} during analysis
-            </span>
-          </div>
-          {discovery.summary.errors.map((err, i) => (
-            <div key={i} style={{ fontSize: 12, color: 'var(--db-red-text)', paddingLeft: 22 }}>{err}</div>
-          ))}
-        </div>
-      )}
 
       {/* Hero KPI Cards */}
       <div style={{

--- a/ui/dashboard/src/app/projects/[id]/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 import Link from 'next/link';
 import Shell from '@/components/layout/AppShell';
 import { SchemaIndexPanel } from '@/components/SchemaIndexPanel';
+import { RunErrorIndicator } from '@/components/common/RunErrorIndicator';
 import {
   api, CostEstimate, DebugLogEntry, DiscoveryResult, DiscoveryRunStatus, Project, RunStep, SchemaIndexStatus,
   PROJECT_STATE_READY,
@@ -647,6 +648,11 @@ function LiveRunPanel({ run, onCancel }: { run: DiscoveryRunStatus; onCancel: ()
             }}>
               {phaseLabel[run.phase] || run.phase}
             </span>
+            {/* Errored run: collapse the raw error to a compact warning icon
+                next to the status. Clicking it expands the full text; the icon
+                itself stays put and survives refresh (it is derived from
+                run.error, which the backend keeps on the run). */}
+            <RunErrorIndicator errors={run.error} label="Discovery run error" />
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span style={{ fontSize: 12, color: 'var(--db-text-tertiary)' }}>{run.progress}%</span>
@@ -692,10 +698,6 @@ function LiveRunPanel({ run, onCancel }: { run: DiscoveryRunStatus; onCancel: ()
             </span>
           )}
         </div>
-
-        {run.error && (
-          <div style={{ fontSize: 12, color: 'var(--db-red-text)', paddingBottom: 10 }}>{run.error}</div>
-        )}
       </div>
 
       {/* Step list */}

--- a/ui/dashboard/src/components/common/RunErrorIndicator.tsx
+++ b/ui/dashboard/src/components/common/RunErrorIndicator.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { Popover, ScrollArea } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+// Popover geometry — named constants (not inline magic numbers) so every
+// call site across the community and enterprise dashboards renders the error
+// popover identically.
+const POPOVER_WIDTH = 460;
+const POPOVER_MAX_HEIGHT = 320;
+
+export interface RunErrorIndicatorProps {
+  // A single run-level error (e.g. run.error) or a list of per-area errors
+  // (e.g. summary.errors). Falsy / blank entries are ignored.
+  errors?: string | string[] | null;
+  // Heading shown above the error text in the expanded popover. Defaults to
+  // an "N area(s) failed during analysis" summary derived from the count.
+  label?: string;
+  // Icon size in px — matches the surrounding status icons at each call site.
+  iconSize?: number;
+}
+
+// normalizeRunErrors flattens the string | string[] input into a trimmed,
+// de-blanked list. Exported for unit testing and reuse.
+export function normalizeRunErrors(errors?: string | string[] | null): string[] {
+  if (!errors) return [];
+  const list = Array.isArray(errors) ? errors : [errors];
+  return list.map((e) => (e ?? '').trim()).filter(Boolean);
+}
+
+// RunErrorIndicator collapses a discovery run's error(s) down to a compact
+// warning icon. Clicking the icon expands the full error text in a scrollable,
+// word-wrapped popover; closing it (click-away, Escape, or clicking the icon
+// again) hides the detail while the icon stays put. The icon is derived purely
+// from the passed-in error data, so it survives a page refresh as long as the
+// run still carries an error — the indicator persists, only the wall of raw
+// text is hidden by default.
+export function RunErrorIndicator({ errors, label, iconSize = 16 }: RunErrorIndicatorProps) {
+  const [opened, setOpened] = useState(false);
+  const list = normalizeRunErrors(errors);
+  if (list.length === 0) return null;
+
+  const heading = label
+    ?? (list.length === 1 ? '1 area failed during analysis' : `${list.length} areas failed during analysis`);
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={setOpened}
+      position="bottom-start"
+      width={POPOVER_WIDTH}
+      shadow="md"
+      withArrow
+    >
+      <Popover.Target>
+        <button
+          type="button"
+          onClick={() => setOpened((o) => !o)}
+          aria-label={heading}
+          aria-expanded={opened}
+          title={heading}
+          style={{
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            padding: 2, border: 'none', background: 'transparent',
+            color: 'var(--db-red-text)', cursor: 'pointer', lineHeight: 0,
+            borderRadius: 'var(--db-radius)',
+          }}
+        >
+          <IconAlertTriangle size={iconSize} />
+        </button>
+      </Popover.Target>
+      <Popover.Dropdown p="xs">
+        <div style={{
+          fontSize: 13, fontWeight: 500, color: 'var(--db-red-text)',
+          marginBottom: 8, display: 'flex', alignItems: 'center', gap: 6,
+        }}>
+          <IconAlertTriangle size={14} />
+          <span>{heading}</span>
+        </div>
+        {/* Long raw errors (e.g. a GLM/Bedrock context-length dump) live inside
+            this scrollable, word-wrapped container rather than spilling into the
+            page body. */}
+        <ScrollArea.Autosize mah={POPOVER_MAX_HEIGHT} type="auto">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {list.map((err, i) => (
+              <div key={i} style={{
+                fontSize: 12, color: 'var(--db-red-text)',
+                background: 'var(--db-red-bg)', borderRadius: 'var(--db-radius)',
+                padding: '6px 8px',
+                whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                fontFamily: 'var(--db-font-mono, ui-monospace, SFMono-Regular, monospace)',
+              }}>
+                {err}
+              </div>
+            ))}
+          </div>
+        </ScrollArea.Autosize>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## What & why

When a discovery run errors — an analysis area fails, the LLM rejects the request, etc. — the dashboard rendered the **full raw error by default**: a red wall of text such as a long `bedrock/openai-compat … ValidationException … context length` dump, both on the project home (live run panel) and on the discovery run detail page. The error is worth keeping, but it shouldn't dominate the page by default.

## What changed

- **New shared component** `ui/dashboard/src/components/common/RunErrorIndicator.tsx`:
  - Renders a compact warning icon whenever `run.error` / `summary.errors` is present (and nothing at all when there's no error).
  - Clicking the icon opens a popover showing the full error(s) in a **scrollable, word-wrapped** container, so a giant context-length dump stays inside the popover instead of spilling into the page body.
  - Closing the popover (click-away, `Esc`, or clicking the icon again) collapses the detail; the icon itself stays put.
  - Accepts either a single `run.error` string or a `summary.errors` list; an exported `normalizeRunErrors` helper trims and de-blanks the input.
- **Project home** (`projects/[id]/page.tsx`): the live-run panel's raw `run.error` `<div>` is replaced by the indicator, next to the run status.
- **Run detail** (`.../discoveries/[runId]/page.tsx`): the always-expanded *"N area(s) failed during analysis"* red banner is replaced by the indicator, next to the run status badge.
- **Persistence preserved:** the indicator is derived purely from the run's error data, so it reappears after a refresh; the existing run-panel *Dismiss* behaviour is untouched.

## Testing

- **New** `RunErrorIndicator.test.tsx` (10 cases): no render on empty/blank input; icon shown but collapsed by default; click expands the full text; singular vs plural heading derivation; collapse keeps the icon; and `normalizeRunErrors` edge cases (string, list, blanks).
- Local checks: `npm run build` ✓, `npm test` ✓ (351 tests / 30 suites), `npm run lint` ✓ (0 errors).

Closes #346

— Co-coded with Jale 🤖