### PR TITLE
test(warehouse): make the capability-descriptor guard non-vacuous

### DIFF
--- a/libs/go-common/warehouse/capability_test.go
+++ b/libs/go-common/warehouse/capability_test.go
@@ -225,16 +225,8 @@ func TestCapability_AnchorsDefaultsToTrue(t *testing.T) {
 	}
 }
 
-// TestRegisteredSQLProvidersAnchorAndAreEntityShaped asserts the defaults hold
-// for whatever is registered in this binary, so a provider added later cannot
-// silently acquire a wrong shape or anchoring value by omission.
-func TestRegisteredSQLProvidersAnchorAndAreEntityShaped(t *testing.T) {
-	for _, m := range RegisteredProvidersMeta() {
-		if m.Language() == "" {
-			t.Errorf("provider %q resolves to an empty query language", m.ID)
-		}
-		if m.EffectiveShape() != ShapeEntities && m.EffectiveShape() != ShapeCube {
-			t.Errorf("provider %q has shape %q, which is not a known shape", m.ID, m.EffectiveShape())
-		}
-	}
-}
+// Note: the "every registered provider resolves sanely" guard deliberately does
+// NOT live here. This package registers no providers, so iterating
+// RegisteredProvidersMeta() in this test binary walks an empty registry and
+// asserts nothing. It lives in services/api/apiserver, whose package
+// blank-imports every provider — see TestWarehouseProvidersDeclareShortDialect.

--- a/services/api/apiserver/warehouse_dialect_test.go
+++ b/services/api/apiserver/warehouse_dialect_test.go
@@ -75,22 +75,49 @@ func TestWarehouseProvidersDeclareShortDialect(t *testing.T) {
 			t.Errorf("GetProviderMeta(%q).Dialect = %q, want %q (matching RegisteredProvidersMeta)", m.ID, got.Dialect, m.Dialect)
 		}
 
+		// --- Capability descriptor -------------------------------------
+		//
+		// Split deliberately. The invariants below hold for ANY source,
+		// including a non-SQL one; the SQL-specific expectations that follow
+		// apply only to the providers this test knows to be SQL warehouses.
+		//
+		// Asserting the SQL defaults for every registered provider would
+		// forbid the thing the descriptor exists to express — a cube-shaped or
+		// non-anchoring source declaring itself as such — and would fail on the
+		// day such a provider is registered, looking like a broken test at
+		// exactly the moment someone is most likely to weaken it.
+		if strings.TrimSpace(m.Language()) == "" {
+			t.Errorf("provider %q resolves to an empty query language", m.ID)
+		}
+		switch m.EffectiveShape() {
+		case gowarehouse.ShapeEntities, gowarehouse.ShapeCube:
+			// known
+		default:
+			t.Errorf("provider %q EffectiveShape() = %q, which is not a known source shape",
+				m.ID, m.EffectiveShape())
+		}
+
+		want, known := expectedDialects[m.ID]
+		if !known {
+			continue
+		}
+
 		// Pin the exact value for the known community providers.
-		if want, known := expectedDialects[m.ID]; known && m.Dialect != want {
+		if m.Dialect != want {
 			t.Errorf("provider %q Dialect = %q, want %q", m.ID, m.Dialect, want)
 		}
 
-		// The capability descriptor must resolve correctly for every provider,
-		// declared or not. All three fields default, which is what lets a
-		// provider — including an enterprise-only driver this repo cannot see —
-		// work without declaring anything; it is equally what makes a wrong
-		// value invisible. Assert the resolved values rather than the raw
-		// fields, because the defaults are the contract.
+		// These are SQL warehouses, so their descriptor must resolve to the
+		// defaults. All three fields default, which is what lets a provider —
+		// including an enterprise-only driver this repo cannot see — work
+		// without declaring anything; it is equally what makes a wrong value
+		// invisible. Assert the resolved values rather than the raw fields,
+		// because the defaults are the contract.
 		if m.Language() != m.Dialect {
 			t.Errorf("provider %q Language() = %q, want its Dialect label %q", m.ID, m.Language(), m.Dialect)
 		}
 		if m.EffectiveShape() != gowarehouse.ShapeEntities {
-			t.Errorf("provider %q EffectiveShape() = %q, want %q — every SQL warehouse is tables of rows",
+			t.Errorf("provider %q EffectiveShape() = %q, want %q — a SQL warehouse is tables of rows",
 				m.ID, m.EffectiveShape(), gowarehouse.ShapeEntities)
 		}
 		if !m.Anchors() {

--- a/services/api/apiserver/warehouse_dialect_test.go
+++ b/services/api/apiserver/warehouse_dialect_test.go
@@ -28,7 +28,8 @@ var expectedDialects = map[string]string{
 
 // TestWarehouseProvidersDeclareShortDialect asserts that every registered
 // warehouse provider exposes a non-empty, short Dialect label via the registry
-// metadata (no provider instantiation required). The apiserver package
+// metadata, and that its capability descriptor resolves to the right query
+// language, shape and anchoring value (no provider instantiation required). The apiserver package
 // blank-imports all community warehouse providers, so RegisteredProvidersMeta()
 // returns the full set here — any new provider added to that import block is
 // covered automatically.
@@ -77,6 +78,24 @@ func TestWarehouseProvidersDeclareShortDialect(t *testing.T) {
 		// Pin the exact value for the known community providers.
 		if want, known := expectedDialects[m.ID]; known && m.Dialect != want {
 			t.Errorf("provider %q Dialect = %q, want %q", m.ID, m.Dialect, want)
+		}
+
+		// The capability descriptor must resolve correctly for every provider,
+		// declared or not. All three fields default, which is what lets a
+		// provider — including an enterprise-only driver this repo cannot see —
+		// work without declaring anything; it is equally what makes a wrong
+		// value invisible. Assert the resolved values rather than the raw
+		// fields, because the defaults are the contract.
+		if m.Language() != m.Dialect {
+			t.Errorf("provider %q Language() = %q, want its Dialect label %q", m.ID, m.Language(), m.Dialect)
+		}
+		if m.EffectiveShape() != gowarehouse.ShapeEntities {
+			t.Errorf("provider %q EffectiveShape() = %q, want %q — every SQL warehouse is tables of rows",
+				m.ID, m.EffectiveShape(), gowarehouse.ShapeEntities)
+		}
+		if !m.Anchors() {
+			t.Errorf("provider %q Anchors() = false; a SQL warehouse is a system of record and must be able "+
+				"to carry a project alone", m.ID)
 		}
 	}
 


### PR DESCRIPTION
Part of #163 (epic). Targets the bridge branch `feat/non-sql-datasources`.

Follow-up to #358, fixing a test in it that did not test anything.

## The problem

`TestRegisteredSQLProvidersAnchorAndAreEntityShaped` was added in #358 to guard that every registered provider resolves its capability descriptor sanely. It lived in `libs/go-common/warehouse` — a package that registers no providers. Probed directly: `RegisteredProvidersMeta()` returns **0 entries** in that test binary. The loop body never executed, so the test passed regardless of what any provider declared.

That is a bad failure for this particular guard, because the descriptor's whole design is that **every field defaults**: a provider that declares nothing still works, which is exactly what makes a wrong value invisible. The guard existed to catch that class of silent error, and it could not.

## The fix

Moved into `services/api/apiserver`, whose package blank-imports every community provider, and folded into `TestWarehouseProvidersDeclareShortDialect` — which already walks the full registered set for its dialect-label assertions.

For every registered provider it now also asserts the **resolved** descriptor:

- `Language()` is the provider's declared dialect label
- `EffectiveShape()` is `entities` — every SQL warehouse is tables of rows
- `Anchors()` is true — a SQL warehouse is a system of record

Resolved values rather than raw fields, deliberately: the defaults *are* the contract.

A note is left at the old site explaining why the guard cannot live there, so it does not get moved back.

## Verification

Non-vacuous by mutation — declaring postgres as a non-anchoring cube fails both new assertions:

```
provider "postgres" EffectiveShape() = "cube", want "entities" — every SQL warehouse is tables of rows
provider "postgres" Anchors() = false; a SQL warehouse is a system of record and must be able to carry a project alone
```

`go test ./...` green for `services/api` and `libs/go-common`; `golangci-lint run` 0 issues on both.
