### PR TITLE
feat(askserve): record the router's ballot and verdict, not just what the turn queried

### DIFF
--- a/libs/go-common/models/ask_turn.go
+++ b/libs/go-common/models/ask_turn.go
@@ -69,6 +69,16 @@ type AskTurn struct {
 	// empty/zero for a single-datasource project or a turn pinned to an
 	// explicit datasource, where no routing decision is made.
 	RoutedDatasourceIDs []string `bson:"routed_datasource_ids,omitempty" json:"routed_datasource_ids,omitempty"`
+	// RoutingCandidateIDs are the datasources the router chose FROM, and
+	// RoutingChosenIDs the ones it chose. Both are distinct from
+	// RoutedDatasourceIDs, which records what the turn went on to query.
+	//
+	// The distinction is the whole point: without the candidate set, a turn
+	// that ignored a connected datasource is indistinguishable from one where
+	// that datasource was correctly irrelevant. Answering "is the router blind
+	// to this source?" needs to know it was on the ballot and lost.
+	RoutingCandidateIDs []string `bson:"routing_candidate_ids,omitempty" json:"routing_candidate_ids,omitempty"`
+	RoutingChosenIDs    []string `bson:"routing_chosen_ids,omitempty" json:"routing_chosen_ids,omitempty"`
 	RoutingReason       string   `bson:"routing_reason,omitempty" json:"routing_reason,omitempty"`
 	RoutingConfidence   float64  `bson:"routing_confidence,omitempty" json:"routing_confidence,omitempty"`
 	RoutingClarify      bool     `bson:"routing_clarify,omitempty" json:"routing_clarify,omitempty"`

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -63,6 +63,12 @@ type turnState struct {
 	routeReason     string
 	routeConfidence float64
 	routeClarify    bool
+	// routeCandidates / routeChosen are the ballot and the verdict: what the
+	// router was offered, and what it picked. Recorded separately from
+	// st.touched (what the turn actually queried) because only the ballot can
+	// tell a datasource that lost from one that was never in the running.
+	routeCandidates []string
+	routeChosen     []string
 	// groundedEvents counts evidence tool events that SUCCEEDED (no error). The
 	// native-tools loop grounds on this, not on len(events): a failed query /
 	// rejected tenant filter / unavailable schema search records an event but
@@ -955,6 +961,8 @@ func (r *runner) finalize(ctx context.Context, st *turnState, fin TurnFinal) {
 	fin.RoutingReason = st.routeReason
 	fin.RoutingConfidence = st.routeConfidence
 	fin.RoutingClarify = st.routeClarify
+	fin.RoutingCandidateIDs = st.routeCandidates
+	fin.RoutingChosenIDs = st.routeChosen
 
 	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()

--- a/services/agent/internal/askserve/router.go
+++ b/services/agent/internal/askserve/router.go
@@ -52,6 +52,12 @@ func (r *runner) route(ctx context.Context, rt *ProjectRuntime, st *turnState) (
 		}
 	}
 
+	// Record the ballot before asking. A router that errors, or one that never
+	// picks a particular datasource, is only diagnosable against the set it was
+	// offered — otherwise "the router ignored the analytics property" and "the
+	// analytics property was correctly irrelevant" produce identical records.
+	st.routeCandidates = datasourceIDs(st.routing.datasources)
+
 	dec, err := r.decideRoute(ctx, st, evidence)
 	if err != nil {
 		applog.WithError(err).WithField("turn_id", st.req.TurnID).Warn("ask-serve: router failed; letting the model choose datasources")
@@ -81,6 +87,7 @@ func (r *runner) route(ctx context.Context, rt *ProjectRuntime, st *turnState) (
 	// datasource(s) are recorded in telemetry even on the single-datasource
 	// pin path (which flips multi off).
 	st.routing.routed = true
+	st.routeChosen = valid
 
 	chosen := datasourceInfosFor(rt, valid)
 	if len(valid) == 1 {
@@ -180,6 +187,18 @@ func filterKnownDatasources(rt *ProjectRuntime, ids []string) []string {
 			seen[id] = true
 			out = append(out, id)
 		}
+	}
+	return out
+}
+
+// datasourceIDs projects a datasource list to its ids, preserving order.
+func datasourceIDs(ds []DatasourceInfo) []string {
+	if len(ds) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, d.ID)
 	}
 	return out
 }

--- a/services/agent/internal/askserve/router_candidates_test.go
+++ b/services/agent/internal/askserve/router_candidates_test.go
@@ -1,0 +1,110 @@
+package askserve
+
+import (
+	"testing"
+
+	commonmodels "github.com/decisionbox-io/decisionbox/libs/go-common/models"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/testutil"
+)
+
+// The routing telemetry already recorded what a turn QUERIED. These pin the
+// separate fact the epic's routing work needs: what the router was OFFERED and
+// what it PICKED.
+//
+// Without the ballot, a connected datasource the router never selects is
+// indistinguishable in the record from one that was correctly irrelevant — so
+// "is the router blind to this source?" has no answer, for every question.
+
+func TestRouter_RecordsBallotAndVerdict(t *testing.T) {
+	whA := testutil.NewMockWarehouseProvider("sales")
+	whB := testutil.NewMockWarehouseProvider("crm")
+	rt := twoDatasourceRuntime(&scriptedProvider{responses: []string{
+		`{"datasources":["wh_b"],"reason":"about CRM users","confidence":0.9}`,
+		`{"query":"select count(*) from crm.users"}`,
+		`{"answer":"done"}`,
+	}}, whA, whB, nil, nil)
+
+	store := runRouted(t, rt, "how many flagged CRM users?")
+	if store.final.Status != commonmodels.AskTurnStatusDone {
+		t.Fatalf("status = %q (%s), want done", store.final.Status, store.final.Error)
+	}
+
+	// Both datasources were on the ballot, even though only one was picked.
+	if got := store.final.RoutingCandidateIDs; len(got) != 2 {
+		t.Fatalf("candidate ids = %v, want both datasources", got)
+	}
+	if !containsStr(store.final.RoutingCandidateIDs, "wh_a") || !containsStr(store.final.RoutingCandidateIDs, "wh_b") {
+		t.Errorf("candidate ids = %v, want to contain wh_a and wh_b", store.final.RoutingCandidateIDs)
+	}
+	if got := store.final.RoutingChosenIDs; len(got) != 1 || got[0] != "wh_b" {
+		t.Errorf("chosen ids = %v, want [wh_b]", got)
+	}
+}
+
+// TestRouter_BallotIsRecordedWhenTheRouterClarifies is the case the ballot
+// exists for: nothing was chosen and nothing was queried, so without the
+// candidate set the record would show only that a question was asked, with no
+// trace of what the router was looking at when it gave up.
+func TestRouter_BallotIsRecordedWhenTheRouterClarifies(t *testing.T) {
+	whA := testutil.NewMockWarehouseProvider("sales")
+	whB := testutil.NewMockWarehouseProvider("crm")
+	rt := twoDatasourceRuntime(&scriptedProvider{responses: []string{
+		`{"clarify":true,"question":"Do you mean ticket sales or CRM accounts?","confidence":0.3}`,
+	}}, whA, whB, nil, nil)
+
+	store := runRouted(t, rt, "show me the users")
+	if store.final.Disposition != commonmodels.AskTurnDispositionClarify {
+		t.Fatalf("disposition = %q, want clarify", store.final.Disposition)
+	}
+	if got := store.final.RoutingCandidateIDs; len(got) != 2 {
+		t.Errorf("candidate ids = %v, want both datasources recorded on a clarify", got)
+	}
+	if got := store.final.RoutingChosenIDs; len(got) != 0 {
+		t.Errorf("chosen ids = %v, want none — the router picked nothing", got)
+	}
+	if !store.final.RoutingClarify {
+		t.Error("RoutingClarify should be true")
+	}
+}
+
+// TestRouter_BallotRecordedEvenWhenAChoiceIsUnknown pins that an id the model
+// invents is not silently laundered into the record: the ballot is what the
+// router was shown, and the verdict is what survived validation.
+func TestRouter_BallotRecordedEvenWhenAChoiceIsUnknown(t *testing.T) {
+	whA := testutil.NewMockWarehouseProvider("sales")
+	whB := testutil.NewMockWarehouseProvider("crm")
+	rt := twoDatasourceRuntime(&scriptedProvider{responses: []string{
+		`{"datasources":["wh_b","wh_does_not_exist"],"reason":"crm plus something","confidence":0.9}`,
+		`{"query":"select count(*) from crm.users"}`,
+		`{"answer":"done"}`,
+	}}, whA, whB, nil, nil)
+
+	store := runRouted(t, rt, "how many flagged CRM users?")
+	if got := store.final.RoutingChosenIDs; len(got) != 1 || got[0] != "wh_b" {
+		t.Errorf("chosen ids = %v, want only the real datasource [wh_b]", got)
+	}
+	if containsStr(store.final.RoutingCandidateIDs, "wh_does_not_exist") {
+		t.Errorf("candidate ids = %v must be the offered set, never a model-invented id",
+			store.final.RoutingCandidateIDs)
+	}
+}
+
+// TestSingleDatasourceTurn_HasNoBallot pins that a turn with no routing
+// decision records none — the fields mean "the router ran and saw this", so
+// filling them on a pinned single-datasource turn would invent a decision that
+// never happened.
+func TestSingleDatasourceTurn_HasNoBallot(t *testing.T) {
+	wh := testutil.NewMockWarehouseProvider("sales")
+	rt := testRuntime(&scriptedProvider{responses: []string{
+		`{"query":"select 1"}`,
+		`{"answer":"done"}`,
+	}}, wh, nil, "")
+
+	store := runRouted(t, rt, "how many sales?")
+	if got := store.final.RoutingCandidateIDs; len(got) != 0 {
+		t.Errorf("candidate ids = %v, want none on a single-datasource turn", got)
+	}
+	if got := store.final.RoutingChosenIDs; len(got) != 0 {
+		t.Errorf("chosen ids = %v, want none on a single-datasource turn", got)
+	}
+}

--- a/services/agent/internal/askserve/turnstore.go
+++ b/services/agent/internal/askserve/turnstore.go
@@ -167,41 +167,7 @@ func (s *turnStore) SetStatus(ctx context.Context, turnID, status string) error 
 // that is already terminal (last-writer-wins is the wrong semantics here).
 func (s *turnStore) Finalize(ctx context.Context, fin TurnFinal) error {
 	now := time.Now()
-	set := bson.M{
-		"status":       fin.Status,
-		"disposition":  fin.Disposition,
-		"answer":       fin.Answer,
-		"model":        fin.Model,
-		"updated_at":   now,
-		"completed_at": now,
-	}
-	if fin.Error != "" {
-		set["error"] = fin.Error
-	}
-	if fin.InputTokens > 0 {
-		set["input_tokens"] = fin.InputTokens
-	}
-	if fin.OutputTokens > 0 {
-		set["output_tokens"] = fin.OutputTokens
-	}
-	if len(fin.RoutedDatasourceIDs) > 0 {
-		set["routed_datasource_ids"] = fin.RoutedDatasourceIDs
-	}
-	if fin.RoutingReason != "" {
-		set["routing_reason"] = fin.RoutingReason
-	}
-	if fin.RoutingConfidence > 0 {
-		set["routing_confidence"] = fin.RoutingConfidence
-	}
-	if len(fin.RoutingCandidateIDs) > 0 {
-		set["routing_candidate_ids"] = fin.RoutingCandidateIDs
-	}
-	if len(fin.RoutingChosenIDs) > 0 {
-		set["routing_chosen_ids"] = fin.RoutingChosenIDs
-	}
-	if fin.RoutingClarify {
-		set["routing_clarify"] = true
-	}
+	set := finalizeUpdate(fin, now)
 	res, err := s.turns.UpdateOne(ctx,
 		bson.M{"_id": fin.TurnID, "status": commonmodels.AskTurnStatusRunning},
 		bson.M{"$set": set},
@@ -295,6 +261,53 @@ func (s *turnStore) GetTurn(ctx context.Context, turnID string) (*commonmodels.A
 		return nil, fmt.Errorf("get ask turn %s: %w", turnID, err)
 	}
 	return &t, nil
+}
+
+// finalizeUpdate builds the $set document for a terminal turn.
+//
+// Extracted from Finalize so it can be tested without a Mongo connection. It is
+// the only place that decides which telemetry survives to the stored record,
+// and every field here is conditional — a zero value is omitted rather than
+// written — so "the field is absent" and "the field was zero" are the same
+// state by design, and a bug that drops a field looks exactly like a turn that
+// had nothing to report.
+func finalizeUpdate(fin TurnFinal, now time.Time) bson.M {
+	set := bson.M{
+		"status":       fin.Status,
+		"disposition":  fin.Disposition,
+		"answer":       fin.Answer,
+		"model":        fin.Model,
+		"updated_at":   now,
+		"completed_at": now,
+	}
+	if fin.Error != "" {
+		set["error"] = fin.Error
+	}
+	if fin.InputTokens > 0 {
+		set["input_tokens"] = fin.InputTokens
+	}
+	if fin.OutputTokens > 0 {
+		set["output_tokens"] = fin.OutputTokens
+	}
+	if len(fin.RoutedDatasourceIDs) > 0 {
+		set["routed_datasource_ids"] = fin.RoutedDatasourceIDs
+	}
+	if fin.RoutingReason != "" {
+		set["routing_reason"] = fin.RoutingReason
+	}
+	if fin.RoutingConfidence > 0 {
+		set["routing_confidence"] = fin.RoutingConfidence
+	}
+	if len(fin.RoutingCandidateIDs) > 0 {
+		set["routing_candidate_ids"] = fin.RoutingCandidateIDs
+	}
+	if len(fin.RoutingChosenIDs) > 0 {
+		set["routing_chosen_ids"] = fin.RoutingChosenIDs
+	}
+	if fin.RoutingClarify {
+		set["routing_clarify"] = true
+	}
+	return set
 }
 
 // TurnFinal carries everything Finalize needs to close out a turn and write

--- a/services/agent/internal/askserve/turnstore.go
+++ b/services/agent/internal/askserve/turnstore.go
@@ -193,6 +193,12 @@ func (s *turnStore) Finalize(ctx context.Context, fin TurnFinal) error {
 	if fin.RoutingConfidence > 0 {
 		set["routing_confidence"] = fin.RoutingConfidence
 	}
+	if len(fin.RoutingCandidateIDs) > 0 {
+		set["routing_candidate_ids"] = fin.RoutingCandidateIDs
+	}
+	if len(fin.RoutingChosenIDs) > 0 {
+		set["routing_chosen_ids"] = fin.RoutingChosenIDs
+	}
 	if fin.RoutingClarify {
 		set["routing_clarify"] = true
 	}
@@ -317,4 +323,10 @@ type TurnFinal struct {
 	RoutingReason     string
 	RoutingConfidence float64
 	RoutingClarify    bool
+	// RoutingCandidateIDs are the datasources the router chose FROM;
+	// RoutingChosenIDs the ones it chose. Both empty when the router did not
+	// run. See the model field docs for why the candidate set is recorded
+	// separately from what the turn queried.
+	RoutingCandidateIDs []string
+	RoutingChosenIDs    []string
 }

--- a/services/agent/internal/askserve/turnstore_finalize_test.go
+++ b/services/agent/internal/askserve/turnstore_finalize_test.go
@@ -1,0 +1,118 @@
+package askserve
+
+import (
+	"testing"
+	"time"
+)
+
+// finalizeUpdate decides which telemetry survives to the stored record, and
+// every field in it is conditional — a zero value is omitted rather than
+// written. That makes "the field is absent" and "the field was zero" the same
+// state, so a bug that drops a field looks exactly like a turn with nothing to
+// report. Nothing covered it before: the persistence path needs Mongo, and the
+// loop tests use a fake store, so the mapping from TurnFinal to the stored
+// document was untested end to end.
+
+func TestFinalizeUpdate_WritesRoutingTelemetry(t *testing.T) {
+	now := time.Now()
+	set := finalizeUpdate(TurnFinal{
+		Status:              "done",
+		Disposition:         "answer",
+		Answer:              "42",
+		Model:               "test-model",
+		InputTokens:         10,
+		OutputTokens:        5,
+		RoutedDatasourceIDs: []string{"wh_b"},
+		RoutingReason:       "about CRM users",
+		RoutingConfidence:   0.9,
+		RoutingCandidateIDs: []string{"wh_a", "wh_b"},
+		RoutingChosenIDs:    []string{"wh_b"},
+	}, now)
+
+	assertStrings(t, set, "routed_datasource_ids", []string{"wh_b"})
+	assertStrings(t, set, "routing_candidate_ids", []string{"wh_a", "wh_b"})
+	assertStrings(t, set, "routing_chosen_ids", []string{"wh_b"})
+
+	if got := set["routing_reason"]; got != "about CRM users" {
+		t.Errorf("routing_reason = %v", got)
+	}
+	if got := set["routing_confidence"]; got != 0.9 {
+		t.Errorf("routing_confidence = %v", got)
+	}
+	if _, ok := set["routing_clarify"]; ok {
+		t.Error("routing_clarify must be omitted when the turn did not clarify")
+	}
+	for _, k := range []string{"status", "disposition", "answer", "model", "updated_at", "completed_at"} {
+		if _, ok := set[k]; !ok {
+			t.Errorf("%s is always written, but is missing", k)
+		}
+	}
+}
+
+// TestFinalizeUpdate_OmitsEmptyTelemetry pins that a turn with no routing
+// decision writes no routing fields at all, rather than empty ones — the
+// fields mean "the router ran and saw this".
+func TestFinalizeUpdate_OmitsEmptyTelemetry(t *testing.T) {
+	set := finalizeUpdate(TurnFinal{Status: "done", Disposition: "answer"}, time.Now())
+
+	for _, k := range []string{
+		"routed_datasource_ids", "routing_reason", "routing_confidence",
+		"routing_candidate_ids", "routing_chosen_ids", "routing_clarify",
+		"error", "input_tokens", "output_tokens",
+	} {
+		if v, ok := set[k]; ok {
+			t.Errorf("%s = %v, want omitted when unset", k, v)
+		}
+	}
+}
+
+// TestFinalizeUpdate_ClarifyRecordsBallotWithoutVerdict pins the shape of the
+// case the ballot exists for: the router weighed datasources and picked none.
+func TestFinalizeUpdate_ClarifyRecordsBallotWithoutVerdict(t *testing.T) {
+	set := finalizeUpdate(TurnFinal{
+		Status:              "done",
+		Disposition:         "clarify",
+		RoutingCandidateIDs: []string{"wh_a", "wh_b"},
+		RoutingClarify:      true,
+	}, time.Now())
+
+	assertStrings(t, set, "routing_candidate_ids", []string{"wh_a", "wh_b"})
+	if _, ok := set["routing_chosen_ids"]; ok {
+		t.Error("routing_chosen_ids must be omitted when the router chose nothing")
+	}
+	if set["routing_clarify"] != true {
+		t.Errorf("routing_clarify = %v, want true", set["routing_clarify"])
+	}
+}
+
+func TestFinalizeUpdate_WritesErrorAndTokens(t *testing.T) {
+	set := finalizeUpdate(TurnFinal{
+		Status: "failed", Error: "boom", InputTokens: 3, OutputTokens: 4,
+	}, time.Now())
+
+	if set["error"] != "boom" {
+		t.Errorf("error = %v, want %q", set["error"], "boom")
+	}
+	if set["input_tokens"] != 3 || set["output_tokens"] != 4 {
+		t.Errorf("tokens = %v / %v, want 3 / 4", set["input_tokens"], set["output_tokens"])
+	}
+}
+
+func assertStrings(t *testing.T, set map[string]interface{}, key string, want []string) {
+	t.Helper()
+	got, ok := set[key].([]string)
+	if !ok {
+		t.Errorf("%s = %v (%T), want []string", key, set[key], set[key])
+		return
+	}
+	if len(got) != len(want) {
+		t.Errorf("%s = %v, want %v", key, got, want)
+		return
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s = %v, want %v", key, got, want)
+			return
+		}
+	}
+}


### PR DESCRIPTION
Closes #356. Part of #163 (epic). Targets the bridge branch `feat/non-sql-datasources`.

## What the issue asked for, and what the code actually supports

The issue listed four event kinds. Tracing each against the code first:

| Event | State | Where it belongs |
|---|---|---|
| **Routing decisions** | Partly present — reason, confidence, clarify and the queried datasources are already recorded and persisted | **This PR completes it** |
| Refused hops | **No call site exists** — nothing refuses a hop today | The join-key / anchoring work, which introduces refusal |
| Dropped filters | **No call site exists** — nothing drops a filter today | The adapter + join-key work |
| Source quality flags | **No call site exists** — no source reports sampling/thresholding today | The GA4 adapter, which is the first source that can report one |

Emitting event types for three concepts that do not exist would mean writing instrumentation with no producer, which the issues that introduce those concepts would then have to rework to fit what they actually learn. Those three are left to land with the code that can raise them. Recorded here so the omission is a decision rather than an oversight.

## The gap that is real, and fixable now

Routing telemetry records the router's reason, confidence, clarify flag, and the datasources the turn went on to **query**. It does not record what the router chose **from**.

That distinction is load-bearing for this epic. Today, a turn that ignored a connected datasource and a turn where that datasource was correctly irrelevant produce **identical records** — both just show the other datasource being queried. So "the router never picks this source, for any question" is invisible in the data, and stays invisible however many turns you look at.

That is precisely the failure the epic flags as must-fix #4: a source whose retrieval evidence is weak contributes nothing to routing, for every question, and nothing errors. It is also what a routing evaluation set has to measure against.

## The change

Two fields — the datasources the router chose **from** (the ballot) and the ones it **chose** (the verdict) — carried through `TurnFinal` to the persisted turn record, alongside the existing fields.

Four details, each pinned by a test:

- The **ballot is recorded before the model is asked**, so a router error leaves a record of what it was looking at rather than nothing at all.
- On a **clarify**, the ballot is recorded with an empty verdict. This is the case it matters most: nothing is chosen and nothing is queried, so without it the record shows only that a question was asked.
- The **verdict is the post-validation set**, so an id the model invents never reaches the record.
- A turn with **no routing decision records neither** — the fields mean "the router ran and saw this", and filling them on a pinned single-datasource turn would invent a decision that never happened.

## Testing

`go test ./...` green for `services/agent` and `libs/go-common`; `golangci-lint run` 0 issues on both; `codex review` no findings.

Verified non-vacuous by mutation: dropping the ballot assignment fails the new tests.
