### PR TITLE
feat(warehouse): resolve a datasource's effective anchoring, demotion only

### DIFF
--- a/libs/go-common/warehouse/anchoring_test.go
+++ b/libs/go-common/warehouse/anchoring_test.go
@@ -1,11 +1,21 @@
 package warehouse
 
-import "testing"
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+// probeSeq keeps each probe registration unique. The registry is package-global
+// and RegisterWithMeta panics on a duplicate name, so fixed slugs would panic
+// on the second iteration under `go test -count=2`.
+var probeSeq atomic.Int32
 
 // anchoringProbe registers a provider with a given CanAnchor value under a
 // unique slug, so these tests exercise the real registry rather than a stub.
-func anchoringProbe(t *testing.T, slug string, canAnchor bool) string {
+func anchoringProbe(t *testing.T, name string, canAnchor bool) string {
 	t.Helper()
+	slug := fmt.Sprintf("%s_%d", name, probeSeq.Add(1))
 	RegisterWithMeta(slug, func(ProviderConfig) (Provider, error) {
 		return &mockWarehouseProvider{}, nil
 	}, ProviderMeta{

--- a/libs/go-common/warehouse/anchoring_test.go
+++ b/libs/go-common/warehouse/anchoring_test.go
@@ -1,0 +1,75 @@
+package warehouse
+
+import "testing"
+
+// anchoringProbe registers a provider with a given CanAnchor value under a
+// unique slug, so these tests exercise the real registry rather than a stub.
+func anchoringProbe(t *testing.T, slug string, canAnchor bool) string {
+	t.Helper()
+	RegisterWithMeta(slug, func(ProviderConfig) (Provider, error) {
+		return &mockWarehouseProvider{}, nil
+	}, ProviderMeta{
+		Name:       slug,
+		Dialect:    "Probe SQL",
+		Capability: Capability{CanAnchor: Anchoring(canAnchor)},
+	})
+	return slug
+}
+
+func TestEffectiveAnchoring(t *testing.T) {
+	anchor := anchoringProbe(t, "probe_anchor_yes", true)
+	enrich := anchoringProbe(t, "probe_anchor_no", false)
+
+	tests := []struct {
+		name     string
+		provider string
+		override *bool
+		want     bool
+	}{
+		{"anchoring provider, no override", anchor, nil, true},
+		{"anchoring provider demoted", anchor, Anchoring(false), false},
+		{"anchoring provider explicitly kept", anchor, Anchoring(true), true},
+
+		// The ceiling: a provider that cannot anchor stays non-anchoring
+		// whatever the datasource says. Promotion would assert something about
+		// the data that is not true.
+		{"non-anchoring provider, no override", enrich, nil, false},
+		{"non-anchoring provider cannot be promoted", enrich, Anchoring(true), false},
+		{"non-anchoring provider demoted stays demoted", enrich, Anchoring(false), false},
+
+		// Unregistered providers resolve to anchoring — see the doc comment.
+		{"unregistered provider", "probe_never_registered", nil, true},
+		{"unregistered provider demoted", "probe_never_registered", Anchoring(false), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EffectiveAnchoring(tc.provider, tc.override); got != tc.want {
+				t.Errorf("EffectiveAnchoring(%q, %v) = %v, want %v", tc.provider, tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnchoringOverrideAllowed pins that promotion is refused rather than
+// silently ignored. Storing a value that does nothing would leave the user
+// believing they had changed something.
+func TestAnchoringOverrideAllowed(t *testing.T) {
+	anchor := anchoringProbe(t, "probe_allow_yes", true)
+	enrich := anchoringProbe(t, "probe_allow_no", false)
+
+	if !AnchoringOverrideAllowed(anchor, true) {
+		t.Error("keeping an anchoring provider anchoring must be allowed")
+	}
+	if !AnchoringOverrideAllowed(anchor, false) {
+		t.Error("demoting an anchoring provider must be allowed")
+	}
+	if AnchoringOverrideAllowed(enrich, true) {
+		t.Error("promoting a non-anchoring provider must be refused")
+	}
+	if !AnchoringOverrideAllowed(enrich, false) {
+		t.Error("demotion is always legal, including for a provider that already cannot anchor")
+	}
+	if !AnchoringOverrideAllowed("probe_never_registered", true) {
+		t.Error("an unregistered provider must not be treated as non-anchoring")
+	}
+}

--- a/libs/go-common/warehouse/capability.go
+++ b/libs/go-common/warehouse/capability.go
@@ -212,3 +212,46 @@ func (m ProviderMeta) Language() string {
 	}
 	return "SQL"
 }
+
+// EffectiveAnchoring resolves whether one connected datasource may carry a
+// project by itself, from its provider's capability and the per-datasource
+// override.
+//
+// The two inputs answer different questions and compose one way only.
+// `CanAnchor` on the provider is what a source of this TYPE is capable of, and
+// it is a ceiling: a provider that cannot anchor can never be promoted, because
+// promotion would be a claim about the data that isn't true. The override is
+// what THIS customer's datasource is being used as, and it may only demote —
+// saying "our warehouse already holds this, treat it as enrichment" is a
+// legitimate statement about where the records actually live.
+//
+// override nil means "not set", which resolves to the provider's capability.
+//
+// An unregistered provider resolves to anchoring. That is the safe reading
+// rather than the permissive one: a binary that has not linked a provider
+// cannot construct it either, so such a datasource cannot be connected at all —
+// the project is broken in an obvious way long before anchoring is consulted.
+// The alternative default would make anchoring depend on which providers a
+// binary happens to blank-import, which is invisible at the call site.
+func EffectiveAnchoring(provider string, override *bool) bool {
+	if meta, ok := GetProviderMeta(provider); ok && !meta.Anchors() {
+		return false
+	}
+	if override != nil {
+		return *override
+	}
+	return true
+}
+
+// AnchoringOverrideAllowed reports whether `want` is a legal override for a
+// datasource of this provider type. Only demotion is legal; promoting a
+// provider that declares CanAnchor false is refused rather than ignored, so the
+// caller can tell the user why instead of silently storing a value that does
+// nothing.
+func AnchoringOverrideAllowed(provider string, want bool) bool {
+	if !want {
+		return true // demotion is always legal
+	}
+	meta, ok := GetProviderMeta(provider)
+	return !ok || meta.Anchors()
+}

--- a/services/agent/internal/models/project.go
+++ b/services/agent/internal/models/project.go
@@ -172,6 +172,17 @@ type WarehouseConfig struct {
 
 	FilterField string            `bson:"filter_field,omitempty" json:"filter_field,omitempty"`
 	FilterValue string            `bson:"filter_value,omitempty" json:"filter_value,omitempty"`
+	// Anchoring is the per-datasource override of whether this source may
+	// carry the project by itself. Nil means "not set" — the provider's own
+	// capability decides. It may only DEMOTE: a provider that declares it
+	// cannot anchor is never promoted by this field. Resolve it with
+	// warehouse.EffectiveAnchoring(Provider, Anchoring) rather than reading it
+	// directly, so the provider ceiling is always applied.
+	//
+	// Deliberately not called "primary": a project's primary datasource is a
+	// selection among the ones connected, which is a different concept already
+	// in use here.
+	Anchoring *bool `bson:"anchoring,omitempty" json:"anchoring,omitempty"`
 	Config      map[string]string `bson:"config,omitempty" json:"config,omitempty"` // provider-specific: workgroup, database, region, cluster_id, etc.
 }
 

--- a/services/api/internal/handler/anchoring_test.go
+++ b/services/api/internal/handler/anchoring_test.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/api/models"
+)
+
+// probeSeq keeps each registration unique: the registry is package-global and
+// RegisterWithMeta panics on a duplicate name, so fixed slugs would panic on
+// the second iteration under `go test -count=2`.
+var probeSeq atomic.Int32
+
+func anchoringProbe(t *testing.T, name string, canAnchor bool) string {
+	t.Helper()
+	slug := fmt.Sprintf("%s_%d", name, probeSeq.Add(1))
+	gowarehouse.RegisterWithMeta(slug, func(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) {
+		return nil, fmt.Errorf("probe provider is not constructible")
+	}, gowarehouse.ProviderMeta{
+		Name:       slug,
+		Dialect:    "Probe SQL",
+		Capability: gowarehouse.Capability{CanAnchor: gowarehouse.Anchoring(canAnchor)},
+	})
+	return slug
+}
+
+// A promotion must be REFUSED, not stored. Storing it is the worse failure:
+// EffectiveAnchoring applies the provider as a ceiling and ignores the value,
+// so the setting reads back as applied while changing nothing — and the user
+// believes an enrichment-only source can now carry the project alone.
+func TestRejectAnchoringPromotion(t *testing.T) {
+	anchor := anchoringProbe(t, "probe_api_anchor", true)
+	enrich := anchoringProbe(t, "probe_api_enrich", false)
+
+	tests := []struct {
+		name       string
+		warehouses []models.WarehouseConfig
+		wantOK     bool
+	}{
+		{
+			name:       "no override is always fine",
+			warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: enrich}},
+			wantOK:     true,
+		},
+		{
+			name:       "demoting an anchoring provider is legal",
+			warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: anchor, Anchoring: gowarehouse.Anchoring(false)}},
+			wantOK:     true,
+		},
+		{
+			name:       "demoting a non-anchoring provider is legal (a no-op, but true)",
+			warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: enrich, Anchoring: gowarehouse.Anchoring(false)}},
+			wantOK:     true,
+		},
+		{
+			name:       "keeping an anchoring provider anchoring is legal",
+			warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: anchor, Anchoring: gowarehouse.Anchoring(true)}},
+			wantOK:     true,
+		},
+		{
+			name:       "promoting a non-anchoring provider is refused",
+			warehouses: []models.WarehouseConfig{{ID: "wh_ga", Provider: enrich, Anchoring: gowarehouse.Anchoring(true)}},
+			wantOK:     false,
+		},
+		{
+			name: "one bad entry among good ones is still refused",
+			warehouses: []models.WarehouseConfig{
+				{ID: "wh_1", Provider: anchor},
+				{ID: "wh_ga", Provider: enrich, Anchoring: gowarehouse.Anchoring(true)},
+			},
+			wantOK: false,
+		},
+		{
+			name:       "an entry with no provider is skipped rather than rejected",
+			warehouses: []models.WarehouseConfig{{ID: "wh_blank", Anchoring: gowarehouse.Anchoring(true)}},
+			wantOK:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			got := rejectAnchoringPromotion(rec, tc.warehouses)
+
+			if got != tc.wantOK {
+				t.Fatalf("rejectAnchoringPromotion = %v, want %v", got, tc.wantOK)
+			}
+			if tc.wantOK {
+				if rec.Code != http.StatusOK {
+					t.Errorf("wrote status %d on an allowed request", rec.Code)
+				}
+				return
+			}
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			}
+			// The message must name the offending datasource and say which
+			// direction is legal — a bare "invalid" would leave the user with
+			// no way to tell what to change.
+			body := rec.Body.String()
+			if !strings.Contains(body, "wh_ga") {
+				t.Errorf("error body does not name the offending datasource: %s", body)
+			}
+			if !strings.Contains(body, "never on") {
+				t.Errorf("error body does not state that only demotion is legal: %s", body)
+			}
+		})
+	}
+}

--- a/services/api/internal/handler/anchoring_test.go
+++ b/services/api/internal/handler/anchoring_test.go
@@ -23,9 +23,15 @@ func anchoringProbe(t *testing.T, name string, canAnchor bool) string {
 	gowarehouse.RegisterWithMeta(slug, func(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) {
 		return nil, fmt.Errorf("probe provider is not constructible")
 	}, gowarehouse.ProviderMeta{
-		Name:       slug,
-		Dialect:    "Probe SQL",
-		Capability: gowarehouse.Capability{CanAnchor: gowarehouse.Anchoring(canAnchor)},
+		Name:    slug,
+		Dialect: "Probe SQL",
+		// The registry is process-global, so a probe registered here is visible
+		// to every other test in this package — including the invariant that
+		// every registered warehouse provider declares pricing. A probe that
+		// skipped it would fail that test rather than this one, from a file
+		// that has nothing to do with pricing.
+		DefaultPricing: &gowarehouse.WarehousePricing{CostModel: "per_query"},
+		Capability:     gowarehouse.Capability{CanAnchor: gowarehouse.Anchoring(canAnchor)},
 	})
 	return slug
 }

--- a/services/api/internal/handler/projects.go
+++ b/services/api/internal/handler/projects.go
@@ -16,6 +16,7 @@ import (
 	"github.com/decisionbox-io/decisionbox/libs/go-common/policy"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/secrets"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/telemetry"
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/api/database"
 	apilog "github.com/decisionbox-io/decisionbox/services/api/internal/log"
 	"github.com/decisionbox-io/decisionbox/services/api/managedai"
@@ -285,6 +286,10 @@ func (h *ProjectsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !rejectAnchoringPromotion(w, p.EffectiveWarehouses()) {
+		return
+	}
+
 	// Multi-warehouse projects cannot be configured through this create path:
 	// it neither enforces the multi_warehouse_enabled feature gate nor reserves
 	// data-source quota per warehouse (each warehouse bills as one data source,
@@ -544,6 +549,9 @@ func (h *ProjectsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// the value above was an unchanged echo, and EffectiveWarehouses() ignores
 	// the legacy field anyway.
 	if incoming.Warehouse.Provider != "" && len(existing.Warehouses) == 0 {
+		if !rejectAnchoringPromotion(w, []models.WarehouseConfig{incoming.Warehouse}) {
+			return
+		}
 		existing.Warehouse = incoming.Warehouse
 	}
 	if incoming.LLM.Provider != "" {
@@ -711,4 +719,27 @@ func (h *ProjectsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		"deleted":         id,
 		"secrets_skipped": secretsSkipped,
 	})
+}
+
+// rejectAnchoringPromotion refuses a request that tries to promote a datasource
+// whose provider declares it cannot anchor, writing a 400 and returning false.
+//
+// The override may only DEMOTE. Storing a promotion instead of refusing it
+// would be the worse failure: EffectiveAnchoring applies the provider as a
+// ceiling and would ignore the stored value, so the setting would read back as
+// applied while changing nothing — and the user would believe their
+// enrichment-only source had been made able to carry the project.
+func rejectAnchoringPromotion(w http.ResponseWriter, whs []models.WarehouseConfig) bool {
+	for _, wh := range whs {
+		if wh.Anchoring == nil || wh.Provider == "" {
+			continue
+		}
+		if !gowarehouse.AnchoringOverrideAllowed(wh.Provider, *wh.Anchoring) {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf(
+				"data source %q uses provider %q, which cannot anchor a project; `anchoring` may be turned off for a source but never on",
+				wh.ID, wh.Provider))
+			return false
+		}
+	}
+	return true
 }

--- a/services/api/models/project.go
+++ b/services/api/models/project.go
@@ -191,6 +191,17 @@ type WarehouseConfig struct {
 	Location    string            `bson:"location,omitempty" json:"location,omitempty"`
 	FilterField string            `bson:"filter_field,omitempty" json:"filter_field,omitempty"`
 	FilterValue string            `bson:"filter_value,omitempty" json:"filter_value,omitempty"`
+	// Anchoring is the per-datasource override of whether this source may
+	// carry the project by itself. Nil means "not set" — the provider's own
+	// capability decides. It may only DEMOTE: a provider that declares it
+	// cannot anchor is never promoted by this field. Resolve it with
+	// warehouse.EffectiveAnchoring(Provider, Anchoring) rather than reading it
+	// directly, so the provider ceiling is always applied.
+	//
+	// Deliberately not called "primary": a project's primary datasource is a
+	// selection among the ones connected, which is a different concept already
+	// in use here.
+	Anchoring *bool `bson:"anchoring,omitempty" json:"anchoring,omitempty"`
 	Config      map[string]string `bson:"config,omitempty" json:"config,omitempty"` // provider-specific: workgroup, database, region, cluster_id, etc.
 }
 


### PR DESCRIPTION
Part of #163 (epic), the platform half of the anchoring work (decisionbox-io/decisionbox-enterprise#242, W6). Targets the bridge branch `feat/non-sql-datasources`.

This is **resolution only**. Enforcement — refusing a non-anchoring source as a project's only datasource, and refusing standalone Discovery — lands next in the enterprise handler, on top of this.

## The rule

Anchoring answers two different questions that compose one way only:

- **`CanAnchor`** (provider) — what a source of this *type* is capable of. Shipped with the capability descriptor.
- **`Anchoring`** (datasource) — what *this customer's* source is being used as. Added here.

`EffectiveAnchoring(provider, override)` applies the provider as a **ceiling**:

| Provider | Override | Effective |
|---|---|---|
| anchors | unset | ✅ |
| anchors | `false` | ❌ (demoted) |
| anchors | `true` | ✅ |
| **cannot anchor** | unset | ❌ |
| **cannot anchor** | `true` | ❌ — **promotion never applies** |
| cannot anchor | `false` | ❌ |

Promotion is refused because it asserts something about the data that isn't true, and the standalone Discovery run it would license produces exactly the shallow output this feature exists to avoid. Demotion is always legal — "our warehouse already holds this, treat it as enrichment" is a true statement about where the records live.

`AnchoringOverrideAllowed` exists so a caller can **refuse** a promotion rather than store a value that silently does nothing, leaving the user believing they changed something.

## An unregistered provider resolves to anchoring

Deliberate, and the safer of the two options. A binary that has not linked a provider cannot construct it either, so such a datasource cannot be connected at all — the project is broken visibly, long before anchoring is consulted.

The opposite default would make anchoring depend on which providers a binary happens to blank-import: a build missing an import would quietly treat a legitimate warehouse as enrichment-only, with nothing at the call site to suggest why.

## The field

`WarehouseConfig.Anchoring *bool` on both the API and agent models. Nil means "not set" — the provider decides.

Deliberately **not** called `primary`: a project's primary datasource is a selection among those connected, which is a different concept already in use in this struct.

Callers resolve via `warehouse.EffectiveAnchoring(Provider, Anchoring)` rather than reading the field, so the provider ceiling is always applied. The doc comment on the field says so.

## Testing

Tests register real providers in the registry (both anchoring and not) rather than stubbing the lookup, so the ceiling is exercised through the same path production uses. Every row of the table above is a case.

`go test ./...` green for `libs/go-common`, `services/api`, `services/agent`; `golangci-lint run` 0 issues on all three.
