### PR TITLE
refactor(warehouse): share the dataset requirement with everything that configures a source

### DIFF
--- a/libs/go-common/warehouse/shape.go
+++ b/libs/go-common/warehouse/shape.go
@@ -1,0 +1,26 @@
+package warehouse
+
+// RequiresDataset reports whether a provider needs a dataset configured.
+//
+// Everything table-shaped does — a dataset is where its tables live. A
+// cube-shaped source has none, so demanding one makes it unconfigurable, or
+// forces an operator to invent a value that means nothing and then wonder why
+// it is ignored.
+//
+// An unregistered slug requires one. That default matters as much as the cube
+// case: it is what every provider needed before shape existed, and the
+// opposite default would silently drop the check for a real warehouse whose
+// provider a binary happens not to link.
+//
+// This lives beside the capability descriptor rather than at a call site
+// because the question is asked wherever a datasource is configured — by the
+// agent when it builds a provider, and by whatever validates the request that
+// created it. Two copies would be two chances to disagree about whether a
+// source is configurable at all.
+func RequiresDataset(providerSlug string) bool {
+	meta, ok := GetProviderMeta(providerSlug)
+	if !ok {
+		return true
+	}
+	return meta.EffectiveShape() != ShapeCube
+}

--- a/libs/go-common/warehouse/shape_test.go
+++ b/libs/go-common/warehouse/shape_test.go
@@ -1,0 +1,47 @@
+package warehouse
+
+import (
+	"testing"
+)
+
+// shapeStubFactory satisfies the registry's factory signature without doing
+// anything — registration only needs a non-nil factory.
+func shapeStubFactory(ProviderConfig) (Provider, error) { return nil, nil }
+
+func init() {
+	RegisterWithMeta("shape-test-tabular", shapeStubFactory, ProviderMeta{
+		Name: "Tabular test source",
+	})
+	RegisterWithMeta("shape-test-cube", shapeStubFactory, ProviderMeta{
+		Name:       "Cube test source",
+		Capability: Capability{Shape: ShapeCube},
+	})
+}
+
+// TestRequiresDataset decides whether a datasource can be configured at all.
+// A cube-shaped source has no datasets, so demanding one makes it
+// unconfigurable — or forces an operator to invent a value that means nothing
+// and then wonder why it is ignored.
+//
+// The default matters as much as the cube case: an unregistered slug must
+// still require a dataset, because that is what every provider needed before
+// shape existed and a wrong default here would silently drop the check for
+// real warehouses.
+func TestRequiresDataset(t *testing.T) {
+	tests := []struct {
+		name, provider string
+		want           bool
+	}{
+		{name: "tabular source needs a dataset", provider: "shape-test-tabular", want: true},
+		{name: "cube source does not", provider: "shape-test-cube", want: false},
+		{name: "unregistered slug still needs one", provider: "not-registered", want: true},
+		{name: "empty slug still needs one", provider: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RequiresDataset(tt.provider); got != tt.want {
+				t.Errorf("RequiresDataset(%q) = %v, want %v", tt.provider, got, tt.want)
+			}
+		})
+	}
+}

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -291,18 +291,6 @@ func warehouseIDOrDefault(wh models.WarehouseConfig) string {
 	return wh.ID
 }
 
-// requiresDataset reports whether a provider needs a dataset configured.
-// Everything table-shaped does — a dataset is where its tables live. A
-// cube-shaped source has none, and an unregistered slug is treated as
-// table-shaped, which is what every provider was before shape existed.
-func requiresDataset(providerSlug string) bool {
-	meta, ok := gowarehouse.GetProviderMeta(providerSlug)
-	if !ok {
-		return true
-	}
-	return meta.EffectiveShape() != gowarehouse.ShapeCube
-}
-
 func initWarehouseProvider(ctx context.Context, project *models.Project, warehouseID string, secretProvider gosecrets.Provider, projectID string) (gowarehouse.Provider, error) {
 	wh, ok := project.WarehouseByID(warehouseID)
 	if !ok || wh.Provider == "" {
@@ -315,7 +303,7 @@ func initWarehouseProvider(ctx context.Context, project *models.Project, warehou
 	// invent a value that means nothing. The shape is declared at provider
 	// registration, so this needs no connection and no credentials.
 	datasets := wh.Datasets
-	if len(datasets) == 0 && requiresDataset(wh.Provider) {
+	if len(datasets) == 0 && gowarehouse.RequiresDataset(wh.Provider) {
 		return nil, fmt.Errorf("no datasets configured in project")
 	}
 

--- a/services/agent/agentserver/dataset_requirement_test.go
+++ b/services/agent/agentserver/dataset_requirement_test.go
@@ -1,49 +1,40 @@
 package agentserver
 
 import (
+	"context"
+	"strings"
 	"testing"
 
-	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
 
-// stubProvider satisfies the registry's factory signature without doing
-// anything — registration only needs a non-nil factory.
-func stubFactory(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) { return nil, nil }
-
-func init() {
-	gowarehouse.RegisterWithMeta("test-tabular-source", stubFactory, gowarehouse.ProviderMeta{
-		Name: "Tabular test source",
-	})
-	gowarehouse.RegisterWithMeta("test-cube-source", stubFactory, gowarehouse.ProviderMeta{
-		Name:       "Cube test source",
-		Capability: gowarehouse.Capability{Shape: gowarehouse.ShapeCube},
-	})
-}
-
-// TestRequiresDataset decides whether a datasource can be configured at all.
-// A cube-shaped source has no datasets, so demanding one makes it
-// unconfigurable — or forces an operator to invent a value that means nothing
-// and then wonder why it is ignored.
-//
-// The default matters as much as the cube case: an unregistered slug must
-// still require a dataset, because that is what every provider needed before
-// shape existed and a wrong default here would silently drop the check for
-// real warehouses.
-func TestRequiresDataset(t *testing.T) {
-	tests := []struct {
-		name, provider string
-		want           bool
-	}{
-		{name: "tabular source needs a dataset", provider: "test-tabular-source", want: true},
-		{name: "cube source does not", provider: "test-cube-source", want: false},
-		{name: "unregistered slug still needs one", provider: "not-registered", want: true},
-		{name: "empty slug still needs one", provider: "", want: true},
+// initWarehouseProvider is where the dataset requirement actually bites: a
+// source configured without one is refused before a provider is constructed.
+// The shared helper can be correct and this call site still let a
+// dataset-less warehouse through, or refuse a cube source that legitimately
+// has none — which is the failure that made a cube source unconfigurable in
+// the first place.
+func TestInitWarehouseProvider_DatasetRequirementFollowsShape(t *testing.T) {
+	project := func(provider string, datasets []string) *models.Project {
+		return &models.Project{
+			ID:         "p1",
+			Warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: provider, Datasets: datasets}},
+		}
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := requiresDataset(tt.provider); got != tt.want {
-				t.Errorf("requiresDataset(%q) = %v, want %v", tt.provider, got, tt.want)
-			}
-		})
-	}
+
+	t.Run("a table-shaped source without a dataset is refused", func(t *testing.T) {
+		_, err := initWarehouseProvider(context.Background(), project("test-tabular-source", nil), "wh_1", &fakeSecretProvider{}, "p1")
+		if err == nil || !strings.Contains(err.Error(), "no datasets configured") {
+			t.Fatalf("err = %v, want a missing-dataset refusal", err)
+		}
+	})
+
+	t.Run("a cube source without a dataset gets past the requirement", func(t *testing.T) {
+		// Whatever construction then does, the assertion is that the dataset
+		// check did not refuse it: a cube source has no datasets to give.
+		_, err := initWarehouseProvider(context.Background(), project("test-cube-source", nil), "wh_1", &fakeSecretProvider{}, "p1")
+		if err != nil && strings.Contains(err.Error(), "no datasets configured") {
+			t.Fatalf("a source with no datasets was asked for one: %v", err)
+		}
+	})
 }

--- a/services/agent/agentserver/shape_stubs_test.go
+++ b/services/agent/agentserver/shape_stubs_test.go
@@ -1,0 +1,25 @@
+package agentserver
+
+import (
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+)
+
+// Shape-declaring stub providers for this package's tests. Registration only
+// needs a non-nil factory; nothing here is ever constructed.
+//
+// They live in their own file because more than one test reads them, and the
+// registry is process-global: a package whose stubs are registered from
+// whichever test file happened to need them first breaks the moment that file
+// is the one that moves.
+
+func shapeStubFactory(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) { return nil, nil }
+
+func init() {
+	gowarehouse.RegisterWithMeta("test-tabular-source", shapeStubFactory, gowarehouse.ProviderMeta{
+		Name: "Tabular test source",
+	})
+	gowarehouse.RegisterWithMeta("test-cube-source", shapeStubFactory, gowarehouse.ProviderMeta{
+		Name:       "Cube test source",
+		Capability: gowarehouse.Capability{Shape: gowarehouse.ShapeCube},
+	})
+}


### PR DESCRIPTION
## Why

*"Does this source need a dataset configured?"* is asked wherever a datasource is configured — by the agent when it builds a provider, and by whatever validates the request that created it in the first place. It lived **unexported inside the agent**, so the second caller has no way to ask and has to guess.

Guessing has a wrong answer in each direction, and both are quiet:

- **Demand one from a source that has none** → the source is unconfigurable, or an operator invents a value that means nothing and then wonders why it is ignored.
- **Drop the demand** → a real warehouse is configurable with nothing to query, and it surfaces much later as an empty index.

Two copies of this rule would be two chances to disagree about whether a source can be configured at all.

## What changed

`requiresDataset` moves from `agentserver` to **`warehouse.RequiresDataset`**, beside the capability descriptor it reads. No behaviour change: same registry lookup, same defaults, and the agent's own call site now goes through it.

The default is the part worth keeping an eye on — an **unregistered slug still requires a dataset**. That is what every provider needed before shape existed, and the opposite default would silently drop the check for a real warehouse whose provider a binary happens not to link.

The test moves with the function. Its stub provider registrations stay in the agent package but in **a file of their own**: the registry is process-global and a second test there (`TestProjectNeedsBlurbs`) reads the same slugs, so a package whose stubs live in whichever test file first needed them breaks the moment that file moves — which is exactly what happened while writing this, and is why the file exists.

## Verification

- `make build`, `make test-go`, `make lint-go`, `make lint-docs` — clean. The one pre-existing failure, `libs/go-common/mongodb TestNewClient_UnreachableHost`, is an environment artefact (it expects `localhost:27099` to be unreachable; something in this container listens on it), untouched by this branch and failing identically on the base commit.
- `TestRequiresDataset` moves to the warehouse package, covering the cube case, the table case, and both flavours of unregistered slug.
- **New: `TestInitWarehouseProvider_DatasetRequirementFollowsShape`** — the call site had no coverage at all, so the requirement could be deleted from it, or applied to every source regardless of shape, without a single failure. Both of those are now caught.
- **5 mutations, all killed**, including: an unregistered provider no longer needing a dataset, a cube source being asked for one, and the two call-site mutants the new test exists for.

## Scope

This unblocks a follow-up in the enterprise data-source routes, which reject any datasource configured without a dataset and so cannot currently accept a source that has none.

— Co-coded with Jale 🤖
