### PR TITLE
feat(warehouse,agent): query-language seam + capability descriptor

### DIFF
--- a/libs/go-common/warehouse/capability.go
+++ b/libs/go-common/warehouse/capability.go
@@ -1,6 +1,9 @@
 package warehouse
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // SourceShape describes how a source organises what can be queried. It is not
 // cosmetic bookkeeping: it decides what a correct query even looks like, and
@@ -104,10 +107,20 @@ func AsQueryRunner(p Provider) QueryRunner {
 type sqlRunner struct{ p Provider }
 
 // RunQuery forwards the query text to Provider.Query with nil params, exactly
-// as the executor did before the seam existed. A structured payload is a
-// programming error here rather than a runtime condition to recover from: a
-// caller that builds one has chosen a non-SQL query shape for a SQL provider.
+// as the executor did before the seam existed.
+//
+// A structured payload is refused rather than ignored. Running Text alone
+// would execute something other than what the caller asked for — Text is only
+// a readable rendering when a payload is present, and may be empty — and a SQL
+// provider cannot interpret the payload. Dropping it would produce a
+// well-formed result for the wrong question, which is the failure mode this
+// seam exists to prevent; a caller that reaches here with a payload has paired
+// a non-SQL query shape with a SQL provider.
 func (r sqlRunner) RunQuery(ctx context.Context, q NativeQuery) (*QueryResult, error) {
+	if q.IsStructured() {
+		return nil, fmt.Errorf("warehouse: %T cannot execute a structured query payload (%T); "+
+			"a structured query needs a provider that implements QueryRunner", r.p, q.Payload)
+	}
 	return r.p.Query(ctx, q.Text, nil)
 }
 

--- a/libs/go-common/warehouse/capability.go
+++ b/libs/go-common/warehouse/capability.go
@@ -1,0 +1,170 @@
+package warehouse
+
+import "context"
+
+// SourceShape describes how a source organises what can be queried. It is not
+// cosmetic bookkeeping: it decides what a correct query even looks like, and
+// downstream consumers (prompt construction, pack generation, exploration)
+// branch on it rather than guessing from the provider name.
+type SourceShape string
+
+const (
+	// ShapeEntities is the table/object model: named collections of rows with
+	// columns, selected from and joined. Every SQL warehouse is this shape, as
+	// is an object-based API such as a CRM.
+	ShapeEntities SourceShape = "entities"
+
+	// ShapeCube is the metric/dimension model: there are no tables and no rows
+	// to select from. A query is a choice of metrics, dimensions, a date range
+	// and optional filters, and the source computes the result. A web-analytics
+	// property is this shape.
+	//
+	// Modelling a cube as pseudo-tables would lie about capability — the agent
+	// would generate joins and filters the source cannot honour, and the
+	// failure would surface as a confusing query-time error rather than an
+	// honest "this source can't do that".
+	ShapeCube SourceShape = "cube"
+)
+
+// NativeQuery is a query expressed in a source's own language.
+//
+// SQL sources carry the statement in Text and leave Payload nil. A source
+// whose query is a structured request rather than a string — a report
+// specification, for instance — carries that request in Payload and may leave
+// Text empty, or set it to a human-readable rendering for logs and prompts.
+//
+// The two fields exist because the repair loop, the debug log and the stored
+// query history all want something printable, while the executing provider
+// wants the real payload. Collapsing them to a string would force structured
+// sources to serialise and re-parse their own requests.
+type NativeQuery struct {
+	// Text is the query as text: the SQL statement, or a readable rendering of
+	// a structured payload. Never empty for SQL sources.
+	Text string
+
+	// Payload is the provider-native structured request, or nil when Text is
+	// the whole query. A provider that sets this is responsible for type-
+	// asserting it back in RunQuery.
+	Payload any
+}
+
+// SQLQuery builds a NativeQuery for a plain SQL statement.
+func SQLQuery(sql string) NativeQuery { return NativeQuery{Text: sql} }
+
+// IsStructured reports whether the query carries a payload the executing
+// provider must interpret, rather than text it can run directly.
+func (q NativeQuery) IsStructured() bool { return q.Payload != nil }
+
+// String renders the query for logs, prompts and stored history. It never
+// returns the payload, so a provider that wants its structured request to be
+// legible must render it into Text.
+func (q NativeQuery) String() string { return q.Text }
+
+// QueryRunner is the narrow seam the query-execution loop actually depends on:
+// generate a query in the source's language, run it, and on failure ask for a
+// repair prompt in that same language. Everything else the SQL Provider
+// interface offers — dataset listing, schema introspection, identifier
+// quoting — is irrelevant to executing a query and is deliberately absent.
+//
+// SQL providers do not implement this directly; AsQueryRunner adapts them, so
+// the SQL path is unchanged. A non-SQL adapter implements QueryRunner itself
+// and needs none of the table-shaped surface.
+type QueryRunner interface {
+	// RunQuery executes a query in the source's native language.
+	RunQuery(ctx context.Context, q NativeQuery) (*QueryResult, error)
+
+	// QueryLanguage names the language queries are written in — "SQL" and its
+	// dialects, or a source's own request format. Used to tell the model what
+	// it is writing.
+	QueryLanguage() string
+
+	// QueryFixPrompt returns the repair-prompt template for this language, or
+	// "" when the source offers none. This is the generalisation of
+	// Provider.SQLFixPrompt; the same placeholder contract applies.
+	QueryFixPrompt() string
+}
+
+// AsQueryRunner returns p as a QueryRunner. A provider that implements the
+// interface itself is returned unchanged; any other provider is wrapped in an
+// adapter that maps RunQuery onto Query, QueryLanguage onto SQLDialect, and
+// QueryFixPrompt onto SQLFixPrompt.
+//
+// The adapter is what keeps this extraction behaviour-preserving: every
+// existing SQL provider — including the ones registered from the enterprise
+// plugin repo, which this package cannot see — keeps working with no change
+// and no compile break.
+func AsQueryRunner(p Provider) QueryRunner {
+	if r, ok := p.(QueryRunner); ok {
+		return r
+	}
+	return sqlRunner{p: p}
+}
+
+// sqlRunner adapts a SQL Provider to the QueryRunner seam.
+type sqlRunner struct{ p Provider }
+
+// RunQuery forwards the query text to Provider.Query with nil params, exactly
+// as the executor did before the seam existed. A structured payload is a
+// programming error here rather than a runtime condition to recover from: a
+// caller that builds one has chosen a non-SQL query shape for a SQL provider.
+func (r sqlRunner) RunQuery(ctx context.Context, q NativeQuery) (*QueryResult, error) {
+	return r.p.Query(ctx, q.Text, nil)
+}
+
+func (r sqlRunner) QueryLanguage() string  { return r.p.SQLDialect() }
+func (r sqlRunner) QueryFixPrompt() string { return r.p.SQLFixPrompt() }
+
+// Unwrap exposes the adapted Provider so callers that still need the
+// table-shaped surface (schema discovery, identifier quoting) can reach it
+// without keeping a second reference alongside the runner.
+func (r sqlRunner) Unwrap() Provider { return r.p }
+
+// Anchoring returns a pointer to v, for declaring ProviderMeta.CanAnchor.
+//
+// Only a provider that cannot anchor needs to say so:
+//
+//	CanAnchor: warehouse.Anchoring(false)
+func Anchoring(v bool) *bool { return &v }
+
+// Language returns the query language for this provider: the declared
+// QueryLanguage, falling back to the display Dialect, and finally to "SQL".
+//
+// The fallback is what lets every already-registered SQL provider — in this
+// repo and in the enterprise plugin repo — carry a correct language without
+// being edited.
+func (m ProviderMeta) Language() string {
+	if m.QueryLanguage != "" {
+		return m.QueryLanguage
+	}
+	if m.Dialect != "" {
+		return m.Dialect
+	}
+	return "SQL"
+}
+
+// EffectiveShape returns the declared source shape, defaulting to
+// ShapeEntities. The default is safe for an undeclared provider because every
+// source that existed before shape did is table-shaped; a cube source cannot
+// be introduced without declaring itself one, since nothing else about it
+// would work.
+func (m ProviderMeta) EffectiveShape() SourceShape {
+	if m.Shape != "" {
+		return m.Shape
+	}
+	return ShapeEntities
+}
+
+// Anchors reports whether a source of this type can carry a project by itself
+// — a system of record rather than a system of observation.
+//
+// Undeclared means true. That direction is deliberate: a warehouse or CRM is
+// the system of record by construction, so the sources that existed before
+// this flag are all anchoring, and a provider that forgets to declare keeps
+// working. The failure mode of the opposite default would be silent — an
+// existing datasource quietly becoming ineligible to be a project's only
+// source, refused with no error anyone would connect to a missing field.
+//
+// Only a source whose value is purely correlative declares CanAnchor false.
+func (m ProviderMeta) Anchors() bool {
+	return m.CanAnchor == nil || *m.CanAnchor
+}

--- a/libs/go-common/warehouse/capability.go
+++ b/libs/go-common/warehouse/capability.go
@@ -126,30 +126,46 @@ func (r sqlRunner) Unwrap() Provider { return r.p }
 //	CanAnchor: warehouse.Anchoring(false)
 func Anchoring(v bool) *bool { return &v }
 
-// Language returns the query language for this provider: the declared
-// QueryLanguage, falling back to the display Dialect, and finally to "SQL".
+// Capability is the source-capability descriptor: what language a source's
+// queries are written in, how it is shaped, and whether it can carry a project
+// by itself. It is declared once at provider registration and travels from
+// there to everything that has to reason about a source without opening a
+// connection to it — prompt construction, routing, pack generation.
 //
-// The fallback is what lets every already-registered SQL provider — in this
-// repo and in the enterprise plugin repo — carry a correct language without
-// being edited.
-func (m ProviderMeta) Language() string {
-	if m.QueryLanguage != "" {
-		return m.QueryLanguage
-	}
-	if m.Dialect != "" {
-		return m.Dialect
+// Every field is optional and defaults to what was true before the descriptor
+// existed, so a provider registered before this type — including the
+// enterprise-only drivers this repo cannot see — stays correct unedited.
+type Capability struct {
+	// QueryLanguage names the language queries against this source are written
+	// in. Empty resolves via Language().
+	QueryLanguage string `json:"query_language,omitempty"`
+
+	// Shape is how the source organises what can be queried. Empty resolves to
+	// ShapeEntities via EffectiveShape().
+	Shape SourceShape `json:"shape,omitempty"`
+
+	// CanAnchor declares whether a source of this type can carry a project by
+	// itself. Nil resolves to true via Anchors(); declare it only to say false,
+	// using Anchoring(false).
+	CanAnchor *bool `json:"can_anchor,omitempty"`
+}
+
+// Language returns the declared query language, defaulting to "SQL".
+func (c Capability) Language() string {
+	if c.QueryLanguage != "" {
+		return c.QueryLanguage
 	}
 	return "SQL"
 }
 
 // EffectiveShape returns the declared source shape, defaulting to
-// ShapeEntities. The default is safe for an undeclared provider because every
+// ShapeEntities. The default is safe for an undeclared source because every
 // source that existed before shape did is table-shaped; a cube source cannot
 // be introduced without declaring itself one, since nothing else about it
 // would work.
-func (m ProviderMeta) EffectiveShape() SourceShape {
-	if m.Shape != "" {
-		return m.Shape
+func (c Capability) EffectiveShape() SourceShape {
+	if c.Shape != "" {
+		return c.Shape
 	}
 	return ShapeEntities
 }
@@ -159,12 +175,27 @@ func (m ProviderMeta) EffectiveShape() SourceShape {
 //
 // Undeclared means true. That direction is deliberate: a warehouse or CRM is
 // the system of record by construction, so the sources that existed before
-// this flag are all anchoring, and a provider that forgets to declare keeps
+// this flag are all anchoring, and a source that forgets to declare keeps
 // working. The failure mode of the opposite default would be silent — an
 // existing datasource quietly becoming ineligible to be a project's only
 // source, refused with no error anyone would connect to a missing field.
 //
 // Only a source whose value is purely correlative declares CanAnchor false.
-func (m ProviderMeta) Anchors() bool {
-	return m.CanAnchor == nil || *m.CanAnchor
+func (c Capability) Anchors() bool {
+	return c.CanAnchor == nil || *c.CanAnchor
+}
+
+// Language returns the query language for this provider: the declared
+// QueryLanguage, falling back to the display Dialect, and finally to "SQL".
+//
+// The Dialect fallback is what lets every already-registered SQL provider
+// carry a correct language without being edited.
+func (m ProviderMeta) Language() string {
+	if m.QueryLanguage != "" {
+		return m.QueryLanguage
+	}
+	if m.Dialect != "" {
+		return m.Dialect
+	}
+	return "SQL"
 }

--- a/libs/go-common/warehouse/capability_test.go
+++ b/libs/go-common/warehouse/capability_test.go
@@ -1,0 +1,194 @@
+package warehouse
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// recordingProvider captures what AsQueryRunner's adapter forwards to the
+// underlying SQL Provider.
+type recordingProvider struct {
+	mockWarehouseProvider
+	gotQuery  string
+	gotParams map[string]interface{}
+	called    int
+	err       error
+}
+
+func (r *recordingProvider) Query(_ context.Context, q string, params map[string]interface{}) (*QueryResult, error) {
+	r.called++
+	r.gotQuery = q
+	r.gotParams = params
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &QueryResult{Columns: []string{"c"}}, nil
+}
+
+func (r *recordingProvider) SQLFixPrompt() string { return "fix {{ORIGINAL_SQL}}" }
+
+// nativeRunner is a provider that speaks the seam directly — the shape a
+// non-SQL adapter takes.
+type nativeRunner struct {
+	mockWarehouseProvider
+	got NativeQuery
+}
+
+func (n *nativeRunner) RunQuery(_ context.Context, q NativeQuery) (*QueryResult, error) {
+	n.got = q
+	return &QueryResult{}, nil
+}
+func (n *nativeRunner) QueryLanguage() string  { return "Report Request" }
+func (n *nativeRunner) QueryFixPrompt() string { return "native fix prompt" }
+
+func TestAsQueryRunner_AdaptsASQLProvider(t *testing.T) {
+	p := &recordingProvider{}
+	r := AsQueryRunner(p)
+
+	res, err := r.RunQuery(context.Background(), SQLQuery("SELECT 1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected a result")
+	}
+	if p.called != 1 {
+		t.Errorf("Provider.Query called %d times, want 1", p.called)
+	}
+	if p.gotQuery != "SELECT 1" {
+		t.Errorf("forwarded query = %q, want %q", p.gotQuery, "SELECT 1")
+	}
+	if p.gotParams != nil {
+		t.Errorf("forwarded params = %v, want nil — the executor never passed params", p.gotParams)
+	}
+	if got := r.QueryLanguage(); got != "Mock SQL" {
+		t.Errorf("QueryLanguage() = %q, want the provider's SQLDialect %q", got, "Mock SQL")
+	}
+	if got := r.QueryFixPrompt(); got != "fix {{ORIGINAL_SQL}}" {
+		t.Errorf("QueryFixPrompt() = %q, want the provider's SQLFixPrompt", got)
+	}
+}
+
+func TestAsQueryRunner_PropagatesProviderError(t *testing.T) {
+	want := errors.New("warehouse down")
+	r := AsQueryRunner(&recordingProvider{err: want})
+
+	if _, err := r.RunQuery(context.Background(), SQLQuery("SELECT 1")); !errors.Is(err, want) {
+		t.Errorf("error = %v, want it to be %v unwrapped", err, want)
+	}
+}
+
+func TestAsQueryRunner_ReturnsANativeRunnerUnchanged(t *testing.T) {
+	n := &nativeRunner{}
+	r := AsQueryRunner(n)
+
+	if r != QueryRunner(n) {
+		t.Fatal("a provider that implements QueryRunner must not be wrapped")
+	}
+	if got := r.QueryLanguage(); got != "Report Request" {
+		t.Errorf("QueryLanguage() = %q, want the runner's own language", got)
+	}
+}
+
+func TestAsQueryRunner_UnwrapReachesTheProvider(t *testing.T) {
+	p := &recordingProvider{}
+	r := AsQueryRunner(p)
+
+	u, ok := r.(interface{ Unwrap() Provider })
+	if !ok {
+		t.Fatal("the SQL adapter must expose the provider it wraps")
+	}
+	if u.Unwrap() != Provider(p) {
+		t.Error("Unwrap returned a different provider")
+	}
+}
+
+func TestNativeQuery_StructuredPayload(t *testing.T) {
+	type reportRequest struct{ Metrics []string }
+
+	sql := SQLQuery("SELECT 1")
+	if sql.IsStructured() {
+		t.Error("a SQL query carries no payload")
+	}
+	if sql.String() != "SELECT 1" {
+		t.Errorf("String() = %q, want the statement", sql.String())
+	}
+
+	structured := NativeQuery{
+		Text:    "metrics=[sessions] by date",
+		Payload: reportRequest{Metrics: []string{"sessions"}},
+	}
+	if !structured.IsStructured() {
+		t.Error("a query with a payload must report itself as structured")
+	}
+	if structured.String() != "metrics=[sessions] by date" {
+		t.Errorf("String() = %q, want the readable rendering, never the payload", structured.String())
+	}
+
+	n := &nativeRunner{}
+	if _, err := n.RunQuery(context.Background(), structured); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := n.got.Payload.(reportRequest); !ok {
+		t.Errorf("payload reached the runner as %T, want it preserved as reportRequest", n.got.Payload)
+	}
+}
+
+func TestProviderMeta_LanguageFallsBackToDialect(t *testing.T) {
+	tests := []struct {
+		name string
+		meta ProviderMeta
+		want string
+	}{
+		{"declared language wins", ProviderMeta{QueryLanguage: "SOQL", Dialect: "ignored"}, "SOQL"},
+		{"undeclared falls back to the dialect label", ProviderMeta{Dialect: "PostgreSQL"}, "PostgreSQL"},
+		{"neither declared falls back to SQL", ProviderMeta{}, "SQL"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.meta.Language(); got != tc.want {
+				t.Errorf("Language() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProviderMeta_ShapeDefaultsToEntities(t *testing.T) {
+	if got := (ProviderMeta{}).EffectiveShape(); got != ShapeEntities {
+		t.Errorf("EffectiveShape() = %q, want %q for an undeclared provider", got, ShapeEntities)
+	}
+	if got := (ProviderMeta{Shape: ShapeCube}).EffectiveShape(); got != ShapeCube {
+		t.Errorf("EffectiveShape() = %q, want %q", got, ShapeCube)
+	}
+}
+
+// TestProviderMeta_AnchorsDefaultsToTrue pins the direction of the default.
+// Getting this backwards would silently make every already-registered
+// datasource — including the enterprise-only drivers this repo cannot see —
+// ineligible to be a project's only source, with no error to trace it by.
+func TestProviderMeta_AnchorsDefaultsToTrue(t *testing.T) {
+	if !(ProviderMeta{}).Anchors() {
+		t.Error("an undeclared provider must anchor; a warehouse is the system of record by construction")
+	}
+	if !(ProviderMeta{CanAnchor: Anchoring(true)}).Anchors() {
+		t.Error("an explicit true must anchor")
+	}
+	if (ProviderMeta{CanAnchor: Anchoring(false)}).Anchors() {
+		t.Error("an explicit false must not anchor")
+	}
+}
+
+// TestRegisteredSQLProvidersAnchorAndAreEntityShaped asserts the defaults hold
+// for whatever is registered in this binary, so a provider added later cannot
+// silently acquire a wrong shape or anchoring value by omission.
+func TestRegisteredSQLProvidersAnchorAndAreEntityShaped(t *testing.T) {
+	for _, m := range RegisteredProvidersMeta() {
+		if m.Language() == "" {
+			t.Errorf("provider %q resolves to an empty query language", m.ID)
+		}
+		if m.EffectiveShape() != ShapeEntities && m.EffectiveShape() != ShapeCube {
+			t.Errorf("provider %q has shape %q, which is not a known shape", m.ID, m.EffectiveShape())
+		}
+	}
+}

--- a/libs/go-common/warehouse/capability_test.go
+++ b/libs/go-common/warehouse/capability_test.go
@@ -3,6 +3,7 @@ package warehouse
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -67,6 +68,32 @@ func TestAsQueryRunner_AdaptsASQLProvider(t *testing.T) {
 	}
 	if got := r.QueryFixPrompt(); got != "fix {{ORIGINAL_SQL}}" {
 		t.Errorf("QueryFixPrompt() = %q, want the provider's SQLFixPrompt", got)
+	}
+}
+
+// TestAsQueryRunner_RefusesAStructuredPayload pins that the SQL adapter never
+// silently runs Text while dropping a payload. Text is only a readable
+// rendering when a payload is present and may be empty, so executing it alone
+// would return a well-formed answer to a different question — the exact
+// failure this seam exists to prevent.
+func TestAsQueryRunner_RefusesAStructuredPayload(t *testing.T) {
+	p := &recordingProvider{}
+	r := AsQueryRunner(p)
+
+	q := NativeQuery{Text: "sessions by date", Payload: map[string]any{"metrics": []string{"sessions"}}}
+	res, err := r.RunQuery(context.Background(), q)
+
+	if err == nil {
+		t.Fatal("a SQL provider must refuse a structured payload, not drop it")
+	}
+	if res != nil {
+		t.Error("a refused query must not return a result")
+	}
+	if p.called != 0 {
+		t.Errorf("Provider.Query called %d times, want 0 — the refusal must precede execution", p.called)
+	}
+	if !strings.Contains(err.Error(), "structured query") {
+		t.Errorf("error = %q, want it to name the structured payload as the problem", err.Error())
 	}
 }
 

--- a/libs/go-common/warehouse/capability_test.go
+++ b/libs/go-common/warehouse/capability_test.go
@@ -141,7 +141,7 @@ func TestProviderMeta_LanguageFallsBackToDialect(t *testing.T) {
 		meta ProviderMeta
 		want string
 	}{
-		{"declared language wins", ProviderMeta{QueryLanguage: "SOQL", Dialect: "ignored"}, "SOQL"},
+		{"declared language wins", ProviderMeta{Capability: Capability{QueryLanguage: "SOQL"}, Dialect: "ignored"}, "SOQL"},
 		{"undeclared falls back to the dialect label", ProviderMeta{Dialect: "PostgreSQL"}, "PostgreSQL"},
 		{"neither declared falls back to SQL", ProviderMeta{}, "SQL"},
 	}
@@ -154,11 +154,30 @@ func TestProviderMeta_LanguageFallsBackToDialect(t *testing.T) {
 	}
 }
 
-func TestProviderMeta_ShapeDefaultsToEntities(t *testing.T) {
-	if got := (ProviderMeta{}).EffectiveShape(); got != ShapeEntities {
+// TestCapability_TravelsWithAProviderMeta pins that the embedded descriptor is
+// reachable through the meta, so a consumer holding a ProviderMeta does not
+// need to know the descriptor is a separate type.
+func TestCapability_TravelsWithAProviderMeta(t *testing.T) {
+	m := ProviderMeta{
+		Dialect:    "GA4",
+		Capability: Capability{Shape: ShapeCube, CanAnchor: Anchoring(false)},
+	}
+	if m.EffectiveShape() != ShapeCube {
+		t.Errorf("EffectiveShape() = %q, want %q through the embedded descriptor", m.EffectiveShape(), ShapeCube)
+	}
+	if m.Anchors() {
+		t.Error("a provider declaring CanAnchor(false) must not anchor")
+	}
+	if got := m.Language(); got != "GA4" {
+		t.Errorf("Language() = %q, want the Dialect fallback %q", got, "GA4")
+	}
+}
+
+func TestCapability_ShapeDefaultsToEntities(t *testing.T) {
+	if got := (Capability{}).EffectiveShape(); got != ShapeEntities {
 		t.Errorf("EffectiveShape() = %q, want %q for an undeclared provider", got, ShapeEntities)
 	}
-	if got := (ProviderMeta{Shape: ShapeCube}).EffectiveShape(); got != ShapeCube {
+	if got := (Capability{Shape: ShapeCube}).EffectiveShape(); got != ShapeCube {
 		t.Errorf("EffectiveShape() = %q, want %q", got, ShapeCube)
 	}
 }
@@ -167,14 +186,14 @@ func TestProviderMeta_ShapeDefaultsToEntities(t *testing.T) {
 // Getting this backwards would silently make every already-registered
 // datasource — including the enterprise-only drivers this repo cannot see —
 // ineligible to be a project's only source, with no error to trace it by.
-func TestProviderMeta_AnchorsDefaultsToTrue(t *testing.T) {
-	if !(ProviderMeta{}).Anchors() {
+func TestCapability_AnchorsDefaultsToTrue(t *testing.T) {
+	if !(Capability{}).Anchors() {
 		t.Error("an undeclared provider must anchor; a warehouse is the system of record by construction")
 	}
-	if !(ProviderMeta{CanAnchor: Anchoring(true)}).Anchors() {
+	if !(Capability{CanAnchor: Anchoring(true)}).Anchors() {
 		t.Error("an explicit true must anchor")
 	}
-	if (ProviderMeta{CanAnchor: Anchoring(false)}).Anchors() {
+	if (Capability{CanAnchor: Anchoring(false)}).Anchors() {
 		t.Error("an explicit false must not anchor")
 	}
 }

--- a/libs/go-common/warehouse/registry.go
+++ b/libs/go-common/warehouse/registry.go
@@ -34,21 +34,12 @@ type ProviderMeta struct {
 	// Every registered provider sets it.
 	Dialect string `json:"dialect"`
 
-	// QueryLanguage names the language queries against this source are written
-	// in. Empty means "the Dialect label" — see ProviderMeta.Language() — so
-	// every SQL provider is already correct without declaring it. A non-SQL
-	// source declares its own ("SOQL", a report specification, ...).
-	QueryLanguage string `json:"query_language,omitempty"`
-
-	// Shape is how the source organises what can be queried: rows in named
-	// entities, or a cube of metrics and dimensions. Empty means
-	// ShapeEntities — see ProviderMeta.EffectiveShape().
-	Shape SourceShape `json:"shape,omitempty"`
-
-	// CanAnchor declares whether a source of this type can carry a project by
-	// itself. Nil means true — see ProviderMeta.Anchors() for why the default
-	// runs that way. Declare it only to say false, via warehouse.Anchoring(false).
-	CanAnchor *bool `json:"can_anchor,omitempty"`
+	// Capability is the source-capability descriptor — query language, shape,
+	// and whether the source can anchor a project. Embedded, so its fields are
+	// declared and serialised inline. Every field defaults to what was true
+	// before the descriptor existed; a provider that declares none is
+	// unaffected. ProviderMeta.Language() additionally falls back to Dialect.
+	Capability
 
 	ConfigFields   []ConfigField     `json:"config_fields"`
 	AuthMethods    []AuthMethod      `json:"auth_methods,omitempty"`

--- a/libs/go-common/warehouse/registry.go
+++ b/libs/go-common/warehouse/registry.go
@@ -32,7 +32,24 @@ type ProviderMeta struct {
 	// constructed Provider (and therefore config/credentials), this label is
 	// declared at registration and available by slug with no instantiation.
 	// Every registered provider sets it.
-	Dialect        string            `json:"dialect"`
+	Dialect string `json:"dialect"`
+
+	// QueryLanguage names the language queries against this source are written
+	// in. Empty means "the Dialect label" — see ProviderMeta.Language() — so
+	// every SQL provider is already correct without declaring it. A non-SQL
+	// source declares its own ("SOQL", a report specification, ...).
+	QueryLanguage string `json:"query_language,omitempty"`
+
+	// Shape is how the source organises what can be queried: rows in named
+	// entities, or a cube of metrics and dimensions. Empty means
+	// ShapeEntities — see ProviderMeta.EffectiveShape().
+	Shape SourceShape `json:"shape,omitempty"`
+
+	// CanAnchor declares whether a source of this type can carry a project by
+	// itself. Nil means true — see ProviderMeta.Anchors() for why the default
+	// runs that way. Declare it only to say false, via warehouse.Anchoring(false).
+	CanAnchor *bool `json:"can_anchor,omitempty"`
+
 	ConfigFields   []ConfigField     `json:"config_fields"`
 	AuthMethods    []AuthMethod      `json:"auth_methods,omitempty"`
 	DefaultPricing *WarehousePricing `json:"default_pricing,omitempty"`

--- a/services/agent/agentserver/ask_serve.go
+++ b/services/agent/agentserver/ask_serve.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"syscall"
 
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/ai"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/ai/schema_retrieve"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/askserve"
@@ -222,6 +223,18 @@ func runAskServe(cfg *config.Config) error {
 					KeyMetrics:   wh.Card.KeyMetrics,
 				}
 			}
+			// Capability descriptor, resolved by provider slug from the
+			// registry — declared at registration, so this needs no
+			// connection and no credentials. An unregistered slug yields the
+			// zero descriptor, which resolves to SQL / entity-shaped /
+			// anchoring: what was true before the descriptor existed.
+			capability := gowarehouse.Capability{}
+			if meta, ok := gowarehouse.GetProviderMeta(wh.Provider); ok {
+				capability = meta.Capability
+				// Resolve the Dialect fallback here so downstream consumers
+				// read one already-resolved language.
+				capability.QueryLanguage = meta.Language()
+			}
 			datasources = append(datasources, askserve.DatasourceInfo{
 				ID:          warehouseID(wh),
 				Label:       wh.Label,
@@ -233,6 +246,7 @@ func runAskServe(cfg *config.Config) error {
 				FilterField: wh.FilterField,
 				FilterValue: wh.FilterValue,
 				Card:        card,
+				Capability:  capability,
 			})
 		}
 

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -3,8 +3,6 @@ package askserve
 import (
 	"fmt"
 	"strings"
-
-	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 )
 
 // buildSystemPrompt renders the Q&A system prompt for one turn on the JSON-text
@@ -124,48 +122,25 @@ func writeDataSection(b *strings.Builder, routing turnRouting) {
 // (dialect, datasets, read-only rule, and the tenant-scope predicate when the
 // dataset is multi-tenant). Shared verbatim by both prompt builders on a
 // single-datasource / pinned turn.
+//
+// The block is SQL-shaped throughout, as is the prompt around it — the tool
+// contract offers a `query` string documented as "SELECT / CTE only", and the
+// grounding guidance points at INFORMATION_SCHEMA. A cube-shaped source has no
+// coherent rendering here until there is an adapter defining what its query
+// actually is, so generalising this section alone would hand the model a cube
+// description wrapped in SQL instructions: contradictory guidance it would
+// resolve by writing SQL anyway. The prompt and tool surface generalise
+// together with the first non-SQL adapter.
 func writeWarehouseSection(b *strings.Builder, d DatasourceInfo) {
 	b.WriteString("WAREHOUSE\n")
-	if isCube(d) {
-		fmt.Fprintf(b, "- Query language: %s\n", d.Language())
-		b.WriteString(cubeShapeRule)
-	} else if d.Dialect != "" {
+	if d.Dialect != "" {
 		fmt.Fprintf(b, "- SQL dialect: %s\n", d.Dialect)
 	}
 	if len(d.Datasets) > 0 {
 		fmt.Fprintf(b, "- Datasets available: %s\n", strings.Join(d.Datasets, ", "))
 	}
-	if isCube(d) {
-		b.WriteString("- This source is READ-ONLY. It answers reports; it cannot be written to.\n")
-	} else {
-		b.WriteString("- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n")
-	}
+	b.WriteString("- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n")
 	writeTenantScope(b, "- ", d)
-}
-
-// cubeShapeRule tells the model what a cube-shaped source is, in the terms it
-// has to write queries in. It states the absence of tables explicitly because
-// the failure it prevents is not a syntax error: a model that assumes tables
-// writes a join the source cannot honour, and the source rejects it with an
-// error that reads as a bug rather than as "this source can't do that".
-const cubeShapeRule = "- This source is a metric/dimension cube, not tables of rows: there is nothing to SELECT from and nothing to join. A query names metrics, dimensions, a date range, and optional filters.\n"
-
-// isCube reports whether a datasource is cube-shaped. Sources that declare no
-// shape are entity-shaped, which is every SQL warehouse.
-func isCube(d DatasourceInfo) bool {
-	return d.EffectiveShape() == gowarehouse.ShapeCube
-}
-
-// anyCube reports whether a turn's routing includes a cube-shaped datasource.
-// Used to keep the multi-datasource preamble truthful on a mixed project
-// without changing a word of it on a SQL-only one.
-func anyCube(datasources []DatasourceInfo) bool {
-	for _, d := range datasources {
-		if isCube(d) {
-			return true
-		}
-	}
-	return false
 }
 
 // writeDatasourcesSection renders the DATASOURCES catalog for a multi-datasource
@@ -173,11 +148,7 @@ func anyCube(datasources []DatasourceInfo) bool {
 // card) plus the one-warehouse-per-statement + bounded multi-hop rules.
 func writeDatasourcesSection(b *strings.Builder, routing turnRouting) {
 	b.WriteString("DATASOURCES\n")
-	if anyCube(routing.datasources) {
-		b.WriteString("This project has multiple datasources, and they are not all the same shape. Each query runs against exactly ONE datasource — pass its id as datasource_id — in that datasource's own query language. A single query cannot span datasources.\n")
-	} else {
-		b.WriteString("This project has multiple datasources. Each SQL query runs against exactly ONE datasource — pass its id as datasource_id. A single query cannot join across datasources.\n")
-	}
+	b.WriteString("This project has multiple datasources. Each SQL query runs against exactly ONE datasource — pass its id as datasource_id. A single query cannot join across datasources.\n")
 	for _, d := range routing.datasources {
 		primary := ""
 		if d.ID == routing.primary {
@@ -201,10 +172,7 @@ func writeDatasourcesSection(b *strings.Builder, routing turnRouting) {
 				fmt.Fprintf(b, "  key metrics: %s\n", strings.Join(d.Card.KeyMetrics, ", "))
 			}
 		}
-		if isCube(d) {
-			fmt.Fprintf(b, "  query language: %s\n", d.Language())
-			b.WriteString("  shape: metric/dimension cube — no tables, no rows to select from, no joins\n")
-		} else if d.Dialect != "" {
+		if d.Dialect != "" {
 			fmt.Fprintf(b, "  SQL dialect: %s\n", d.Dialect)
 		}
 		if len(d.Datasets) > 0 {

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -3,6 +3,8 @@ package askserve
 import (
 	"fmt"
 	"strings"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 )
 
 // buildSystemPrompt renders the Q&A system prompt for one turn on the JSON-text
@@ -124,14 +126,46 @@ func writeDataSection(b *strings.Builder, routing turnRouting) {
 // single-datasource / pinned turn.
 func writeWarehouseSection(b *strings.Builder, d DatasourceInfo) {
 	b.WriteString("WAREHOUSE\n")
-	if d.Dialect != "" {
+	if isCube(d) {
+		fmt.Fprintf(b, "- Query language: %s\n", d.Language())
+		b.WriteString(cubeShapeRule)
+	} else if d.Dialect != "" {
 		fmt.Fprintf(b, "- SQL dialect: %s\n", d.Dialect)
 	}
 	if len(d.Datasets) > 0 {
 		fmt.Fprintf(b, "- Datasets available: %s\n", strings.Join(d.Datasets, ", "))
 	}
-	b.WriteString("- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n")
+	if isCube(d) {
+		b.WriteString("- This source is READ-ONLY. It answers reports; it cannot be written to.\n")
+	} else {
+		b.WriteString("- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n")
+	}
 	writeTenantScope(b, "- ", d)
+}
+
+// cubeShapeRule tells the model what a cube-shaped source is, in the terms it
+// has to write queries in. It states the absence of tables explicitly because
+// the failure it prevents is not a syntax error: a model that assumes tables
+// writes a join the source cannot honour, and the source rejects it with an
+// error that reads as a bug rather than as "this source can't do that".
+const cubeShapeRule = "- This source is a metric/dimension cube, not tables of rows: there is nothing to SELECT from and nothing to join. A query names metrics, dimensions, a date range, and optional filters.\n"
+
+// isCube reports whether a datasource is cube-shaped. Sources that declare no
+// shape are entity-shaped, which is every SQL warehouse.
+func isCube(d DatasourceInfo) bool {
+	return d.EffectiveShape() == gowarehouse.ShapeCube
+}
+
+// anyCube reports whether a turn's routing includes a cube-shaped datasource.
+// Used to keep the multi-datasource preamble truthful on a mixed project
+// without changing a word of it on a SQL-only one.
+func anyCube(datasources []DatasourceInfo) bool {
+	for _, d := range datasources {
+		if isCube(d) {
+			return true
+		}
+	}
+	return false
 }
 
 // writeDatasourcesSection renders the DATASOURCES catalog for a multi-datasource
@@ -139,7 +173,11 @@ func writeWarehouseSection(b *strings.Builder, d DatasourceInfo) {
 // card) plus the one-warehouse-per-statement + bounded multi-hop rules.
 func writeDatasourcesSection(b *strings.Builder, routing turnRouting) {
 	b.WriteString("DATASOURCES\n")
-	b.WriteString("This project has multiple datasources. Each SQL query runs against exactly ONE datasource — pass its id as datasource_id. A single query cannot join across datasources.\n")
+	if anyCube(routing.datasources) {
+		b.WriteString("This project has multiple datasources, and they are not all the same shape. Each query runs against exactly ONE datasource — pass its id as datasource_id — in that datasource's own query language. A single query cannot span datasources.\n")
+	} else {
+		b.WriteString("This project has multiple datasources. Each SQL query runs against exactly ONE datasource — pass its id as datasource_id. A single query cannot join across datasources.\n")
+	}
 	for _, d := range routing.datasources {
 		primary := ""
 		if d.ID == routing.primary {
@@ -163,7 +201,10 @@ func writeDatasourcesSection(b *strings.Builder, routing turnRouting) {
 				fmt.Fprintf(b, "  key metrics: %s\n", strings.Join(d.Card.KeyMetrics, ", "))
 			}
 		}
-		if d.Dialect != "" {
+		if isCube(d) {
+			fmt.Fprintf(b, "  query language: %s\n", d.Language())
+			b.WriteString("  shape: metric/dimension cube — no tables, no rows to select from, no joins\n")
+		} else if d.Dialect != "" {
 			fmt.Fprintf(b, "  SQL dialect: %s\n", d.Dialect)
 		}
 		if len(d.Datasets) > 0 {

--- a/services/agent/internal/askserve/prompt_shape_test.go
+++ b/services/agent/internal/askserve/prompt_shape_test.go
@@ -1,0 +1,161 @@
+package askserve
+
+import (
+	"strings"
+	"testing"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+)
+
+// sqlDatasource is the shape every datasource had before the capability
+// descriptor existed: no declaration at all.
+func sqlDatasource(id string) DatasourceInfo {
+	return DatasourceInfo{
+		ID:       id,
+		Label:    "Warehouse " + id,
+		Dialect:  "postgres",
+		Datasets: []string{"public"},
+	}
+}
+
+func cubeDatasource(id string) DatasourceInfo {
+	return DatasourceInfo{
+		ID:    id,
+		Label: "Analytics " + id,
+		// A cube source still carries a Dialect hint (the provider slug); the
+		// point of the shape flag is that the renderer must not treat it as a
+		// SQL dialect.
+		Dialect: "ga4",
+		Capability: gowarehouse.Capability{
+			QueryLanguage: "GA4 Report Request",
+			Shape:         gowarehouse.ShapeCube,
+			CanAnchor:     gowarehouse.Anchoring(false),
+		},
+	}
+}
+
+// TestWarehouseSection_SQLRenderingIsUnchanged pins the exact block an
+// undeclared (SQL) datasource produces. This is the regression guard for the
+// descriptor work: threading capability through must not alter one character
+// of what a SQL project's model sees.
+func TestWarehouseSection_SQLRenderingIsUnchanged(t *testing.T) {
+	var b strings.Builder
+	writeWarehouseSection(&b, sqlDatasource("wh_1"))
+
+	want := "WAREHOUSE\n" +
+		"- SQL dialect: postgres\n" +
+		"- Datasets available: public\n" +
+		"- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n"
+
+	if got := b.String(); got != want {
+		t.Errorf("SQL warehouse block changed.\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestWarehouseSection_CubeDoesNotClaimSQL pins that a cube-shaped source is
+// never described as SQL. Describing it as SQL is the failure the shape flag
+// exists to prevent: the model writes joins and a SELECT the source cannot
+// honour, and the rejection reads like a bug rather than an honest capability
+// limit.
+func TestWarehouseSection_CubeDoesNotClaimSQL(t *testing.T) {
+	var b strings.Builder
+	writeWarehouseSection(&b, cubeDatasource("ga_1"))
+	got := b.String()
+
+	if strings.Contains(got, "SQL dialect") {
+		t.Errorf("a cube source must not be given a SQL dialect line:\n%s", got)
+	}
+	if strings.Contains(got, "SELECT/CTE") {
+		t.Errorf("a cube source must not be told to emit SELECT/CTE queries:\n%s", got)
+	}
+	if !strings.Contains(got, "Query language: GA4 Report Request") {
+		t.Errorf("expected the declared query language in the block:\n%s", got)
+	}
+	if !strings.Contains(got, "metric/dimension cube") {
+		t.Errorf("expected the cube shape to be stated:\n%s", got)
+	}
+	if !strings.Contains(got, "READ-ONLY") {
+		t.Errorf("the read-only rule must survive the shape branch:\n%s", got)
+	}
+}
+
+// TestDatasourcesSection_SQLOnlyPreambleIsUnchanged pins the multi-datasource
+// preamble for a SQL-only project.
+func TestDatasourcesSection_SQLOnlyPreambleIsUnchanged(t *testing.T) {
+	var b strings.Builder
+	writeDatasourcesSection(&b, turnRouting{
+		datasources: []DatasourceInfo{sqlDatasource("wh_1"), sqlDatasource("wh_2")},
+		primary:     "wh_1",
+	})
+	got := b.String()
+
+	want := "This project has multiple datasources. Each SQL query runs against exactly ONE datasource — pass its id as datasource_id. A single query cannot join across datasources.\n"
+	if !strings.Contains(got, want) {
+		t.Errorf("SQL-only preamble changed.\ngot:\n%s\nwant to contain:\n%s", got, want)
+	}
+	if strings.Contains(got, "not all the same shape") {
+		t.Errorf("a SQL-only project must not get the mixed-shape preamble:\n%s", got)
+	}
+	if c := strings.Count(got, "SQL dialect: postgres"); c != 2 {
+		t.Errorf("expected a dialect line per datasource, got %d:\n%s", c, got)
+	}
+}
+
+// TestDatasourcesSection_MixedShapesAreDescribedHonestly pins that a project
+// mixing shapes stops claiming every query is SQL, and that each datasource is
+// described in its own terms.
+func TestDatasourcesSection_MixedShapesAreDescribedHonestly(t *testing.T) {
+	var b strings.Builder
+	writeDatasourcesSection(&b, turnRouting{
+		datasources: []DatasourceInfo{sqlDatasource("wh_1"), cubeDatasource("ga_1")},
+		primary:     "wh_1",
+	})
+	got := b.String()
+
+	if !strings.Contains(got, "not all the same shape") {
+		t.Errorf("a mixed-shape project needs the generalised preamble:\n%s", got)
+	}
+	if strings.Contains(got, "Each SQL query runs against exactly ONE datasource") {
+		t.Errorf("the SQL-only preamble must not appear on a mixed project:\n%s", got)
+	}
+	if !strings.Contains(got, "query language: GA4 Report Request") {
+		t.Errorf("the cube datasource must carry its own language:\n%s", got)
+	}
+	if !strings.Contains(got, "SQL dialect: postgres") {
+		t.Errorf("the SQL datasource must keep its dialect line:\n%s", got)
+	}
+}
+
+// TestDatasourceInfo_DescriptorDefaults pins that a datasource which declares
+// nothing behaves exactly as it did before the descriptor existed. A zero
+// value reaching the wrong default here would be silent — the datasource would
+// simply stop being eligible to anchor.
+func TestDatasourceInfo_DescriptorDefaults(t *testing.T) {
+	d := DatasourceInfo{ID: "wh_1"}
+
+	if got := d.EffectiveShape(); got != gowarehouse.ShapeEntities {
+		t.Errorf("EffectiveShape() = %q, want %q", got, gowarehouse.ShapeEntities)
+	}
+	if !d.Anchors() {
+		t.Error("an undeclared datasource must be able to anchor a project")
+	}
+	if got := d.Language(); got != "SQL" {
+		t.Errorf("Language() = %q, want %q", got, "SQL")
+	}
+	if isCube(d) {
+		t.Error("an undeclared datasource must not be treated as a cube")
+	}
+}
+
+// TestAnyCube pins the mixed-project predicate the preamble branches on.
+func TestAnyCube(t *testing.T) {
+	if anyCube(nil) {
+		t.Error("no datasources means no cube")
+	}
+	if anyCube([]DatasourceInfo{sqlDatasource("a"), sqlDatasource("b")}) {
+		t.Error("SQL-only routing must not report a cube")
+	}
+	if !anyCube([]DatasourceInfo{sqlDatasource("a"), cubeDatasource("b")}) {
+		t.Error("a single cube datasource must be detected")
+	}
+}

--- a/services/agent/internal/askserve/prompt_shape_test.go
+++ b/services/agent/internal/askserve/prompt_shape_test.go
@@ -18,26 +18,10 @@ func sqlDatasource(id string) DatasourceInfo {
 	}
 }
 
-func cubeDatasource(id string) DatasourceInfo {
-	return DatasourceInfo{
-		ID:    id,
-		Label: "Analytics " + id,
-		// A cube source still carries a Dialect hint (the provider slug); the
-		// point of the shape flag is that the renderer must not treat it as a
-		// SQL dialect.
-		Dialect: "ga4",
-		Capability: gowarehouse.Capability{
-			QueryLanguage: "GA4 Report Request",
-			Shape:         gowarehouse.ShapeCube,
-			CanAnchor:     gowarehouse.Anchoring(false),
-		},
-	}
-}
-
-// TestWarehouseSection_SQLRenderingIsUnchanged pins the exact block an
-// undeclared (SQL) datasource produces. This is the regression guard for the
-// descriptor work: threading capability through must not alter one character
-// of what a SQL project's model sees.
+// TestWarehouseSection_SQLRenderingIsUnchanged pins the exact block a
+// datasource produces. This is the regression guard for the descriptor work:
+// threading capability through the runtime must not alter one character of
+// what a project's model sees.
 func TestWarehouseSection_SQLRenderingIsUnchanged(t *testing.T) {
 	var b strings.Builder
 	writeWarehouseSection(&b, sqlDatasource("wh_1"))
@@ -48,40 +32,36 @@ func TestWarehouseSection_SQLRenderingIsUnchanged(t *testing.T) {
 		"- The warehouse is READ-ONLY. Emit only SELECT/CTE queries. Never attempt INSERT, UPDATE, DELETE, MERGE, or DDL.\n"
 
 	if got := b.String(); got != want {
-		t.Errorf("SQL warehouse block changed.\ngot:\n%s\nwant:\n%s", got, want)
+		t.Errorf("warehouse block changed.\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestWarehouseSection_CubeDoesNotClaimSQL pins that a cube-shaped source is
-// never described as SQL. Describing it as SQL is the failure the shape flag
-// exists to prevent: the model writes joins and a SELECT the source cannot
-// honour, and the rejection reads like a bug rather than an honest capability
-// limit.
-func TestWarehouseSection_CubeDoesNotClaimSQL(t *testing.T) {
-	var b strings.Builder
-	writeWarehouseSection(&b, cubeDatasource("ga_1"))
-	got := b.String()
+// TestWarehouseSection_DescriptorDoesNotLeakIntoThePrompt pins that carrying a
+// capability descriptor on a datasource changes nothing about what is
+// rendered. The prompt and tool surface are SQL-shaped throughout and
+// generalise together with the first non-SQL adapter; until then a declared
+// shape must not produce a partly-generalised prompt.
+func TestWarehouseSection_DescriptorDoesNotLeakIntoThePrompt(t *testing.T) {
+	plain := sqlDatasource("wh_1")
+	declared := sqlDatasource("wh_1")
+	declared.Capability = gowarehouse.Capability{
+		QueryLanguage: "PostgreSQL",
+		Shape:         gowarehouse.ShapeEntities,
+		CanAnchor:     gowarehouse.Anchoring(true),
+	}
 
-	if strings.Contains(got, "SQL dialect") {
-		t.Errorf("a cube source must not be given a SQL dialect line:\n%s", got)
-	}
-	if strings.Contains(got, "SELECT/CTE") {
-		t.Errorf("a cube source must not be told to emit SELECT/CTE queries:\n%s", got)
-	}
-	if !strings.Contains(got, "Query language: GA4 Report Request") {
-		t.Errorf("expected the declared query language in the block:\n%s", got)
-	}
-	if !strings.Contains(got, "metric/dimension cube") {
-		t.Errorf("expected the cube shape to be stated:\n%s", got)
-	}
-	if !strings.Contains(got, "READ-ONLY") {
-		t.Errorf("the read-only rule must survive the shape branch:\n%s", got)
+	var a, b strings.Builder
+	writeWarehouseSection(&a, plain)
+	writeWarehouseSection(&b, declared)
+
+	if a.String() != b.String() {
+		t.Errorf("declaring a descriptor changed the prompt.\nplain:\n%s\ndeclared:\n%s", a.String(), b.String())
 	}
 }
 
-// TestDatasourcesSection_SQLOnlyPreambleIsUnchanged pins the multi-datasource
-// preamble for a SQL-only project.
-func TestDatasourcesSection_SQLOnlyPreambleIsUnchanged(t *testing.T) {
+// TestDatasourcesSection_PreambleIsUnchanged pins the multi-datasource
+// preamble and per-datasource dialect lines.
+func TestDatasourcesSection_PreambleIsUnchanged(t *testing.T) {
 	var b strings.Builder
 	writeDatasourcesSection(&b, turnRouting{
 		datasources: []DatasourceInfo{sqlDatasource("wh_1"), sqlDatasource("wh_2")},
@@ -91,44 +71,16 @@ func TestDatasourcesSection_SQLOnlyPreambleIsUnchanged(t *testing.T) {
 
 	want := "This project has multiple datasources. Each SQL query runs against exactly ONE datasource — pass its id as datasource_id. A single query cannot join across datasources.\n"
 	if !strings.Contains(got, want) {
-		t.Errorf("SQL-only preamble changed.\ngot:\n%s\nwant to contain:\n%s", got, want)
-	}
-	if strings.Contains(got, "not all the same shape") {
-		t.Errorf("a SQL-only project must not get the mixed-shape preamble:\n%s", got)
+		t.Errorf("preamble changed.\ngot:\n%s\nwant to contain:\n%s", got, want)
 	}
 	if c := strings.Count(got, "SQL dialect: postgres"); c != 2 {
 		t.Errorf("expected a dialect line per datasource, got %d:\n%s", c, got)
 	}
 }
 
-// TestDatasourcesSection_MixedShapesAreDescribedHonestly pins that a project
-// mixing shapes stops claiming every query is SQL, and that each datasource is
-// described in its own terms.
-func TestDatasourcesSection_MixedShapesAreDescribedHonestly(t *testing.T) {
-	var b strings.Builder
-	writeDatasourcesSection(&b, turnRouting{
-		datasources: []DatasourceInfo{sqlDatasource("wh_1"), cubeDatasource("ga_1")},
-		primary:     "wh_1",
-	})
-	got := b.String()
-
-	if !strings.Contains(got, "not all the same shape") {
-		t.Errorf("a mixed-shape project needs the generalised preamble:\n%s", got)
-	}
-	if strings.Contains(got, "Each SQL query runs against exactly ONE datasource") {
-		t.Errorf("the SQL-only preamble must not appear on a mixed project:\n%s", got)
-	}
-	if !strings.Contains(got, "query language: GA4 Report Request") {
-		t.Errorf("the cube datasource must carry its own language:\n%s", got)
-	}
-	if !strings.Contains(got, "SQL dialect: postgres") {
-		t.Errorf("the SQL datasource must keep its dialect line:\n%s", got)
-	}
-}
-
 // TestDatasourceInfo_DescriptorDefaults pins that a datasource which declares
 // nothing behaves exactly as it did before the descriptor existed. A zero
-// value reaching the wrong default here would be silent — the datasource would
+// value resolving the wrong way here would be silent — the datasource would
 // simply stop being eligible to anchor.
 func TestDatasourceInfo_DescriptorDefaults(t *testing.T) {
 	d := DatasourceInfo{ID: "wh_1"}
@@ -141,21 +93,5 @@ func TestDatasourceInfo_DescriptorDefaults(t *testing.T) {
 	}
 	if got := d.Language(); got != "SQL" {
 		t.Errorf("Language() = %q, want %q", got, "SQL")
-	}
-	if isCube(d) {
-		t.Error("an undeclared datasource must not be treated as a cube")
-	}
-}
-
-// TestAnyCube pins the mixed-project predicate the preamble branches on.
-func TestAnyCube(t *testing.T) {
-	if anyCube(nil) {
-		t.Error("no datasources means no cube")
-	}
-	if anyCube([]DatasourceInfo{sqlDatasource("a"), sqlDatasource("b")}) {
-		t.Error("SQL-only routing must not report a cube")
-	}
-	if !anyCube([]DatasourceInfo{sqlDatasource("a"), cubeDatasource("b")}) {
-		t.Error("a single cube datasource must be detected")
 	}
 }

--- a/services/agent/internal/askserve/types.go
+++ b/services/agent/internal/askserve/types.go
@@ -3,6 +3,7 @@ package askserve
 import (
 	"context"
 
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/queryexec"
 )
 
@@ -83,6 +84,15 @@ type DatasourceInfo struct {
 	// Card is the structured routing card (subject areas / entities / metrics).
 	// Optional; nil when the datasource has no card yet.
 	Card *DatasourceCard
+	// Capability is the source-capability descriptor resolved from the
+	// provider registry at runtime-build time: the query language, the source
+	// shape, and whether this kind of source can anchor a project. Carried
+	// here so routing and prompt construction can reason about a datasource
+	// without opening a connection to it.
+	//
+	// Zero-valued for a datasource whose provider declares nothing, which
+	// resolves to the pre-descriptor behaviour: SQL, entity-shaped, anchoring.
+	gowarehouse.Capability
 }
 
 // DatasourceCard mirrors models.WarehouseCard — the structured routing signal

--- a/services/agent/internal/queryexec/characterization_test.go
+++ b/services/agent/internal/queryexec/characterization_test.go
@@ -395,8 +395,7 @@ type failThenSucceedWarehouse struct {
 func (w *failThenSucceedWarehouse) Query(ctx context.Context, query string, params map[string]interface{}) (*gowarehouse.QueryResult, error) {
 	w.calls++
 	if w.calls <= w.failures {
-		w.MockWarehouseProvider.Calls = append(w.MockWarehouseProvider.Calls,
-			testutil.MockWarehouseCall{Method: "Query", Query: query})
+		w.Calls = append(w.Calls, testutil.MockWarehouseCall{Method: "Query", Query: query})
 		return nil, w.err
 	}
 	return w.MockWarehouseProvider.Query(ctx, query, params)

--- a/services/agent/internal/queryexec/characterization_test.go
+++ b/services/agent/internal/queryexec/characterization_test.go
@@ -1,0 +1,414 @@
+package queryexec
+
+// Characterization tests for the query-execution repair loop.
+//
+// These pin the CURRENT observable behaviour of QueryExecutor — how many times
+// the warehouse is called, how many times the fixer is called, the exact error
+// strings callers match on, and the shape of the recorded repair trail — so
+// that extracting a query-runner seam underneath it is provably behaviour-
+// preserving. They are deliberately exact where the surrounding unit tests are
+// loose (several assert only `err != nil`), because "the loop still fails" is
+// not the property that matters here: "the loop fails after the same number of
+// warehouse round-trips, with the same message, having recorded the same
+// history" is.
+//
+// If a change makes one of these fail, that is a behaviour change. Either it
+// was intended — in which case update the test in the same commit and say so —
+// or the change is wrong. Do not relax an assertion to make it pass.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/testutil"
+)
+
+// queryCalls counts the Query calls the executor made against the mock.
+func queryCalls(wh *testutil.MockWarehouseProvider) int {
+	n := 0
+	for _, c := range wh.Calls {
+		if c.Method == "Query" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCharacterization_RetryBudget pins the loop's arithmetic: MaxRetries=N
+// costs N+1 warehouse round-trips and N fixer calls, and every failed attempt
+// leaves one entry in Errors. The off-by-one here is load-bearing — the final
+// attempt is executed but never repaired, because the budget check precedes
+// the fix call.
+func TestCharacterization_RetryBudget(t *testing.T) {
+	for _, maxRetries := range []int{0, 1, 2, 5} {
+		t.Run(fmt.Sprintf("max_retries_%d", maxRetries), func(t *testing.T) {
+			wh := testutil.NewMockWarehouseProvider("test_dataset")
+			wh.QueryError = errors.New("persistent error")
+			fixer := &mockFixer{}
+
+			e := NewQueryExecutor(QueryExecutorOptions{
+				Warehouse:  wh,
+				SQLFixer:   fixer,
+				MaxRetries: maxRetries,
+			})
+
+			// MaxRetries=0 is not "no retries": NewQueryExecutor treats the zero
+			// value as "unset" and substitutes the default of 5.
+			effective := maxRetries
+			if maxRetries == 0 {
+				effective = 5
+			}
+
+			result, err := e.Execute(context.Background(), "SELECT 1", "test")
+			if err == nil {
+				t.Fatal("expected the run to fail once the retry budget is exhausted")
+			}
+			if got, want := queryCalls(wh), effective+1; got != want {
+				t.Errorf("warehouse Query calls = %d, want %d (one per attempt, budget+1)", got, want)
+			}
+			if got, want := fixer.Calls, effective; got != want {
+				t.Errorf("fixer calls = %d, want %d (the last attempt is not repaired)", got, want)
+			}
+			if result == nil {
+				t.Fatal("a budget-exhausted Execute must still return its partial result")
+			}
+			if got, want := result.FixAttempts, effective; got != want {
+				t.Errorf("FixAttempts = %d, want %d", got, want)
+			}
+			if got, want := len(result.Errors), effective+1; got != want {
+				t.Errorf("len(Errors) = %d, want %d (one per failed attempt)", got, want)
+			}
+			if got, want := len(result.FixHistory), effective; got != want {
+				t.Errorf("len(FixHistory) = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestCharacterization_ErrorShapes pins the exact wording of every terminal
+// error the executor produces. Callers upstream match on these strings, and
+// the enterprise ask path surfaces some of them to end users.
+func TestCharacterization_ErrorShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func() *QueryExecutor
+		query      string
+		wantErr    string
+		wantResult bool // whether a non-nil partial result accompanies the error
+	}{
+		{
+			name: "budget exhausted names the attempt count and wraps the warehouse error",
+			setup: func() *QueryExecutor {
+				wh := testutil.NewMockWarehouseProvider("d")
+				wh.QueryError = errors.New("boom")
+				return NewQueryExecutor(QueryExecutorOptions{
+					Warehouse: wh, SQLFixer: &mockFixer{}, MaxRetries: 2,
+				})
+			},
+			query:      "SELECT 1",
+			wantErr:    "query failed after 3 attempts: boom",
+			wantResult: true,
+		},
+		{
+			name: "no fixer configured is reported as such, not as an exhausted budget",
+			setup: func() *QueryExecutor {
+				wh := testutil.NewMockWarehouseProvider("d")
+				wh.QueryError = errors.New("boom")
+				return NewQueryExecutor(QueryExecutorOptions{
+					Warehouse: wh, MaxRetries: 3,
+				})
+			},
+			query:      "SELECT 1",
+			wantErr:    "query failed and no SQL fixer available: boom",
+			wantResult: true,
+		},
+		{
+			name: "a failing fixer surfaces as a fix failure, not a query failure",
+			setup: func() *QueryExecutor {
+				wh := testutil.NewMockWarehouseProvider("d")
+				wh.QueryError = errors.New("boom")
+				return NewQueryExecutor(QueryExecutorOptions{
+					Warehouse: wh, SQLFixer: &mockFixer{Error: errors.New("llm down")}, MaxRetries: 3,
+				})
+			},
+			query:      "SELECT 1",
+			wantErr:    "failed to fix SQL query: llm down",
+			wantResult: true,
+		},
+		{
+			name: "the incoming query is filter-checked before the warehouse is touched",
+			setup: func() *QueryExecutor {
+				wh := testutil.NewMockWarehouseProvider("d")
+				return NewQueryExecutor(QueryExecutorOptions{
+					Warehouse: wh, SQLFixer: &mockFixer{},
+					FilterField: "app_id", FilterValue: "acme",
+				})
+			},
+			query:      "SELECT * FROM t",
+			wantErr:    "security violation: query must filter by app_id for security",
+			wantResult: false,
+		},
+		{
+			name: "a repaired query that drops the filter is rejected with its own message",
+			setup: func() *QueryExecutor {
+				wh := testutil.NewMockWarehouseProvider("d")
+				wh.QueryError = errors.New("boom")
+				return NewQueryExecutor(QueryExecutorOptions{
+					Warehouse: wh,
+					// The repaired SQL no longer mentions app_id.
+					SQLFixer:    &mockFixer{FixedQuery: "SELECT * FROM t"},
+					MaxRetries:  3,
+					FilterField: "app_id", FilterValue: "acme",
+				})
+			},
+			query:      "SELECT * FROM t WHERE app_id = 'acme'",
+			wantErr:    "fixed query security violation: query must filter by app_id for security",
+			wantResult: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := tc.setup().Execute(context.Background(), tc.query, "test")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if err.Error() != tc.wantErr {
+				t.Errorf("error = %q, want %q", err.Error(), tc.wantErr)
+			}
+			if got := result != nil; got != tc.wantResult {
+				t.Errorf("non-nil result = %v, want %v", got, tc.wantResult)
+			}
+		})
+	}
+}
+
+// TestCharacterization_FilterCheckPrecedesExecution pins that a scope
+// violation costs zero warehouse round-trips — the check runs before the loop,
+// not inside it.
+func TestCharacterization_FilterCheckPrecedesExecution(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("d")
+	e := NewQueryExecutor(QueryExecutorOptions{
+		Warehouse: wh, FilterField: "app_id", FilterValue: "acme",
+	})
+
+	if _, err := e.Execute(context.Background(), "SELECT * FROM t", "test"); err == nil {
+		t.Fatal("expected a security violation")
+	}
+	if n := queryCalls(wh); n != 0 {
+		t.Errorf("warehouse Query calls = %d, want 0 — the filter check must precede execution", n)
+	}
+}
+
+// TestCharacterization_HappyPath pins the untouched-query result shape: no
+// repair recorded, FinalQuery identical to OriginalQuery, and exactly one
+// warehouse round-trip.
+func TestCharacterization_HappyPath(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("d")
+	wh.DefaultResult = &gowarehouse.QueryResult{
+		Columns: []string{"n"},
+		Rows:    []map[string]interface{}{{"n": int64(1)}, {"n": int64(2)}},
+	}
+	fixer := &mockFixer{}
+	e := NewQueryExecutor(QueryExecutorOptions{Warehouse: wh, SQLFixer: fixer})
+
+	result, err := e.Execute(context.Background(), "SELECT n FROM t", "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if queryCalls(wh) != 1 {
+		t.Errorf("warehouse Query calls = %d, want 1", queryCalls(wh))
+	}
+	if fixer.Calls != 0 {
+		t.Errorf("fixer calls = %d, want 0 on the happy path", fixer.Calls)
+	}
+	if result.Fixed {
+		t.Error("Fixed must be false when the first attempt succeeds")
+	}
+	if result.FixAttempts != 0 || len(result.FixHistory) != 0 || len(result.Errors) != 0 {
+		t.Errorf("expected an empty repair trail, got attempts=%d history=%d errors=%d",
+			result.FixAttempts, len(result.FixHistory), len(result.Errors))
+	}
+	if result.OriginalQuery != "SELECT n FROM t" || result.FinalQuery != result.OriginalQuery {
+		t.Errorf("query fields = %q / %q, want both %q",
+			result.OriginalQuery, result.FinalQuery, "SELECT n FROM t")
+	}
+	if result.RowCount != 2 || len(result.Data) != 2 {
+		t.Errorf("RowCount/Data = %d/%d, want 2/2", result.RowCount, len(result.Data))
+	}
+}
+
+// TestCharacterization_RepairTrailChains pins that a successful repair records
+// the before/after SQL as a chain — each attempt's SQLBefore is the previous
+// attempt's SQLAfter — and that the succeeding query becomes FinalQuery. The
+// chain is what makes the history readable as a trajectory rather than a set.
+func TestCharacterization_RepairTrailChains(t *testing.T) {
+	const fixedSQL = "SELECT 1 -- repaired"
+	wh := &failThenSucceedWarehouse{
+		MockWarehouseProvider: testutil.NewMockWarehouseProvider("d"),
+		failures:              2,
+		err:                   errors.New("syntax error"),
+	}
+	fixer := &mockFixer{FixedQuery: fixedSQL}
+	e := NewQueryExecutor(QueryExecutorOptions{Warehouse: wh, SQLFixer: fixer, MaxRetries: 5})
+	e.SetStep(7)
+
+	result, err := e.Execute(context.Background(), "SELECT 1", "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Fixed {
+		t.Error("Fixed must be true when a later attempt succeeded")
+	}
+	if result.FinalQuery != fixedSQL {
+		t.Errorf("FinalQuery = %q, want the repaired SQL %q", result.FinalQuery, fixedSQL)
+	}
+	if result.OriginalQuery != "SELECT 1" {
+		t.Errorf("OriginalQuery = %q, want the query as submitted", result.OriginalQuery)
+	}
+	if got, want := len(result.FixHistory), 2; got != want {
+		t.Fatalf("len(FixHistory) = %d, want %d", got, want)
+	}
+	if result.FixHistory[0].SQLBefore != "SELECT 1" {
+		t.Errorf("first SQLBefore = %q, want the original query", result.FixHistory[0].SQLBefore)
+	}
+	for i, a := range result.FixHistory {
+		if a.SQLAfter != fixedSQL {
+			t.Errorf("attempt %d SQLAfter = %q, want %q", i, a.SQLAfter, fixedSQL)
+		}
+		if a.Attempt != i {
+			t.Errorf("attempt %d records Attempt = %d, want %d", i, a.Attempt, i)
+		}
+		if a.Step != 7 {
+			t.Errorf("attempt %d records Step = %d, want the executor's current step 7", i, a.Step)
+		}
+		if a.FixerError != "" {
+			t.Errorf("attempt %d records FixerError = %q, want empty on a clean fix", i, a.FixerError)
+		}
+		if a.ErrorIn == "" {
+			t.Errorf("attempt %d records no ErrorIn; the triggering error must be kept", i)
+		}
+		if a.InputTokens == 0 || a.OutputTokens == 0 {
+			t.Errorf("attempt %d dropped token accounting (in=%d out=%d)", i, a.InputTokens, a.OutputTokens)
+		}
+		if a.Timestamp.IsZero() {
+			t.Errorf("attempt %d has a zero Timestamp", i)
+		}
+	}
+	if result.FixHistory[1].SQLBefore != result.FixHistory[0].SQLAfter {
+		t.Errorf("history is not chained: attempt 1 SQLBefore = %q, attempt 0 SQLAfter = %q",
+			result.FixHistory[1].SQLBefore, result.FixHistory[0].SQLAfter)
+	}
+}
+
+// TestCharacterization_FixOptsForwardedOnEveryRetry pins that per-call
+// grounding context reaches the fixer on every attempt, not just the first —
+// the verifier relies on this to stop the model re-emitting a hallucinated
+// column.
+func TestCharacterization_FixOptsForwardedOnEveryRetry(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("d")
+	wh.QueryError = errors.New("boom")
+	fixer := &recordingFixer{}
+	e := NewQueryExecutor(QueryExecutorOptions{Warehouse: wh, SQLFixer: fixer, MaxRetries: 3})
+
+	opts := FixOpts{VerificationContext: "step 4 SQL: SELECT id FROM orders"}
+	if _, err := e.ExecuteWithFixOpts(context.Background(), "SELECT 1", "test", opts); err == nil {
+		t.Fatal("expected the run to fail")
+	}
+	if len(fixer.seen) != 3 {
+		t.Fatalf("fixer called %d times, want 3", len(fixer.seen))
+	}
+	for i, got := range fixer.seen {
+		if got != opts {
+			t.Errorf("attempt %d received FixOpts %+v, want %+v unchanged", i, got, opts)
+		}
+	}
+}
+
+// TestCharacterization_ExecuteWithHistoryFields pins the QueryHistory record
+// on both outcomes: it always carries the query as submitted (never the
+// repaired one) and the fix count, and only the success path fills the
+// result-derived fields.
+func TestCharacterization_ExecuteWithHistoryFields(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		wh := testutil.NewMockWarehouseProvider("d")
+		e := NewQueryExecutor(QueryExecutorOptions{Warehouse: wh, SQLFixer: &mockFixer{}})
+
+		result, history := e.ExecuteWithHistory(context.Background(), "SELECT 1", "counting")
+		if !history.Success {
+			t.Error("Success must be true")
+		}
+		if history.Error != "" {
+			t.Errorf("Error = %q, want empty on success", history.Error)
+		}
+		if history.Query != "SELECT 1" || history.Purpose != "counting" {
+			t.Errorf("Query/Purpose = %q/%q, want %q/%q", history.Query, history.Purpose, "SELECT 1", "counting")
+		}
+		if history.RowsReturned != result.RowCount {
+			t.Errorf("RowsReturned = %d, want the result's RowCount %d", history.RowsReturned, result.RowCount)
+		}
+		if history.FixAttempts != result.FixAttempts {
+			t.Errorf("FixAttempts = %d, want %d", history.FixAttempts, result.FixAttempts)
+		}
+		if history.ExecutedAt.IsZero() {
+			t.Error("ExecutedAt must be stamped")
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		wh := testutil.NewMockWarehouseProvider("d")
+		wh.QueryError = errors.New("boom")
+		e := NewQueryExecutor(QueryExecutorOptions{Warehouse: wh, SQLFixer: &mockFixer{}, MaxRetries: 1})
+
+		result, history := e.ExecuteWithHistory(context.Background(), "SELECT 1", "counting")
+		if history.Success {
+			t.Error("Success must be false")
+		}
+		if !strings.Contains(history.Error, "query failed after 2 attempts") {
+			t.Errorf("Error = %q, want it to carry the executor's error", history.Error)
+		}
+		if history.RowsReturned != 0 {
+			t.Errorf("RowsReturned = %d, want 0 on failure", history.RowsReturned)
+		}
+		if history.FixAttempts != result.FixAttempts {
+			t.Errorf("FixAttempts = %d, want the partial result's %d", history.FixAttempts, result.FixAttempts)
+		}
+	})
+}
+
+// --- helpers -------------------------------------------------------------
+
+// failThenSucceedWarehouse fails its first `failures` Query calls, then
+// delegates to the mock. It exists because the shared mock is all-or-nothing:
+// a repair trajectory needs a warehouse that recovers.
+type failThenSucceedWarehouse struct {
+	*testutil.MockWarehouseProvider
+	failures int
+	err      error
+	calls    int
+}
+
+func (w *failThenSucceedWarehouse) Query(ctx context.Context, query string, params map[string]interface{}) (*gowarehouse.QueryResult, error) {
+	w.calls++
+	if w.calls <= w.failures {
+		w.MockWarehouseProvider.Calls = append(w.MockWarehouseProvider.Calls,
+			testutil.MockWarehouseCall{Method: "Query", Query: query})
+		return nil, w.err
+	}
+	return w.MockWarehouseProvider.Query(ctx, query, params)
+}
+
+// recordingFixer captures the FixOpts of every call so a test can assert they
+// are forwarded unchanged across retries.
+type recordingFixer struct {
+	seen []FixOpts
+}
+
+func (f *recordingFixer) FixSQL(_ context.Context, query string, _ string, _ int, opts FixOpts) (FixResult, error) {
+	f.seen = append(f.seen, opts)
+	return FixResult{FixedSQL: query, InputTokens: 1, OutputTokens: 1, DurationMs: 1}, nil
+}

--- a/services/agent/internal/queryexec/native_query_test.go
+++ b/services/agent/internal/queryexec/native_query_test.go
@@ -1,0 +1,149 @@
+package queryexec
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+)
+
+// stubRunner is a QueryRunner that records what it was asked to execute — the
+// shape a non-SQL adapter takes.
+type stubRunner struct {
+	got   []gowarehouse.NativeQuery
+	err   error
+	calls int
+}
+
+func (r *stubRunner) RunQuery(_ context.Context, q gowarehouse.NativeQuery) (*gowarehouse.QueryResult, error) {
+	r.calls++
+	r.got = append(r.got, q)
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &gowarehouse.QueryResult{Columns: []string{"c"}, Rows: []map[string]interface{}{{"c": 1}}}, nil
+}
+
+func (r *stubRunner) QueryLanguage() string  { return "Report Request" }
+func (r *stubRunner) QueryFixPrompt() string { return "" }
+
+// TestExecuteNative_RefusesAStructuredQueryUnderTenantScope is the security
+// property behind the refusal: the scope check reads query TEXT, while a
+// structured query's meaning is in its PAYLOAD, and the two are set
+// independently. Checking the text would pass a query whose payload asks for
+// everything — a security check that reports a guarantee it cannot keep.
+//
+// The refusal must happen before the source is touched, so a rejected query
+// costs zero round-trips and leaks nothing.
+func TestExecuteNative_RefusesAStructuredQueryUnderTenantScope(t *testing.T) {
+	runner := &stubRunner{}
+	e := NewQueryExecutor(QueryExecutorOptions{
+		Runner:      runner,
+		FilterField: "app_id",
+		FilterValue: "acme",
+	})
+
+	// Text that would satisfy the substring scope check, paired with a payload
+	// that carries no scope at all — exactly the bypass being refused.
+	q := gowarehouse.NativeQuery{
+		Text:    "report filtered by app_id = 'acme'",
+		Payload: map[string]any{"metrics": []string{"sessions"}},
+	}
+
+	result, err := e.ExecuteNative(context.Background(), q, "test", FixOpts{})
+	if err == nil {
+		t.Fatal("a structured query under tenant scope must be refused")
+	}
+	if !strings.HasPrefix(err.Error(), "security violation: a structured query cannot be scope-checked against app_id") {
+		t.Errorf("error = %q, want it to name the unenforceable scope field", err.Error())
+	}
+	if result != nil {
+		t.Error("a refused query must not return a result")
+	}
+	if runner.calls != 0 {
+		t.Errorf("runner called %d times, want 0 — the refusal must precede execution", runner.calls)
+	}
+}
+
+// TestExecuteNative_RunsAStructuredQueryWithoutTenantScope pins that the
+// refusal is scoped to the case it is about: with no tenant filter configured
+// there is nothing to enforce, and the payload must reach the runner intact.
+func TestExecuteNative_RunsAStructuredQueryWithoutTenantScope(t *testing.T) {
+	type reportRequest struct{ Metrics []string }
+
+	runner := &stubRunner{}
+	e := NewQueryExecutor(QueryExecutorOptions{Runner: runner})
+
+	q := gowarehouse.NativeQuery{
+		Text:    "sessions by date",
+		Payload: reportRequest{Metrics: []string{"sessions"}},
+	}
+
+	result, err := e.ExecuteNative(context.Background(), q, "test", FixOpts{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("runner called %d times, want 1", runner.calls)
+	}
+	if _, ok := runner.got[0].Payload.(reportRequest); !ok {
+		t.Errorf("payload reached the runner as %T, want it preserved", runner.got[0].Payload)
+	}
+	if result.OriginalQuery != "sessions by date" || result.FinalQuery != "sessions by date" {
+		t.Errorf("query fields = %q / %q, want the readable rendering in both",
+			result.OriginalQuery, result.FinalQuery)
+	}
+	if result.RowCount != 1 {
+		t.Errorf("RowCount = %d, want 1", result.RowCount)
+	}
+}
+
+// TestExecuteNative_StructuredQueryIsNotRepaired pins that a failing
+// structured query is reported rather than rewritten. The fixer rewrites text;
+// applying that to a payload-carrying query would either drop the payload or
+// pair it with contradicting text — a query that runs cleanly and answers a
+// different question than the one asked.
+func TestExecuteNative_StructuredQueryIsNotRepaired(t *testing.T) {
+	runner := &stubRunner{err: context.DeadlineExceeded}
+	fixer := &mockFixer{}
+	e := NewQueryExecutor(QueryExecutorOptions{Runner: runner, SQLFixer: fixer, MaxRetries: 3})
+
+	q := gowarehouse.NativeQuery{Text: "sessions by date", Payload: map[string]any{"m": 1}}
+
+	_, err := e.ExecuteNative(context.Background(), q, "test", FixOpts{})
+	if err == nil {
+		t.Fatal("expected the failure to surface")
+	}
+	if !strings.Contains(err.Error(), "structured queries have no repair path") {
+		t.Errorf("error = %q, want it to say why no repair was attempted", err.Error())
+	}
+	if fixer.Calls != 0 {
+		t.Errorf("fixer called %d times, want 0", fixer.Calls)
+	}
+	if runner.calls != 1 {
+		t.Errorf("runner called %d times, want 1 — no retry without a repair", runner.calls)
+	}
+}
+
+// TestExecute_StringPathIsUnaffectedByTheRefusal pins that a plain SQL query
+// under tenant scope still behaves exactly as before: the text check runs and
+// a scoped query passes it.
+func TestExecute_StringPathIsUnaffectedByTheRefusal(t *testing.T) {
+	runner := &stubRunner{}
+	e := NewQueryExecutor(QueryExecutorOptions{
+		Runner:      runner,
+		FilterField: "app_id",
+		FilterValue: "acme",
+	})
+
+	if _, err := e.Execute(context.Background(), "SELECT 1 WHERE app_id = 'acme'", "test"); err != nil {
+		t.Fatalf("a scoped SQL query must still run: %v", err)
+	}
+	if runner.calls != 1 {
+		t.Errorf("runner called %d times, want 1", runner.calls)
+	}
+	if runner.got[0].IsStructured() {
+		t.Error("the string path must produce an unstructured NativeQuery")
+	}
+}

--- a/services/agent/internal/queryexec/native_query_test.go
+++ b/services/agent/internal/queryexec/native_query_test.go
@@ -126,6 +126,30 @@ func TestExecuteNative_StructuredQueryIsNotRepaired(t *testing.T) {
 	}
 }
 
+// TestExecuteNative_StructuredFailureIsClassifiedBeforeTheFixerCheck pins the
+// order of the two terminal branches. A non-SQL source is exactly the case
+// that legitimately runs without a SQL fixer, so checking the fixer first
+// would report "no SQL fixer available" for a query no SQL fixer could have
+// repaired — an accurate-sounding message pointing at the wrong thing.
+func TestExecuteNative_StructuredFailureIsClassifiedBeforeTheFixerCheck(t *testing.T) {
+	runner := &stubRunner{err: context.DeadlineExceeded}
+	// No SQLFixer configured — the expected shape for a non-SQL source.
+	e := NewQueryExecutor(QueryExecutorOptions{Runner: runner, MaxRetries: 3})
+
+	q := gowarehouse.NativeQuery{Text: "sessions by date", Payload: map[string]any{"m": 1}}
+
+	_, err := e.ExecuteNative(context.Background(), q, "test", FixOpts{})
+	if err == nil {
+		t.Fatal("expected the failure to surface")
+	}
+	if strings.Contains(err.Error(), "no SQL fixer available") {
+		t.Errorf("error = %q, want the structured no-repair message, not the missing-fixer one", err.Error())
+	}
+	if !strings.Contains(err.Error(), "structured queries have no repair path") {
+		t.Errorf("error = %q, want it to say why no repair was attempted", err.Error())
+	}
+}
+
 // TestExecute_StringPathIsUnaffectedByTheRefusal pins that a plain SQL query
 // under tenant scope still behaves exactly as before: the text check runs and
 // a scoped query passes it.

--- a/services/agent/internal/queryexec/query_executor.go
+++ b/services/agent/internal/queryexec/query_executor.go
@@ -173,6 +173,19 @@ func (e *QueryExecutor) ExecuteNative(ctx context.Context, query gowarehouse.Nat
 
 	currentQuery := query
 
+	// A structured query cannot be scope-checked. verifyFilter inspects query
+	// text, but a structured query's meaning lives in its payload — the two are
+	// set independently, so text mentioning the scope field says nothing about
+	// what the payload asks for. Checking the text anyway would report a
+	// guarantee this code cannot keep, and the result would be a query that
+	// passed the security check and ran unscoped. Refuse instead: a source with
+	// structured queries must enforce scope by its own mechanism (a scoped
+	// credential, or a filter the adapter builds into the payload it submits).
+	if query.IsStructured() && e.filterField != "" {
+		return nil, fmt.Errorf("security violation: a structured query cannot be scope-checked against %s; "+
+			"the source must enforce scope through its own credential or payload", e.filterField)
+	}
+
 	if err := e.verifyFilter(currentQuery.String()); err != nil {
 		return nil, fmt.Errorf("security violation: %w", err)
 	}

--- a/services/agent/internal/queryexec/query_executor.go
+++ b/services/agent/internal/queryexec/query_executor.go
@@ -12,9 +12,15 @@ import (
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
 
-// QueryExecutor executes warehouse queries with self-healing capabilities.
+// QueryExecutor executes queries with self-healing capabilities.
+//
+// It depends on the narrow gowarehouse.QueryRunner seam rather than on the
+// full SQL Provider interface: executing a query and repairing a failed one
+// are all it does, and neither needs schema introspection or identifier
+// quoting. A SQL provider is adapted onto the seam by
+// gowarehouse.AsQueryRunner, so the SQL path is unchanged.
 type QueryExecutor struct {
-	warehouse    gowarehouse.Provider
+	runner       gowarehouse.QueryRunner
 	sqlFixer     SQLFixer
 	debugLogger  *debug.Logger
 	maxRetries   int
@@ -63,7 +69,12 @@ type SQLFixer interface {
 
 // QueryExecutorOptions configures the query executor.
 type QueryExecutorOptions struct {
-	Warehouse   gowarehouse.Provider
+	// Warehouse is a SQL provider, adapted onto the QueryRunner seam. This is
+	// how every existing caller configures the executor.
+	Warehouse gowarehouse.Provider
+	// Runner supplies the query seam directly, for a source that is not a SQL
+	// provider. When set it takes precedence over Warehouse.
+	Runner      gowarehouse.QueryRunner
 	SQLFixer    SQLFixer
 	DebugLogger *debug.Logger
 	MaxRetries  int
@@ -76,8 +87,12 @@ func NewQueryExecutor(opts QueryExecutorOptions) *QueryExecutor {
 	if opts.MaxRetries == 0 {
 		opts.MaxRetries = 5
 	}
+	runner := opts.Runner
+	if runner == nil && opts.Warehouse != nil {
+		runner = gowarehouse.AsQueryRunner(opts.Warehouse)
+	}
 	return &QueryExecutor{
-		warehouse:    opts.Warehouse,
+		runner:       runner,
 		sqlFixer:     opts.SQLFixer,
 		debugLogger:  opts.DebugLogger,
 		maxRetries:   opts.MaxRetries,
@@ -131,17 +146,34 @@ func (e *QueryExecutor) Execute(ctx context.Context, query string, purpose strin
 // each time, so the LLM sees the same evidence regardless of which retry
 // attempt is in flight.
 func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, purpose string, opts FixOpts) (*ExecuteResult, error) {
+	return e.ExecuteNative(ctx, gowarehouse.SQLQuery(query), purpose, opts)
+}
+
+// ExecuteNative is ExecuteWithFixOpts over a query in any source's language.
+// It is the executor's general entry point; the string-based methods above
+// wrap a SQL statement into a NativeQuery and call through here.
+//
+// A structured query — one carrying a provider-native payload rather than
+// text — executes through the same loop but is NOT repaired on failure. The
+// repair path rewrites query *text*, and applying a text rewrite to a query
+// whose meaning lives in its payload would either drop the payload or pair it
+// with contradicting text: a query that runs cleanly and answers a different
+// question than the one asked. Sources with structured queries are expected to
+// bring their own repair mechanism (a pre-flight validator catches more, and
+// earlier, than a post-hoc rewrite); until one is wired in, such a failure is
+// returned honestly rather than silently patched.
+func (e *QueryExecutor) ExecuteNative(ctx context.Context, query gowarehouse.NativeQuery, purpose string, opts FixOpts) (*ExecuteResult, error) {
 	startTime := time.Now()
 
 	result := &ExecuteResult{
-		OriginalQuery: query,
-		FinalQuery:    query,
+		OriginalQuery: query.String(),
+		FinalQuery:    query.String(),
 		Errors:        make([]string, 0),
 	}
 
 	currentQuery := query
 
-	if err := e.verifyFilter(currentQuery); err != nil {
+	if err := e.verifyFilter(currentQuery.String()); err != nil {
 		return nil, fmt.Errorf("security violation: %w", err)
 	}
 
@@ -152,17 +184,17 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 			"purpose":  purpose,
 			"phase":    e.currentPhase,
 			"step":     e.currentStep,
-			"query_len": len(currentQuery),
+			"query_len": len(currentQuery.String()),
 		}).Debug("Executing warehouse query")
 
-		qr, err := e.warehouse.Query(ctx, currentQuery, nil)
+		qr, err := e.runner.RunQuery(ctx, currentQuery)
 		executionTime := time.Since(startTime).Milliseconds()
 
 		if err == nil {
 			result.Data = qr.Rows
 			result.RowCount = len(qr.Rows)
 			result.ExecutionTimeMs = executionTime
-			result.FinalQuery = currentQuery
+			result.FinalQuery = currentQuery.String()
 			result.Fixed = attempt > 0
 
 			applog.WithFields(applog.Fields{
@@ -179,7 +211,7 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 					fixedQuery = result.FinalQuery
 				}
 				e.debugLogger.LogWarehouseQuery(ctx, e.currentStep, e.currentPhase,
-					query, purpose, result.Data, result.RowCount, result.ExecutionTimeMs,
+					query.String(), purpose, result.Data, result.RowCount, result.ExecutionTimeMs,
 					nil, result.FixAttempts, fixedQuery)
 			}
 
@@ -204,7 +236,7 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 
 			if e.debugLogger != nil {
 				e.debugLogger.LogWarehouseQuery(ctx, e.currentStep, e.currentPhase,
-					query, purpose, nil, 0, time.Since(startTime).Milliseconds(),
+					query.String(), purpose, nil, 0, time.Since(startTime).Milliseconds(),
 					err, result.FixAttempts, "")
 			}
 			return result, fmt.Errorf("query failed after %d attempts: %w", attempt+1, err)
@@ -215,12 +247,20 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 			return result, fmt.Errorf("query failed and no SQL fixer available: %w", err)
 		}
 
+		if currentQuery.IsStructured() {
+			applog.WithFields(applog.Fields{
+				"purpose": purpose,
+				"error":   err.Error(),
+			}).Error("Structured query failed and the text repair loop cannot repair it")
+			return result, fmt.Errorf("query failed and structured queries have no repair path: %w", err)
+		}
+
 		applog.WithFields(applog.Fields{
 			"attempt": attempt + 1,
 			"error":   err.Error(),
 		}).Info("Attempting SQL fix via LLM")
 
-		fix, fixErr := e.sqlFixer.FixSQL(ctx, currentQuery, err.Error(), attempt, opts)
+		fix, fixErr := e.sqlFixer.FixSQL(ctx, currentQuery.String(), err.Error(), attempt, opts)
 		if fixErr != nil {
 			// The fixer call failed (LLM transport error OR the response
 			// couldn't be parsed into SQL). Record the attempt so the
@@ -232,7 +272,7 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 				Attempt:      attempt,
 				PromptIn:     fix.Prompt,
 				ResponseOut:  fix.Response,
-				SQLBefore:    currentQuery,
+				SQLBefore:    currentQuery.String(),
 				SQLAfter:     fix.FixedSQL,
 				ErrorIn:      err.Error(),
 				FixerError:   fixErr.Error(),
@@ -255,7 +295,7 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 				Attempt:      attempt,
 				PromptIn:     fix.Prompt,
 				ResponseOut:  fix.Response,
-				SQLBefore:    currentQuery,
+				SQLBefore:    currentQuery.String(),
 				SQLAfter:     fix.FixedSQL,
 				ErrorIn:      err.Error(),
 				FixerError:   "fixed query security violation: " + verifyErr.Error(),
@@ -273,7 +313,7 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 			Attempt:      attempt,
 			PromptIn:     fix.Prompt,
 			ResponseOut:  fix.Response,
-			SQLBefore:    currentQuery,
+			SQLBefore:    currentQuery.String(),
 			SQLAfter:     fix.FixedSQL,
 			ErrorIn:      err.Error(),
 			InputTokens:  fix.InputTokens,
@@ -284,7 +324,7 @@ func (e *QueryExecutor) ExecuteWithFixOpts(ctx context.Context, query string, pu
 
 		applog.Debug("SQL fix applied, retrying with corrected query")
 		result.FixAttempts++
-		currentQuery = fix.FixedSQL
+		currentQuery = gowarehouse.SQLQuery(fix.FixedSQL)
 		startTime = time.Now()
 	}
 

--- a/services/agent/internal/queryexec/query_executor.go
+++ b/services/agent/internal/queryexec/query_executor.go
@@ -255,17 +255,22 @@ func (e *QueryExecutor) ExecuteNative(ctx context.Context, query gowarehouse.Nat
 			return result, fmt.Errorf("query failed after %d attempts: %w", attempt+1, err)
 		}
 
-		if e.sqlFixer == nil {
-			applog.Error("Query failed and no SQL fixer available — cannot retry")
-			return result, fmt.Errorf("query failed and no SQL fixer available: %w", err)
-		}
-
+		// Classify a structured failure first. A non-SQL source is the case
+		// that legitimately runs without a SQL fixer, so checking the fixer
+		// first would report "no SQL fixer available" for a query that could
+		// not have been repaired by one anyway — an accurate-sounding message
+		// pointing at the wrong thing.
 		if currentQuery.IsStructured() {
 			applog.WithFields(applog.Fields{
 				"purpose": purpose,
 				"error":   err.Error(),
 			}).Error("Structured query failed and the text repair loop cannot repair it")
 			return result, fmt.Errorf("query failed and structured queries have no repair path: %w", err)
+		}
+
+		if e.sqlFixer == nil {
+			applog.Error("Query failed and no SQL fixer available — cannot retry")
+			return result, fmt.Errorf("query failed and no SQL fixer available: %w", err)
 		}
 
 		applog.WithFields(applog.Fields{


### PR DESCRIPTION
Closes #354. Part of the non-SQL datasources epic; targets the shared bridge branch `feat/non-sql-datasources`, not `main`.

Generalises the driver abstraction from **SQL dialects** to **query languages**, so a source backed by a service API can use the same execute-and-repair pipeline — with no behaviour change for any existing SQL provider.

## The hard gate first

`services/agent/internal/queryexec/characterization_test.go` pins the current repair loop **before** anything is extracted, and is green and unchanged after:

- retry arithmetic — `MaxRetries=N` costs N+1 warehouse round-trips and N fixer calls, because the budget check precedes the fix call
- the zero value of `MaxRetries` means *unset* (default 5), not *no retries*
- the exact wording of all five terminal errors callers match on
- the scope check precedes execution — a violation costs zero round-trips
- the repair trail chains: each attempt's `SQLBefore` is the previous `SQLAfter`
- `FixOpts` reach the fixer unchanged on every retry, not just the first
- `QueryHistory` always records the query as submitted, never the repaired one

Verified non-vacuous by mutation: changing the attempt count in the exhaustion message fails the suite. The surrounding unit tests were loose here — several assert only `err != nil`, which does not catch a loop that fails after a different number of round-trips.

## The seam

`libs/go-common/warehouse/capability.go`:

- **`QueryRunner`** — the narrow interface the execution loop actually needs: `RunQuery` / `QueryLanguage` / `QueryFixPrompt`. Schema introspection, dataset listing and identifier quoting stay on `Provider`, where they belong.
- **`NativeQuery`** — a query in a source's own language: `Text` for logs, prompts and stored history, plus an optional provider-native `Payload`, so a structured request need not be serialised and re-parsed.
- **`AsQueryRunner`** — adapts any SQL `Provider` onto the seam (`RunQuery`→`Query`, `QueryLanguage`→`SQLDialect`, `QueryFixPrompt`→`SQLFixPrompt`). This is what makes the extraction non-breaking: every registered provider — including the enterprise-only drivers this repo cannot see — keeps working unedited, with no compile break.

`QueryExecutor` now holds a `QueryRunner` instead of a `Provider`. `Execute` and `ExecuteWithFixOpts` keep their exact signatures; `ExecuteNative` is the general entry point underneath them.

## The descriptor

`Capability` — query language, source shape (`entities` / `cube`), and `CanAnchor` — declared at provider registration, embedded in `ProviderMeta`, and resolved onto each `DatasourceInfo` by provider slug. Readable with no connection and no credentials.

**Every field defaults to what was true before it existed**, so no provider needed editing: language falls back to the existing `Dialect` label, shape to `entities`, `CanAnchor` to true.

The anchoring default runs that way deliberately. The opposite default fails *silently* — an existing datasource quietly becomes ineligible to be a project's only source, refused with nothing to trace it to. `CanAnchor` is therefore `*bool`: only a source whose value is purely correlative declares `false`.

## Prompt

Unchanged. The descriptor is resolved and carried, but nothing in the prompt branches on it yet.

An earlier revision made the `WAREHOUSE` block cube-aware; review showed that to be worse than doing nothing. The prompt opener, the `TOOLS` block, the grounding guidance and the `query_data` tool schema itself all specify read-only SQL, `SELECT / CTE`, and `INFORMATION_SCHEMA`. A model handed a cube description wrapped in SQL instructions resolves the contradiction by writing SQL anyway. The prompt and tool surface generalise together, with the adapter that defines what a cube query *is*; the reasoning is recorded at `writeWarehouseSection` so the next person doesn't re-derive it.

A test pins that declaring a descriptor changes nothing about the rendered prompt.

## Deliberate limits

- **A structured query executes but is not repaired.** The repair loop rewrites query *text*; applying a text rewrite to a query whose meaning lives in its payload would drop the payload or pair it with contradicting text — a query that runs cleanly and answers a different question. That failure is returned honestly instead, for a source with structured queries to replace with its own repair mechanism (a pre-flight validator catches more, and earlier, than a post-hoc rewrite).
- **A structured query under a tenant filter is refused.** `verifyFilter` reads query text; a structured query's meaning is in its payload, and the two are set independently, so text naming the scope field says nothing about what the payload asks for. Checking it would report a guarantee this code cannot keep. Such a source enforces scope through its own credential or through a filter its adapter builds into the payload.
- **The SQL adapter refuses a structured payload** rather than running `Text` and dropping it.
- **Anchoring is carried, not enforced.** Refusing a non-anchoring source as a project's only datasource belongs to the anchoring issue.
- No adapter, and no scope-enforcement changes (that work item was rejected in the epic).

## Review

Three rounds of `codex review` against the bridge branch, per the engineering guide's review-until-stable rule:

| Round | Finding | Resolution |
|---|---|---|
| 1 | **P1** structured query under tenant scope could pass the text-based scope check and run unscoped | Refused before the source is touched |
| 1 | **P2** only the `WAREHOUSE` block was cube-aware; the surrounding prompt still specified SQL | Cube branch removed — prompt and tools generalise together with the adapter |
| 2 | **P2** `sqlRunner` documented a structured payload as a programming error but silently dropped it | Refuses, naming the provider and payload type |
| 2 | **P3** a structured failure with no SQL fixer reported "no SQL fixer available" | Structured classification moved ahead of the fixer check |
| 3 | none | — |

## Testing

`go build ./...` and `go test ./...` green across `libs/go-common`, `services/agent`, `services/api` and the warehouse providers.

One pre-existing failure is unrelated and reproduces on `main`: `libs/go-common/mongodb TestNewClient_UnreachableHost`, which depends on a hostname failing to resolve.

`gofmt` reports `registry.go` and `query_executor.go` as unformatted — both already are on `main`, in regions this PR does not touch (struct-tag comment alignment, a map literal's key alignment). Left alone to keep the diff reviewable; happy to land a separate formatting pass.
