### PR TITLE
feat(askserve): let a turn declare what it joined two datasources on (#252 W5)

### DIFF
--- a/libs/go-common/agentplugin/joinkey.go
+++ b/libs/go-common/agentplugin/joinkey.go
@@ -1,0 +1,117 @@
+package agentplugin
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// A cross-datasource answer is assembled in hops: query one datasource, then
+// filter another by values read out of that result. The hop is only sound if
+// the field those values came from identifies the same things in both
+// datasources — an order id that is an order id on both sides, not an order id
+// on one and a session id on the other. Nothing in the query text says which of
+// those it is, and the agent cannot tell them apart by looking.
+//
+// The knowledge of which fields bind two datasources is produced when a
+// datasource is connected, by a component that reads both sides' fields. That
+// component is not part of this repository, so this registry is the seam it
+// plugs into: with a validator wired, a declared join key is checked; with none
+// wired, the answer is "cannot tell", never "fine".
+
+// JoinKeyRequest asks whether Field, as observed on the source datasource,
+// binds that datasource to the target one.
+type JoinKeyRequest struct {
+	ProjectID string
+	// SourceDatasourceID is the datasource the values were read FROM.
+	SourceDatasourceID string
+	// TargetDatasourceID is the datasource now being filtered by those values.
+	TargetDatasourceID string
+	// Field is the field name as it appeared in the source result.
+	Field string
+}
+
+// JoinKeyVerdict is a validator's answer.
+//
+// Verified is deliberately one-sided: true means a report positively names this
+// field as a key binding the two datasources. False means only that nothing
+// established it — an absent report, an unindexed datasource and a report that
+// lists other keys all land here, and none of them proves the join is wrong.
+// Detail says which, in words a model can act on, and is what the turn shows
+// instead of a verdict it has not earned.
+type JoinKeyVerdict struct {
+	Verified bool
+	Detail   string
+}
+
+// JoinKeyValidatorFunc answers a JoinKeyRequest. An error means the validator
+// could not reach its evidence; callers must treat that as "cannot tell" and
+// carry on, never as a refusal — a report being unreachable is not a reason to
+// fail a query the user asked for.
+type JoinKeyValidatorFunc func(ctx context.Context, req JoinKeyRequest) (JoinKeyVerdict, error)
+
+var (
+	joinKeyValidatorMu   sync.RWMutex
+	joinKeyValidator     JoinKeyValidatorFunc
+	joinKeyValidatorName string
+)
+
+// RegisterJoinKeyValidator registers fn as THE join-key validator. Plugins call
+// this from init() with a blank import. Empty name or nil fn panics, as does a
+// second registration: unlike the filter registries, which compose in order,
+// there is no meaningful way to combine two answers to "is this a join key" —
+// picking one silently would make the verdict depend on link order.
+func RegisterJoinKeyValidator(name string, fn JoinKeyValidatorFunc) {
+	if name == "" {
+		panic("agentplugin: RegisterJoinKeyValidator called with empty name")
+	}
+	if fn == nil {
+		panic(fmt.Sprintf("agentplugin: RegisterJoinKeyValidator %q called with nil fn", name))
+	}
+	joinKeyValidatorMu.Lock()
+	defer joinKeyValidatorMu.Unlock()
+	if joinKeyValidator != nil {
+		panic(fmt.Sprintf("agentplugin: JoinKeyValidator %q already registered (%q)", name, joinKeyValidatorName))
+	}
+	joinKeyValidator = fn
+	joinKeyValidatorName = name
+}
+
+// ValidateJoinKey asks the registered validator about req.
+//
+// With no validator wired it returns an unverified verdict and no error, so
+// callers need no separate "is one configured" branch: the honest answer to a
+// question nothing can answer is the same as the honest answer to a question
+// answered "not established".
+func ValidateJoinKey(ctx context.Context, req JoinKeyRequest) (JoinKeyVerdict, error) {
+	joinKeyValidatorMu.RLock()
+	fn, name := joinKeyValidator, joinKeyValidatorName
+	joinKeyValidatorMu.RUnlock()
+
+	if fn == nil {
+		return JoinKeyVerdict{Detail: "this deployment has no join-key report to check it against"}, nil
+	}
+	v, err := fn(ctx, req)
+	if err != nil {
+		return JoinKeyVerdict{}, fmt.Errorf("join-key validator %q: %w", name, err)
+	}
+	// A validator cannot verify a join and stay silent about which one: the
+	// turn quotes Detail back to the model, so an empty one would render as a
+	// bare assertion. Supply the fallback rather than dropping the verdict.
+	if v.Detail == "" {
+		if v.Verified {
+			v.Detail = "the join-key report lists it as a key between these datasources"
+		} else {
+			v.Detail = "the join-key report does not list it as a key between these datasources"
+		}
+	}
+	return v, nil
+}
+
+// ResetJoinKeyValidatorForTest drops the registered validator. Test-only.
+func ResetJoinKeyValidatorForTest() {
+	joinKeyValidatorMu.Lock()
+	defer joinKeyValidatorMu.Unlock()
+	joinKeyValidator = nil
+	joinKeyValidatorName = ""
+}

--- a/libs/go-common/agentplugin/joinkey.go
+++ b/libs/go-common/agentplugin/joinkey.go
@@ -91,7 +91,7 @@ func ValidateJoinKey(ctx context.Context, req JoinKeyRequest) (JoinKeyVerdict, e
 	if fn == nil {
 		return JoinKeyVerdict{Detail: "this deployment has no join-key report to check it against"}, nil
 	}
-	v, err := fn(ctx, req)
+	v, err := callValidator(ctx, fn, req)
 	if err != nil {
 		return JoinKeyVerdict{}, fmt.Errorf("join-key validator %q: %w", name, err)
 	}
@@ -106,6 +106,26 @@ func ValidateJoinKey(ctx context.Context, req JoinKeyRequest) (JoinKeyVerdict, e
 		}
 	}
 	return v, nil
+}
+
+// callValidator invokes fn, converting a panic into an error.
+//
+// A validator is another module's code, reached through a blank import: a nil
+// map or a bad index inside it would otherwise escape into whatever goroutine
+// asked. An ask turn runs in one with no recover of its own, so a single
+// declared join could take the agent process down — and with it every other
+// turn running on it — over a question whose honest answer is "cannot tell".
+//
+// This seam promises exactly three outcomes: verified, not verified, or could
+// not tell. A panic must land on the third rather than outside all of them.
+func callValidator(ctx context.Context, fn JoinKeyValidatorFunc, req JoinKeyRequest) (v JoinKeyVerdict, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			v = JoinKeyVerdict{}
+			err = fmt.Errorf("panicked: %v", r)
+		}
+	}()
+	return fn(ctx, req)
 }
 
 // ResetJoinKeyValidatorForTest drops the registered validator. Test-only.

--- a/libs/go-common/agentplugin/joinkey.go
+++ b/libs/go-common/agentplugin/joinkey.go
@@ -121,7 +121,9 @@ func ValidateJoinKey(ctx context.Context, req JoinKeyRequest) (JoinKeyVerdict, e
 func callValidator(ctx context.Context, fn JoinKeyValidatorFunc, req JoinKeyRequest) (v JoinKeyVerdict, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			v = JoinKeyVerdict{}
+			// v needs no clearing: a panicking call never returned, so the
+			// named result still holds its zero value. Assigning it again
+			// would be a line that cannot change what this function does.
 			err = fmt.Errorf("panicked: %v", r)
 		}
 	}()

--- a/libs/go-common/agentplugin/joinkey_test.go
+++ b/libs/go-common/agentplugin/joinkey_test.go
@@ -197,3 +197,24 @@ func TestValidateJoinKey_SurvivesAPanicAndKeepsWorking(t *testing.T) {
 		t.Fatalf("calls = %d, want 2", calls)
 	}
 }
+
+// TestCallValidator_PanicYieldsNoVerdict pins the invariant at the layer that
+// catches the panic, not only at the exported one.
+//
+// ValidateJoinKey discards the verdict whenever an error comes back, so a test
+// there cannot tell whether the recover also cleared it. It has to: a validator
+// that panicked answered nothing, and a verdict surviving out of a recover is a
+// value no one computed.
+func TestCallValidator_PanicYieldsNoVerdict(t *testing.T) {
+	v, err := callValidator(context.Background(),
+		func(context.Context, JoinKeyRequest) (JoinKeyVerdict, error) {
+			panic("boom")
+		}, JoinKeyRequest{Field: "order_id"})
+
+	if err == nil {
+		t.Fatal("a panic must become an error")
+	}
+	if v != (JoinKeyVerdict{}) {
+		t.Fatalf("verdict = %+v, want the zero verdict — nothing was computed", v)
+	}
+}

--- a/libs/go-common/agentplugin/joinkey_test.go
+++ b/libs/go-common/agentplugin/joinkey_test.go
@@ -150,10 +150,11 @@ func TestValidateJoinKey_ValidatorPanicBecomesAnError(t *testing.T) {
 	defer ResetJoinKeyValidatorForTest()
 	ResetJoinKeyValidatorForTest()
 
+	// Stands in for the accident a real validator would have — a nil map or a
+	// bad index while parsing a project's report. What is under test is the
+	// recover, not which runtime fault reached it.
 	RegisterJoinKeyValidator("exploding", func(context.Context, JoinKeyRequest) (JoinKeyVerdict, error) {
-		var m map[string]string
-		m["boom"] = "" // assignment to entry in nil map
-		return JoinKeyVerdict{Verified: true}, nil
+		panic("nil map in the report parser")
 	})
 
 	// The point of the test is that this call RETURNS at all: an ask turn runs

--- a/libs/go-common/agentplugin/joinkey_test.go
+++ b/libs/go-common/agentplugin/joinkey_test.go
@@ -1,0 +1,147 @@
+package agentplugin
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func okValidator(v JoinKeyVerdict) JoinKeyValidatorFunc {
+	return func(context.Context, JoinKeyRequest) (JoinKeyVerdict, error) { return v, nil }
+}
+
+func TestValidateJoinKey_NoValidator_IsUnverifiedNotAnError(t *testing.T) {
+	defer ResetJoinKeyValidatorForTest()
+	ResetJoinKeyValidatorForTest()
+
+	v, err := ValidateJoinKey(context.Background(), JoinKeyRequest{Field: "order_id"})
+	if err != nil {
+		// An unwired seam must not look like a failure: the caller would then
+		// have to decide whether to fail the query, which is exactly the
+		// decision this design removes.
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Verified {
+		t.Fatal("nothing is wired, so nothing can be verified")
+	}
+	if v.Detail == "" {
+		t.Fatal("an unverified verdict must say why; the turn quotes it to the model")
+	}
+}
+
+func TestValidateJoinKey_UsesTheRegisteredValidator(t *testing.T) {
+	defer ResetJoinKeyValidatorForTest()
+	ResetJoinKeyValidatorForTest()
+
+	var got JoinKeyRequest
+	RegisterJoinKeyValidator("test-report", func(_ context.Context, req JoinKeyRequest) (JoinKeyVerdict, error) {
+		got = req
+		return JoinKeyVerdict{Verified: true, Detail: "listed as a shared order key"}, nil
+	})
+
+	want := JoinKeyRequest{ProjectID: "p1", SourceDatasourceID: "wh_a", TargetDatasourceID: "wh_b", Field: "order_id"}
+	v, err := ValidateJoinKey(context.Background(), want)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("validator saw %+v, want %+v", got, want)
+	}
+	if !v.Verified || v.Detail != "listed as a shared order key" {
+		t.Fatalf("verdict = %+v, want the validator's own answer verbatim", v)
+	}
+}
+
+func TestValidateJoinKey_FillsInAMissingDetail(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		verified bool
+		want     string
+	}{
+		{"verified", true, "lists it"},
+		{"unverified", false, "does not list it"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer ResetJoinKeyValidatorForTest()
+			ResetJoinKeyValidatorForTest()
+			RegisterJoinKeyValidator("silent", okValidator(JoinKeyVerdict{Verified: tc.verified}))
+
+			v, err := ValidateJoinKey(context.Background(), JoinKeyRequest{Field: "order_id"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v.Verified != tc.verified {
+				t.Fatalf("Verified = %v, want %v", v.Verified, tc.verified)
+			}
+			if !strings.Contains(v.Detail, tc.want) {
+				t.Fatalf("Detail = %q, want it to contain %q", v.Detail, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateJoinKey_ValidatorErrorIsWrappedAndNamed(t *testing.T) {
+	defer ResetJoinKeyValidatorForTest()
+	ResetJoinKeyValidatorForTest()
+
+	sentinel := errors.New("schema cache unreachable")
+	RegisterJoinKeyValidator("the-report", func(context.Context, JoinKeyRequest) (JoinKeyVerdict, error) {
+		return JoinKeyVerdict{Verified: true, Detail: "ignore me"}, sentinel
+	})
+
+	v, err := ValidateJoinKey(context.Background(), JoinKeyRequest{Field: "order_id"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want it to wrap the validator's own error", err)
+	}
+	if !strings.Contains(err.Error(), "the-report") {
+		t.Fatalf("error = %q, want it to name the validator", err.Error())
+	}
+	// A verdict returned alongside an error must not be usable: an errored
+	// validator did not answer the question.
+	if v.Verified {
+		t.Fatal("an errored validator must never yield a verified verdict")
+	}
+}
+
+func TestRegisterJoinKeyValidator_Rejects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func()
+	}{
+		{"empty name", func() { RegisterJoinKeyValidator("", okValidator(JoinKeyVerdict{})) }},
+		{"nil fn", func() { RegisterJoinKeyValidator("x", nil) }},
+		{"double registration", func() {
+			RegisterJoinKeyValidator("first", okValidator(JoinKeyVerdict{}))
+			RegisterJoinKeyValidator("second", okValidator(JoinKeyVerdict{}))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer ResetJoinKeyValidatorForTest()
+			ResetJoinKeyValidatorForTest()
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("%s must panic", tc.name)
+				}
+			}()
+			tc.call()
+		})
+	}
+}
+
+func TestResetJoinKeyValidatorForTest_AllowsReRegistration(t *testing.T) {
+	defer ResetJoinKeyValidatorForTest()
+	ResetJoinKeyValidatorForTest()
+
+	RegisterJoinKeyValidator("first", okValidator(JoinKeyVerdict{Verified: true, Detail: "a"}))
+	ResetJoinKeyValidatorForTest()
+	RegisterJoinKeyValidator("second", okValidator(JoinKeyVerdict{Verified: true, Detail: "b"}))
+
+	v, err := ValidateJoinKey(context.Background(), JoinKeyRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Detail != "b" {
+		t.Fatalf("Detail = %q, want the re-registered validator's answer", v.Detail)
+	}
+}

--- a/libs/go-common/agentplugin/joinkey_test.go
+++ b/libs/go-common/agentplugin/joinkey_test.go
@@ -145,3 +145,54 @@ func TestResetJoinKeyValidatorForTest_AllowsReRegistration(t *testing.T) {
 		t.Fatalf("Detail = %q, want the re-registered validator's answer", v.Detail)
 	}
 }
+
+func TestValidateJoinKey_ValidatorPanicBecomesAnError(t *testing.T) {
+	defer ResetJoinKeyValidatorForTest()
+	ResetJoinKeyValidatorForTest()
+
+	RegisterJoinKeyValidator("exploding", func(context.Context, JoinKeyRequest) (JoinKeyVerdict, error) {
+		var m map[string]string
+		m["boom"] = "" // assignment to entry in nil map
+		return JoinKeyVerdict{Verified: true}, nil
+	})
+
+	// The point of the test is that this call RETURNS at all: an ask turn runs
+	// in a goroutine with no recover, so an escaping panic takes the whole
+	// agent process down over a question whose honest answer is "cannot tell".
+	v, err := ValidateJoinKey(context.Background(), JoinKeyRequest{Field: "order_id"})
+	if err == nil {
+		t.Fatal("a panicking validator must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "panicked") || !strings.Contains(err.Error(), "exploding") {
+		t.Fatalf("error = %q, want it to name the validator and say it panicked", err.Error())
+	}
+	if v.Verified {
+		t.Fatal("a validator that panicked answered nothing; it must never yield a verified verdict")
+	}
+}
+
+func TestValidateJoinKey_SurvivesAPanicAndKeepsWorking(t *testing.T) {
+	defer ResetJoinKeyValidatorForTest()
+	ResetJoinKeyValidatorForTest()
+
+	calls := 0
+	RegisterJoinKeyValidator("flaky", func(_ context.Context, req JoinKeyRequest) (JoinKeyVerdict, error) {
+		calls++
+		if req.Field == "bad" {
+			panic("boom")
+		}
+		return JoinKeyVerdict{Verified: true, Detail: "fine"}, nil
+	})
+
+	if _, err := ValidateJoinKey(context.Background(), JoinKeyRequest{Field: "bad"}); err == nil {
+		t.Fatal("want an error for the panicking call")
+	}
+	// The registry must not be left in a broken state by the recover.
+	v, err := ValidateJoinKey(context.Background(), JoinKeyRequest{Field: "good"})
+	if err != nil || !v.Verified {
+		t.Fatalf("v=%+v err=%v; a later call must still be answered", v, err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}

--- a/libs/go-common/telemetry/events.go
+++ b/libs/go-common/telemetry/events.go
@@ -2,12 +2,13 @@ package telemetry
 
 // Event names — every event sent by DecisionBox is defined here.
 const (
-	EventServerStarted      = "server_started"
-	EventServerStopped      = "server_stopped"
-	EventProjectCreated     = "project_created"
-	EventDiscoveryCompleted = "discovery_completed"
-	EventDiscoveryFailed    = "discovery_failed"
-	EventAnchoringRefused   = "anchoring_refused"
+	EventServerStarted        = "server_started"
+	EventServerStopped        = "server_stopped"
+	EventProjectCreated       = "project_created"
+	EventDiscoveryCompleted   = "discovery_completed"
+	EventDiscoveryFailed      = "discovery_failed"
+	EventAnchoringRefused     = "anchoring_refused"
+	EventCrossDatasourceQuery = "cross_datasource_query"
 )
 
 // DurationBucket returns a human-readable duration bucket for telemetry.
@@ -113,5 +114,21 @@ func TrackAnchoringRefused(at, providerSlug string) {
 	Track(EventAnchoringRefused, map[string]any{
 		"at":       at,
 		"provider": providerSlug,
+	})
+}
+
+// TrackCrossDatasourceQuery records how one query in a multi-datasource turn
+// positioned itself: whether the model declared which field it carried across
+// from an earlier datasource, and what came of that declaration.
+//
+// This is the evidence for a decision already scheduled — whether an undeclared
+// cross-datasource filter should become a refusal rather than a caveat. It
+// therefore carries no field name, datasource id, or project: the only question
+// it has to answer is how often the declaration is present and how often it
+// holds up.
+func TrackCrossDatasourceQuery(declared bool, outcome string) {
+	Track(EventCrossDatasourceQuery, map[string]any{
+		"declared": declared,
+		"outcome":  outcome,
 	})
 }

--- a/services/agent/internal/askserve/action.go
+++ b/services/agent/internal/askserve/action.go
@@ -63,10 +63,10 @@ type turnAction struct {
 type rawAction struct {
 	Thinking string `json:"thinking"`
 
-	Query      string      `json:"query"`
-	Purpose    string      `json:"purpose"`
-	Datasource string      `json:"datasource_id"`
-	JoinsOn    *rawJoinsOn `json:"joins_on"`
+	Query      string          `json:"query"`
+	Purpose    string          `json:"purpose"`
+	Datasource string          `json:"datasource_id"`
+	JoinsOn    json.RawMessage `json:"joins_on"`
 
 	LookupSchema []string `json:"lookup_schema"`
 	SearchTables string   `json:"search_tables"`
@@ -109,12 +109,12 @@ func parseTurnAction(response string) (*turnAction, error) {
 	// let the chart reference a stale step, and mixing it with a terminal would
 	// finish before the chart is validated). This mirrors the native path's
 	// same-batch refusal.
-	if hasChartPayload(raw.RenderChart) && rawHasNonChartAction(&raw) {
+	if hasJSONPayload(raw.RenderChart) && rawHasNonChartAction(&raw) {
 		return nil, fmt.Errorf("emit render_chart on its own — not together with a query, lookup, search, or answer/clarify/decline; render the chart in one step, then continue in the next")
 	}
 
 	switch {
-	case hasChartPayload(raw.RenderChart):
+	case hasJSONPayload(raw.RenderChart):
 		act.Kind = actRenderChart
 		act.Chart = raw.RenderChart
 	case strings.TrimSpace(raw.Answer) != "":
@@ -154,10 +154,10 @@ func parseTurnAction(response string) (*turnAction, error) {
 	return act, nil
 }
 
-// hasChartPayload reports whether a render_chart value carries an actual object
+// hasJSONPayload reports whether a raw JSON value carries an actual payload
 // (not absent, not JSON null). Guards the parser against a `{"render_chart":null}`
-// stub being treated as a chart action.
-func hasChartPayload(raw json.RawMessage) bool {
+// or `{"joins_on":null}` stub being treated as the thing itself.
+func hasJSONPayload(raw json.RawMessage) bool {
 	s := strings.TrimSpace(string(raw))
 	return s != "" && s != "null"
 }
@@ -192,10 +192,10 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			return
 		}
 		var in struct {
-			Query        string      `json:"query"`
-			Purpose      string      `json:"purpose"`
-			DatasourceID string      `json:"datasource_id"`
-			JoinsOn      *rawJoinsOn `json:"joins_on"`
+			Query        string          `json:"query"`
+			Purpose      string          `json:"purpose"`
+			DatasourceID string          `json:"datasource_id"`
+			JoinsOn      json.RawMessage `json:"joins_on"`
 		}
 		if json.Unmarshal(env.Input, &in) == nil {
 			raw.Query = in.Query
@@ -205,7 +205,7 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			if raw.Datasource == "" {
 				raw.Datasource = in.DatasourceID
 			}
-			if raw.JoinsOn == nil {
+			if len(raw.JoinsOn) == 0 {
 				raw.JoinsOn = in.JoinsOn
 			}
 		}
@@ -252,7 +252,7 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			}
 		}
 	case actRenderChart:
-		if hasChartPayload(raw.RenderChart) {
+		if hasJSONPayload(raw.RenderChart) {
 			return
 		}
 		// The tool-use `input` IS the ChartSpec — capture it raw for validation.
@@ -389,28 +389,23 @@ func jsonHasActionKey(s string) bool {
 	return false
 }
 
-// rawJoinsOn is the wire shape of the joins_on key, shared by the plain payload
-// and the tool-envelope form so the two cannot drift apart.
-type rawJoinsOn struct {
-	SourceStep string `json:"source_step"`
-	Field      string `json:"field"`
-}
-
 // joinDeclaration reads the optional joins_on key of a JSON-text query action.
-// It mirrors joinsFromToolInput: absent is fine, half-present is not — a
-// declaration missing either half claims values were carried across without
-// saying from where, which cannot be checked but reads as though it could.
+//
+// It decodes to the same loose map the native tool path receives and hands it
+// to the same parser, rather than to a typed struct. A struct silently drops
+// keys it does not know, so a real attempt spelled `{"step":..,"column":..}`
+// would arrive indistinguishable from no attempt at all: the model would get
+// no correction, and the turn would be filed as an undeclared hop — which is
+// the measurement deciding whether undeclared hops should eventually be
+// refused. Misreading attempts as non-attempts is the one error that
+// measurement cannot survive.
 func (raw *rawAction) joinDeclaration() (*joinDeclaration, error) {
-	if raw.JoinsOn == nil {
+	if !hasJSONPayload(raw.JoinsOn) { // absent, or an explicit null
 		return nil, nil
 	}
-	step := strings.TrimSpace(raw.JoinsOn.SourceStep)
-	field := strings.TrimSpace(raw.JoinsOn.Field)
-	if step == "" && field == "" {
-		return nil, nil
+	var obj map[string]interface{}
+	if err := json.Unmarshal(raw.JoinsOn, &obj); err != nil {
+		return nil, fmt.Errorf("joins_on must be an object with %q and %q", "source_step", "field")
 	}
-	if step == "" || field == "" {
-		return nil, fmt.Errorf("joins_on requires both %q (the q<N> id of the earlier query) and %q (the column in that result the values came from); omit joins_on entirely if this query stands on its own", "source_step", "field")
-	}
-	return &joinDeclaration{SourceStep: step, Field: field}, nil
+	return joinsFromToolInput(obj)
 }

--- a/services/agent/internal/askserve/action.go
+++ b/services/agent/internal/askserve/action.go
@@ -39,6 +39,10 @@ type turnAction struct {
 	// lookup_schema on a multi-datasource project. Empty = the primary. Ignored
 	// on a single-datasource project or a turn pinned to one datasource.
 	Datasource string
+	// JoinsOn is the model's optional declaration, on a query_data action, that
+	// this query filters on values observed in an earlier query against a
+	// different datasource. nil when it declared none.
+	JoinsOn *joinDeclaration
 
 	LookupSchema []string // lookup_schema
 	SearchTables string   // search_tables
@@ -59,9 +63,10 @@ type turnAction struct {
 type rawAction struct {
 	Thinking string `json:"thinking"`
 
-	Query      string `json:"query"`
-	Purpose    string `json:"purpose"`
-	Datasource string `json:"datasource_id"`
+	Query      string      `json:"query"`
+	Purpose    string      `json:"purpose"`
+	Datasource string      `json:"datasource_id"`
+	JoinsOn    *rawJoinsOn `json:"joins_on"`
 
 	LookupSchema []string `json:"lookup_schema"`
 	SearchTables string   `json:"search_tables"`
@@ -126,6 +131,11 @@ func parseTurnAction(response string) (*turnAction, error) {
 		act.Query = raw.Query
 		act.Purpose = strings.TrimSpace(raw.Purpose)
 		act.Datasource = strings.TrimSpace(raw.Datasource)
+		joins, err := raw.joinDeclaration()
+		if err != nil {
+			return nil, err
+		}
+		act.JoinsOn = joins
 	case len(raw.LookupSchema) > 0:
 		act.Kind = actLookup
 		act.LookupSchema = raw.LookupSchema
@@ -182,9 +192,10 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			return
 		}
 		var in struct {
-			Query        string `json:"query"`
-			Purpose      string `json:"purpose"`
-			DatasourceID string `json:"datasource_id"`
+			Query        string      `json:"query"`
+			Purpose      string      `json:"purpose"`
+			DatasourceID string      `json:"datasource_id"`
+			JoinsOn      *rawJoinsOn `json:"joins_on"`
 		}
 		if json.Unmarshal(env.Input, &in) == nil {
 			raw.Query = in.Query
@@ -193,6 +204,9 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			}
 			if raw.Datasource == "" {
 				raw.Datasource = in.DatasourceID
+			}
+			if raw.JoinsOn == nil {
+				raw.JoinsOn = in.JoinsOn
 			}
 		}
 	case actLookup:
@@ -373,4 +387,30 @@ func jsonHasActionKey(s string) bool {
 		}
 	}
 	return false
+}
+
+// rawJoinsOn is the wire shape of the joins_on key, shared by the plain payload
+// and the tool-envelope form so the two cannot drift apart.
+type rawJoinsOn struct {
+	SourceStep string `json:"source_step"`
+	Field      string `json:"field"`
+}
+
+// joinDeclaration reads the optional joins_on key of a JSON-text query action.
+// It mirrors joinsFromToolInput: absent is fine, half-present is not — a
+// declaration missing either half claims values were carried across without
+// saying from where, which cannot be checked but reads as though it could.
+func (raw *rawAction) joinDeclaration() (*joinDeclaration, error) {
+	if raw.JoinsOn == nil {
+		return nil, nil
+	}
+	step := strings.TrimSpace(raw.JoinsOn.SourceStep)
+	field := strings.TrimSpace(raw.JoinsOn.Field)
+	if step == "" && field == "" {
+		return nil, nil
+	}
+	if step == "" || field == "" {
+		return nil, fmt.Errorf("joins_on requires both %q (the q<N> id of the earlier query) and %q (the column in that result the values came from); omit joins_on entirely if this query stands on its own", "source_step", "field")
+	}
+	return &joinDeclaration{SourceStep: step, Field: field}, nil
 }

--- a/services/agent/internal/askserve/action.go
+++ b/services/agent/internal/askserve/action.go
@@ -205,7 +205,14 @@ func normaliseToolEnvelope(jsonStr string, raw *rawAction) {
 			if raw.Datasource == "" {
 				raw.Datasource = in.DatasourceID
 			}
-			if len(raw.JoinsOn) == 0 {
+			// "Already set" has to mean "says something", not "is present":
+			// null, {} and blank halves are all how a model spells no
+			// declaration, and a stub outranking the real declaration beside
+			// it would file the hop as undeclared with the answer in hand.
+			// A malformed top-level value does outrank it, deliberately —
+			// that is an attempt, and the model should get it corrected
+			// rather than quietly replaced.
+			if joinsOnSaysNothing(raw.JoinsOn) {
 				raw.JoinsOn = in.JoinsOn
 			}
 		}
@@ -400,11 +407,43 @@ func jsonHasActionKey(s string) bool {
 // refused. Misreading attempts as non-attempts is the one error that
 // measurement cannot survive.
 func (raw *rawAction) joinDeclaration() (*joinDeclaration, error) {
-	if !hasJSONPayload(raw.JoinsOn) { // absent, or an explicit null
+	return joinsFromRawJSON(raw.JoinsOn)
+}
+
+// joinsOnSaysNothing reports whether a joins_on value carries no content at all
+// — absent, null, {}, or an object whose every value is blank.
+//
+// This is a question about PRECEDENCE, not validity, which is why it is not
+// joinsFromRawJSON. The normaliser has to decide whether a top-level value is
+// worth keeping over the envelope's, and a template stub the model left behind
+// is not: letting it win would file the hop as undeclared with the real
+// declaration sitting in the envelope. A malformed value that does carry
+// content keeps precedence on purpose — that is an attempt, and it should be
+// corrected rather than quietly overwritten.
+func joinsOnSaysNothing(raw json.RawMessage) bool {
+	if !hasJSONPayload(raw) {
+		return true
+	}
+	var obj map[string]interface{}
+	if json.Unmarshal(raw, &obj) != nil {
+		return false
+	}
+	for _, v := range obj {
+		if str, ok := v.(string); !ok || strings.TrimSpace(str) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// joinsFromRawJSON reads a joins_on value in its wire form, applying the same
+// rules the native tool path applies to the same object.
+func joinsFromRawJSON(raw json.RawMessage) (*joinDeclaration, error) {
+	if !hasJSONPayload(raw) { // absent, or an explicit null
 		return nil, nil
 	}
 	var obj map[string]interface{}
-	if err := json.Unmarshal(raw.JoinsOn, &obj); err != nil {
+	if err := json.Unmarshal(raw, &obj); err != nil {
 		return nil, fmt.Errorf("joins_on must be an object with %q and %q", "source_step", "field")
 	}
 	return joinsFromToolInput(obj)

--- a/services/agent/internal/askserve/joins.go
+++ b/services/agent/internal/askserve/joins.go
@@ -1,0 +1,205 @@
+package askserve
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/decisionbox-io/decisionbox/libs/go-common/agentplugin"
+	"github.com/decisionbox-io/decisionbox/libs/go-common/telemetry"
+)
+
+// A turn combines datasources in hops: query one, then filter another by values
+// read out of that result. Whether the hop is sound turns on one thing the
+// query text cannot show — that the field those values came from names the same
+// entities on both sides. joins_on is where the model says which field it used,
+// so the claim becomes checkable instead of assumed.
+//
+// The declaration is optional and stays optional. An omitted one does not fail
+// the query; it fails to earn `scoped`, and the model is told the result is not
+// verified as scoped to the earlier datasource's rows. That keeps the existing
+// SQL multi-hop path working exactly as it did while making the difference
+// between a checked hop and an unchecked one visible in the result rather than
+// silent. A declaration that is self-contradictory — naming a step that does
+// not exist, or a column that step never returned — IS rejected: that is a
+// malformed call, not an omission, and the model is handed what it needs to fix
+// it.
+
+// joinDeclaration is the model's claim that this query filters on values it
+// read out of an earlier query against a different datasource.
+type joinDeclaration struct {
+	// SourceStep is the q<N> id of that earlier query.
+	SourceStep string
+	// Field is the column IN THAT STEP'S RESULT whose values this query filters
+	// on. It is the source-side name on purpose: that is the one the model
+	// actually observed, so it can be checked against what the step returned,
+	// and it is the one a join-key report is keyed by.
+	Field string
+}
+
+// joinScope is what examining a query's cross-datasource position concluded.
+type joinScope struct {
+	// reject, when non-empty, is the repair message for a declaration that
+	// contradicts the turn. The query MUST NOT run.
+	reject string
+	// scoped is stamped on the result. nil means the question does not arise —
+	// no earlier query in this turn ran against another datasource — and
+	// nothing is added to the summary or the observation.
+	scoped *bool
+	// note is the model-facing explanation, set only when scoped is false.
+	note string
+	// outcome is the coarse telemetry label for this decision.
+	outcome string
+}
+
+// Telemetry outcome labels. They are the evidence for whether the model
+// populates joins_on reliably enough to make an undeclared cross-datasource
+// filter a refusal rather than a caveat.
+const (
+	joinOutcomeUndeclared     = "undeclared"
+	joinOutcomeVerified       = "verified"
+	joinOutcomeUnverified     = "unverified"
+	joinOutcomeValidatorError = "validator_error"
+	joinOutcomeRejectedStep   = "rejected_unknown_step"
+	joinOutcomeRejectedSameDS = "rejected_same_datasource"
+	joinOutcomeRejectedField  = "rejected_unobserved_field"
+)
+
+// recordCrossDatasourceQuery is a package-level var so tests can observe what
+// was reported without a real telemetry sink.
+var recordCrossDatasourceQuery = telemetry.TrackCrossDatasourceQuery
+
+// resolveJoinScope decides what this query's result may claim about its scope.
+//
+// targetDS is the datasource the query is about to run against; decl is the
+// model's declaration, or nil when it made none.
+func (st *turnState) resolveJoinScope(ctx context.Context, targetDS string, decl *joinDeclaration) joinScope {
+	crossed := st.hasQueriedAnotherDatasource(targetDS)
+
+	if decl == nil {
+		if !crossed {
+			// Nothing observed from another datasource yet, so no hop can have
+			// been made. The summary and the observation stay exactly as they
+			// are on a single-datasource turn.
+			return joinScope{}
+		}
+		return joinScope{
+			scoped:  boolPtr(false),
+			outcome: joinOutcomeUndeclared,
+			note: "This turn has already queried another datasource, so this result is NOT verified as scoped to what you observed there. " +
+				"If this query filtered on values you read out of an earlier result, declare which field they came from with joins_on " +
+				"so the join key can be checked; if it did not, the result stands on its own.",
+		}
+	}
+
+	// A step's summary and its datasource are recorded together when a query
+	// succeeds, so the summary is the test for whether the step exists at all.
+	sum, known := st.querySummariesByID[decl.SourceStep]
+	sourceDS := st.queryStepDatasource[decl.SourceStep]
+	if !known {
+		return joinScope{
+			outcome: joinOutcomeRejectedStep,
+			reject: fmt.Sprintf("joins_on names step %q, which is not a query result from this turn (%s). "+
+				"Use the q<N> id shown on the result you took the values from.",
+				decl.SourceStep, st.describeQuerySteps()),
+		}
+	}
+	if sourceDS == targetDS {
+		return joinScope{
+			outcome: joinOutcomeRejectedSameDS,
+			reject: fmt.Sprintf("joins_on names step %s, which ran against this same datasource (%s), so this is not a cross-datasource hop. "+
+				"Declare joins_on only when the values came from a DIFFERENT datasource; otherwise omit it.",
+				decl.SourceStep, targetDS),
+		}
+	}
+	if !hasColumn(sum.Columns, decl.Field) {
+		return joinScope{
+			outcome: joinOutcomeRejectedField,
+			reject: fmt.Sprintf("joins_on says the values came from %q in step %s, but that result has no such column (it returned: %s). "+
+				"Name the column you actually read the values from.",
+				decl.Field, decl.SourceStep, strings.Join(sum.Columns, ", ")),
+		}
+	}
+
+	verdict, err := agentplugin.ValidateJoinKey(ctx, agentplugin.JoinKeyRequest{
+		ProjectID:          st.req.ProjectID,
+		SourceDatasourceID: sourceDS,
+		TargetDatasourceID: targetDS,
+		Field:              decl.Field,
+	})
+	if err != nil {
+		// The report being unreachable is not a reason to fail a query the user
+		// asked for — but it is every reason not to claim the join was checked.
+		return joinScope{
+			scoped:  boolPtr(false),
+			outcome: joinOutcomeValidatorError,
+			note: fmt.Sprintf("The join on %s from step %s could not be checked (%s), so this result is NOT verified as scoped to that datasource's rows. "+
+				"Say so if the answer leans on it.", decl.Field, decl.SourceStep, err.Error()),
+		}
+	}
+	if verdict.Verified {
+		return joinScope{scoped: boolPtr(true), outcome: joinOutcomeVerified}
+	}
+	return joinScope{
+		scoped:  boolPtr(false),
+		outcome: joinOutcomeUnverified,
+		note: fmt.Sprintf("The join on %s from step %s is NOT verified — %s. These rows may not be the ones you observed there; "+
+			"say so if the answer leans on it.", decl.Field, decl.SourceStep, verdict.Detail),
+	}
+}
+
+// track reports the decision, once, for a query that raised the question at all.
+// A query on a turn that has touched only one datasource reports nothing: it is
+// the ordinary single-source path and would drown the signal this exists to
+// gather.
+func (js joinScope) track(declared bool) {
+	if js.outcome == "" {
+		return
+	}
+	recordCrossDatasourceQuery(declared, js.outcome)
+}
+
+// hasQueriedAnotherDatasource reports whether an earlier query in this turn
+// succeeded against a datasource other than target — i.e. whether the model has
+// values in hand that it could have carried across.
+//
+// Only successful queries count, because only they returned rows: a failed
+// query against another datasource gave the model nothing to filter by.
+func (st *turnState) hasQueriedAnotherDatasource(target string) bool {
+	for _, ds := range st.queryStepDatasource {
+		if ds != target {
+			return true
+		}
+	}
+	return false
+}
+
+// describeQuerySteps lists this turn's query step ids for a repair message, or
+// says there are none.
+func (st *turnState) describeQuerySteps() string {
+	if len(st.querySummariesByID) == 0 {
+		return "no query has produced a result yet this turn"
+	}
+	steps := make([]string, 0, len(st.querySummariesByID))
+	for id := range st.querySummariesByID {
+		steps = append(steps, id)
+	}
+	sort.Strings(steps)
+	return "steps so far: " + strings.Join(steps, ", ")
+}
+
+// hasColumn reports whether cols contains name, ignoring case — column casing
+// varies by warehouse, and the model reads the name off the preview. The match
+// is otherwise exact: accepting a near-miss would let a field the model never
+// observed pass as one it did.
+func hasColumn(cols []string, name string) bool {
+	for _, c := range cols {
+		if strings.EqualFold(c, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/services/agent/internal/askserve/joins.go
+++ b/services/agent/internal/askserve/joins.go
@@ -18,13 +18,22 @@ import (
 //
 // The declaration is optional and stays optional. An omitted one does not fail
 // the query; it fails to earn `scoped`, and the model is told the result is not
-// verified as scoped to the earlier datasource's rows. That keeps the existing
-// SQL multi-hop path working exactly as it did while making the difference
-// between a checked hop and an unchecked one visible in the result rather than
-// silent. A declaration that is self-contradictory — naming a step that does
-// not exist, or a column that step never returned — IS rejected: that is a
-// malformed call, not an omission, and the model is handed what it needs to fix
-// it.
+// verified against the earlier datasource. That keeps the existing SQL
+// multi-hop path working exactly as it did while making the difference between
+// a checked hop and an unchecked one visible in the result rather than silent.
+//
+// A declaration that CONTRADICTS the turn is rejected instead, because it is a
+// false claim this code can see through rather than an omission. Four ways:
+// naming a step that never ran, naming one issued in the same batch as this
+// query (its result did not exist when this query was written), naming one that
+// ran against this same datasource, or naming a column that step never
+// returned. Each rejection hands back what is needed to repair it.
+//
+// What a verified declaration establishes is narrower than the name `scoped`
+// suggests: that the declared field is a real key between the two datasources.
+// Whether this query applied it is the model's word. Checking that would mean
+// matching values against the query text, which #375 established is not
+// evidence — so the claim stays inside what the mechanism can keep.
 
 // joinDeclaration is the model's claim that this query filters on values it
 // read out of an earlier query against a different datasource.

--- a/services/agent/internal/askserve/joins.go
+++ b/services/agent/internal/askserve/joins.go
@@ -165,7 +165,17 @@ func (st *turnState) resolveJoinScope(ctx context.Context, targetDS string, decl
 		}
 	}
 	if verdict.Verified {
-		return joinScope{scoped: boolPtr(true), outcome: joinOutcomeVerified}
+		// Said out loud rather than left as silence. What was checked is the
+		// KEY; that this query filtered on the earlier step's values is the
+		// model's own declaration, and the only way to check that would be to
+		// match values against the query text — which is not evidence (#375).
+		// A model told nothing reads the absence as certification.
+		return joinScope{
+			scoped:  boolPtr(true),
+			outcome: joinOutcomeVerified,
+			note: fmt.Sprintf("Join key confirmed: %s is a real key between these datasources (%s). That this query filtered on step %s's values is your declaration, not something checked here — "+
+				"do not present the result as restricted to those rows unless it is.", decl.Field, verdict.Detail, decl.SourceStep),
+		}
 	}
 	return joinScope{
 		scoped:  boolPtr(false),

--- a/services/agent/internal/askserve/joins.go
+++ b/services/agent/internal/askserve/joins.go
@@ -38,6 +38,22 @@ type joinDeclaration struct {
 	Field string
 }
 
+// queryStep is what a completed query contributes to a later hop's check.
+type queryStep struct {
+	// datasource is the datasource the query ran against.
+	datasource string
+	// round is the loop round whose results the model saw it in.
+	//
+	// A join may cite a step only from an EARLIER round. A native provider can
+	// return several query_data calls in one response; the loop runs them in
+	// sequence, so an earlier one's result is recorded before a later one
+	// executes — but the model wrote them all before seeing any of them. A
+	// value from one therefore cannot have reached another's filter, and
+	// treating it as though it had would certify a hop that did not happen and
+	// caveat two independent queries that never touched each other.
+	round int
+}
+
 // joinScope is what examining a query's cross-datasource position concluded.
 type joinScope struct {
 	// reject, when non-empty, is the repair message for a declaration that
@@ -62,6 +78,7 @@ const (
 	joinOutcomeUnverified     = "unverified"
 	joinOutcomeValidatorError = "validator_error"
 	joinOutcomeRejectedStep   = "rejected_unknown_step"
+	joinOutcomeRejectedBatch  = "rejected_same_batch"
 	joinOutcomeRejectedSameDS = "rejected_same_datasource"
 	joinOutcomeRejectedField  = "rejected_unobserved_field"
 )
@@ -93,18 +110,27 @@ func (st *turnState) resolveJoinScope(ctx context.Context, targetDS string, decl
 		}
 	}
 
-	// A step's summary and its datasource are recorded together when a query
+	// A step's summary and its bookkeeping are recorded together when a query
 	// succeeds, so the summary is the test for whether the step exists at all.
 	sum, known := st.querySummariesByID[decl.SourceStep]
-	sourceDS := st.queryStepDatasource[decl.SourceStep]
+	step := st.queryStepsByID[decl.SourceStep]
 	if !known {
 		return joinScope{
 			outcome: joinOutcomeRejectedStep,
-			reject: fmt.Sprintf("joins_on names step %q, which is not a query result from this turn (%s). "+
+			reject: fmt.Sprintf("joins_on names step %q, which is not a query result you have seen this turn (%s). "+
 				"Use the q<N> id shown on the result you took the values from.",
 				decl.SourceStep, st.describeQuerySteps()),
 		}
 	}
+	if !st.observed(step) {
+		return joinScope{
+			outcome: joinOutcomeRejectedBatch,
+			reject: fmt.Sprintf("joins_on names step %s, which you issued in this same step — its result did not exist when this query was written, "+
+				"so no value from it can be in this filter. Run the query that gathers the values on its own, read the result, then filter on it in a later step.",
+				decl.SourceStep),
+		}
+	}
+	sourceDS := step.datasource
 	if sourceDS == targetDS {
 		return joinScope{
 			outcome: joinOutcomeRejectedSameDS,
@@ -167,26 +193,37 @@ func (js joinScope) track(declared bool) {
 // Only successful queries count, because only they returned rows: a failed
 // query against another datasource gave the model nothing to filter by.
 func (st *turnState) hasQueriedAnotherDatasource(target string) bool {
-	for _, ds := range st.queryStepDatasource {
-		if ds != target {
+	for _, step := range st.queryStepsByID {
+		if step.datasource != target && st.observed(step) {
 			return true
 		}
 	}
 	return false
 }
 
-// describeQuerySteps lists this turn's query step ids for a repair message, or
-// says there are none.
+// observed reports whether the model has actually SEEN a step's result — i.e.
+// the step completed in an earlier round. A step from this same round was
+// issued in the same breath as the query now being checked, so its result was
+// not in front of the model when that query was written.
+func (st *turnState) observed(step queryStep) bool {
+	return step.round > 0 && step.round < st.round
+}
+
+// describeQuerySteps lists the step ids this turn could legitimately be cited,
+// or says there are none. Steps from the current round are left out: naming one
+// would point the model at a step that the very next check rejects.
 func (st *turnState) describeQuerySteps() string {
-	if len(st.querySummariesByID) == 0 {
-		return "no query has produced a result yet this turn"
+	steps := make([]string, 0, len(st.queryStepsByID))
+	for id, step := range st.queryStepsByID {
+		if st.observed(step) {
+			steps = append(steps, id)
+		}
 	}
-	steps := make([]string, 0, len(st.querySummariesByID))
-	for id := range st.querySummariesByID {
-		steps = append(steps, id)
+	if len(steps) == 0 {
+		return "no query result is available to join on yet this turn"
 	}
 	sort.Strings(steps)
-	return "steps so far: " + strings.Join(steps, ", ")
+	return "results so far: " + strings.Join(steps, ", ")
 }
 
 // hasColumn reports whether cols contains name, ignoring case — column casing

--- a/services/agent/internal/askserve/joins.go
+++ b/services/agent/internal/askserve/joins.go
@@ -42,6 +42,9 @@ type joinDeclaration struct {
 type queryStep struct {
 	// datasource is the datasource the query ran against.
 	datasource string
+	// columns are the result's columns: the only names a declaration may cite,
+	// because they are the only ones the model could have read values out of.
+	columns []string
 	// round is the loop round whose results the model saw it in.
 	//
 	// A join may cite a step only from an EARLIER round. A native provider can
@@ -110,10 +113,7 @@ func (st *turnState) resolveJoinScope(ctx context.Context, targetDS string, decl
 		}
 	}
 
-	// A step's summary and its bookkeeping are recorded together when a query
-	// succeeds, so the summary is the test for whether the step exists at all.
-	sum, known := st.querySummariesByID[decl.SourceStep]
-	step := st.queryStepsByID[decl.SourceStep]
+	step, known := st.queryStepsByID[decl.SourceStep]
 	if !known {
 		return joinScope{
 			outcome: joinOutcomeRejectedStep,
@@ -139,12 +139,12 @@ func (st *turnState) resolveJoinScope(ctx context.Context, targetDS string, decl
 				decl.SourceStep, targetDS),
 		}
 	}
-	if !hasColumn(sum.Columns, decl.Field) {
+	if !hasColumn(step.columns, decl.Field) {
 		return joinScope{
 			outcome: joinOutcomeRejectedField,
 			reject: fmt.Sprintf("joins_on says the values came from %q in step %s, but that result has no such column (it returned: %s). "+
 				"Name the column you actually read the values from.",
-				decl.Field, decl.SourceStep, strings.Join(sum.Columns, ", ")),
+				decl.Field, decl.SourceStep, strings.Join(step.columns, ", ")),
 		}
 	}
 
@@ -206,7 +206,7 @@ func (st *turnState) hasQueriedAnotherDatasource(target string) bool {
 // issued in the same breath as the query now being checked, so its result was
 // not in front of the model when that query was written.
 func (st *turnState) observed(step queryStep) bool {
-	return step.round > 0 && step.round < st.round
+	return step.round < st.round
 }
 
 // describeQuerySteps lists the step ids this turn could legitimately be cited,

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -1,0 +1,611 @@
+package askserve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/decisionbox-io/decisionbox/libs/go-common/agentplugin"
+	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/testutil"
+)
+
+// --- helpers -----------------------------------------------------------
+
+// twoHopState is a turn that has already run q1 against wh_a, returning the
+// columns a later hop could carry across.
+func twoHopState() *turnState {
+	return &turnState{
+		req: TurnRequest{ProjectID: "p1"},
+		querySummariesByID: map[string]QuerySummary{
+			"q1": {Step: "q1", Columns: []string{"user_id", "spend"}},
+		},
+		queryStepDatasource: map[string]string{"q1": "wh_a"},
+	}
+}
+
+func wireValidator(t *testing.T, fn agentplugin.JoinKeyValidatorFunc) {
+	t.Helper()
+	agentplugin.ResetJoinKeyValidatorForTest()
+	agentplugin.RegisterJoinKeyValidator("test-validator", fn)
+	t.Cleanup(agentplugin.ResetJoinKeyValidatorForTest)
+}
+
+// captureJoinTelemetry swaps the tracker for one that records what was reported.
+func captureJoinTelemetry(t *testing.T) *[]string {
+	t.Helper()
+	var got []string
+	prev := recordCrossDatasourceQuery
+	recordCrossDatasourceQuery = func(declared bool, outcome string) {
+		d := "undeclared"
+		if declared {
+			d = "declared"
+		}
+		got = append(got, d+"/"+outcome)
+	}
+	t.Cleanup(func() { recordCrossDatasourceQuery = prev })
+	return &got
+}
+
+// --- resolveJoinScope --------------------------------------------------
+
+func TestResolveJoinScope_SingleDatasourceTurnStampsNothing(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	st := twoHopState()
+
+	// The second query runs against the SAME datasource as the first, so no
+	// value can have crossed a boundary and the question never arises.
+	js := st.resolveJoinScope(context.Background(), "wh_a", nil)
+	if js.scoped != nil {
+		t.Fatalf("scoped = %v, want nil (nothing to say)", *js.scoped)
+	}
+	if js.note != "" || js.reject != "" || js.outcome != "" {
+		t.Fatalf("want an entirely empty verdict, got %+v", js)
+	}
+}
+
+func TestResolveJoinScope_FirstQueryOfATurnStampsNothing(t *testing.T) {
+	st := &turnState{req: TurnRequest{ProjectID: "p1"}}
+	js := st.resolveJoinScope(context.Background(), "wh_a", nil)
+	if js.scoped != nil || js.outcome != "" {
+		t.Fatalf("the first query of a turn has nothing to have joined to: %+v", js)
+	}
+}
+
+func TestResolveJoinScope_UndeclaredCrossDatasourceIsNotVerifiedNotRefused(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	st := twoHopState()
+
+	js := st.resolveJoinScope(context.Background(), "wh_b", nil)
+	if js.reject != "" {
+		t.Fatalf("an omitted declaration must never block the query, got reject=%q", js.reject)
+	}
+	if js.scoped == nil || *js.scoped {
+		t.Fatalf("scoped = %v, want an explicit false", js.scoped)
+	}
+	if js.outcome != joinOutcomeUndeclared {
+		t.Fatalf("outcome = %q, want %q", js.outcome, joinOutcomeUndeclared)
+	}
+	if !strings.Contains(js.note, "joins_on") {
+		t.Fatalf("the note must tell the model how to fix it, got %q", js.note)
+	}
+}
+
+func TestResolveJoinScope_RejectsADeclarationThatContradictsTheTurn(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		target   string
+		decl     joinDeclaration
+		outcome  string
+		contains []string
+	}{
+		{
+			name:     "step that never ran",
+			target:   "wh_b",
+			decl:     joinDeclaration{SourceStep: "q7", Field: "user_id"},
+			outcome:  joinOutcomeRejectedStep,
+			contains: []string{"q7", "q1"},
+		},
+		{
+			name:     "step on this same datasource",
+			target:   "wh_a",
+			decl:     joinDeclaration{SourceStep: "q1", Field: "user_id"},
+			outcome:  joinOutcomeRejectedSameDS,
+			contains: []string{"q1", "wh_a"},
+		},
+		{
+			name:     "column that step never returned",
+			target:   "wh_b",
+			decl:     joinDeclaration{SourceStep: "q1", Field: "account_id"},
+			outcome:  joinOutcomeRejectedField,
+			contains: []string{"account_id", "user_id, spend"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A validator that would verify anything — the rejection must come
+			// from the turn's own record, before any report is consulted.
+			wireValidator(t, func(context.Context, agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+				t.Fatal("a self-contradictory declaration must be rejected without consulting the report")
+				return agentplugin.JoinKeyVerdict{}, nil
+			})
+			st := twoHopState()
+			js := st.resolveJoinScope(context.Background(), tc.target, &tc.decl)
+			if js.reject == "" {
+				t.Fatalf("want a rejection, got %+v", js)
+			}
+			if js.scoped != nil {
+				t.Fatal("a rejected query produces no result, so it stamps no verdict")
+			}
+			if js.outcome != tc.outcome {
+				t.Fatalf("outcome = %q, want %q", js.outcome, tc.outcome)
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(js.reject, want) {
+					t.Fatalf("rejection %q must contain %q so the model can repair it", js.reject, want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveJoinScope_UnknownStepIsRejectedEvenWhenTheTurnHasNoStepsYet(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	st := &turnState{req: TurnRequest{ProjectID: "p1"}}
+	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "user_id"})
+	if js.reject == "" {
+		t.Fatal("a declaration citing a step that cannot exist must be rejected")
+	}
+	if !strings.Contains(js.reject, "no query has produced a result yet") {
+		t.Fatalf("rejection should say the turn has no steps, got %q", js.reject)
+	}
+}
+
+func TestResolveJoinScope_VerifiedJoinIsScopedAndSaysNothingMore(t *testing.T) {
+	var seen agentplugin.JoinKeyRequest
+	wireValidator(t, func(_ context.Context, req agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		seen = req
+		return agentplugin.JoinKeyVerdict{Verified: true, Detail: "a shared customer key"}, nil
+	})
+	st := twoHopState()
+
+	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "user_id"})
+	if js.scoped == nil || !*js.scoped {
+		t.Fatalf("scoped = %v, want true", js.scoped)
+	}
+	// Nothing to correct, so nothing is said: the observation exists to warn.
+	if js.note != "" {
+		t.Fatalf("a verified join needs no note, got %q", js.note)
+	}
+	want := agentplugin.JoinKeyRequest{ProjectID: "p1", SourceDatasourceID: "wh_a", TargetDatasourceID: "wh_b", Field: "user_id"}
+	if seen != want {
+		t.Fatalf("validator saw %+v, want %+v", seen, want)
+	}
+}
+
+func TestResolveJoinScope_FieldMatchIgnoresCase(t *testing.T) {
+	wireValidator(t, func(_ context.Context, req agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		// The field reaches the report as the model wrote it — the report,
+		// not this code, decides how names compare.
+		if req.Field != "USER_ID" {
+			t.Fatalf("field = %q, want the model's own spelling", req.Field)
+		}
+		return agentplugin.JoinKeyVerdict{Verified: true}, nil
+	})
+	st := twoHopState()
+	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "USER_ID"})
+	if js.reject != "" {
+		t.Fatalf("column casing varies by warehouse; %q should have matched, got %q", "USER_ID", js.reject)
+	}
+	if js.scoped == nil || !*js.scoped {
+		t.Fatalf("scoped = %v, want true", js.scoped)
+	}
+}
+
+func TestResolveJoinScope_UnverifiedDeclarationQuotesTheReport(t *testing.T) {
+	wireValidator(t, func(context.Context, agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		return agentplugin.JoinKeyVerdict{Detail: "the report lists only campaign_id between these datasources"}, nil
+	})
+	st := twoHopState()
+
+	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "user_id"})
+	if js.reject != "" {
+		t.Fatalf("a report that does not list a field is not proof the join is wrong; must not block: %q", js.reject)
+	}
+	if js.scoped == nil || *js.scoped {
+		t.Fatalf("scoped = %v, want false", js.scoped)
+	}
+	if js.outcome != joinOutcomeUnverified {
+		t.Fatalf("outcome = %q, want %q", js.outcome, joinOutcomeUnverified)
+	}
+	if !strings.Contains(js.note, "campaign_id") {
+		t.Fatalf("the note must carry the report's own words, got %q", js.note)
+	}
+}
+
+func TestResolveJoinScope_NoValidatorWiredIsUnverifiedNotRefused(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	st := twoHopState()
+
+	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "user_id"})
+	if js.reject != "" {
+		t.Fatalf("a deployment with no report must still answer questions, got reject=%q", js.reject)
+	}
+	if js.scoped == nil || *js.scoped {
+		t.Fatalf("scoped = %v, want false — nothing checked it", js.scoped)
+	}
+	if js.outcome != joinOutcomeUnverified {
+		t.Fatalf("outcome = %q, want %q", js.outcome, joinOutcomeUnverified)
+	}
+}
+
+func TestResolveJoinScope_AnUnreachableReportDoesNotFailTheQuery(t *testing.T) {
+	wireValidator(t, func(context.Context, agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		return agentplugin.JoinKeyVerdict{Verified: true}, errors.New("schema cache unreachable")
+	})
+	st := twoHopState()
+
+	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "user_id"})
+	if js.reject != "" {
+		t.Fatalf("an unreachable report is not a reason to refuse the user's query, got %q", js.reject)
+	}
+	if js.scoped == nil || *js.scoped {
+		t.Fatalf("scoped = %v, want false — and never the verdict an errored validator returned", js.scoped)
+	}
+	if js.outcome != joinOutcomeValidatorError {
+		t.Fatalf("outcome = %q, want %q", js.outcome, joinOutcomeValidatorError)
+	}
+	if !strings.Contains(js.note, "unreachable") {
+		t.Fatalf("the note should say what went wrong, got %q", js.note)
+	}
+}
+
+// --- telemetry ---------------------------------------------------------
+
+func TestJoinScopeTrack_ReportsOnlyWhenTheQuestionArose(t *testing.T) {
+	got := captureJoinTelemetry(t)
+	joinScope{}.track(false)
+	if len(*got) != 0 {
+		t.Fatalf("an ordinary single-source query must report nothing, got %v", *got)
+	}
+	joinScope{outcome: joinOutcomeUndeclared}.track(false)
+	joinScope{outcome: joinOutcomeVerified}.track(true)
+	joinScope{outcome: joinOutcomeRejectedField}.track(true)
+	want := []string{"undeclared/" + joinOutcomeUndeclared, "declared/" + joinOutcomeVerified, "declared/" + joinOutcomeRejectedField}
+	if strings.Join(*got, "|") != strings.Join(want, "|") {
+		t.Fatalf("tracked %v, want %v", *got, want)
+	}
+}
+
+// --- observation rendering ---------------------------------------------
+
+func TestObservation_OmitsTheScopeLineWhenThereIsNothingToSay(t *testing.T) {
+	sum := QuerySummary{Step: "q1", RowCount: 1, Columns: []string{"n"}, Preview: []map[string]interface{}{{"n": 1}}}
+	scoped := true
+	withVerdict := sum
+	withVerdict.Scoped = &scoped
+
+	if sum.observation() != withVerdict.observation() {
+		t.Fatalf("a verified result must read exactly like an unremarkable one:\n%q\nvs\n%q", sum.observation(), withVerdict.observation())
+	}
+	if strings.Contains(sum.observation(), "verified") {
+		t.Fatalf("nothing about scope belongs in an ordinary observation: %q", sum.observation())
+	}
+}
+
+func TestObservation_ScopeNoteSitsAheadOfTheSourcesOwnCaveats(t *testing.T) {
+	scoped := false
+	sum := QuerySummary{
+		Step: "q2", RowCount: 1, Columns: []string{"n"}, Preview: []map[string]interface{}{{"n": 1}},
+		Scoped: &scoped, ScopeNote: "SCOPE-NOTE-MARKER",
+		Quality: []gowarehouse.QualityCaveat{{Kind: "sampled", Detail: "12% sample"}},
+	}
+	obs := sum.observation()
+	scopeAt := strings.Index(obs, "SCOPE-NOTE-MARKER")
+	caveatAt := strings.Index(obs, "12% sample")
+	if scopeAt < 0 || caveatAt < 0 {
+		t.Fatalf("both the scope note and the source caveat must be rendered:\n%s", obs)
+	}
+	// The source saying "these rows are not the answer" is the stronger claim,
+	// so it keeps the tail position the loop reserves for corrections.
+	if scopeAt > caveatAt {
+		t.Fatalf("the scope note must precede the source's caveats:\n%s", obs)
+	}
+}
+
+func TestObservation_ScopeNoteIsLastWhenTheSourceReportedNothing(t *testing.T) {
+	scoped := false
+	sum := QuerySummary{
+		Step: "q2", RowCount: 1, Columns: []string{"n"}, Preview: []map[string]interface{}{{"n": 1}},
+		Scoped: &scoped, ScopeNote: "SCOPE-NOTE-MARKER",
+	}
+	obs := sum.observation()
+	if !strings.HasSuffix(obs, "SCOPE-NOTE-MARKER") {
+		t.Fatalf("with no caveats to follow it the note takes the tail position:\n%s", obs)
+	}
+}
+
+// --- summary serialisation ---------------------------------------------
+
+func TestQuerySummary_ScopedIsAbsentUnlessItWasDecided(t *testing.T) {
+	js, err := json.Marshal(QuerySummary{Step: "q1", Columns: []string{"n"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(js), "scoped") {
+		t.Fatalf("an undecided verdict must not appear in the persisted summary: %s", js)
+	}
+	no := false
+	js, err = json.Marshal(QuerySummary{Step: "q1", Columns: []string{"n"}, Scoped: &no})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(js), `"scoped":false`) {
+		// omitempty on a *bool omits nil, not false — a decided "no" is the
+		// whole point and must survive to the record.
+		t.Fatalf("a decided false must be persisted as false: %s", js)
+	}
+}
+
+// --- tool definition ---------------------------------------------------
+
+func TestToolQueryData_JoinsOnAppearsOnlyForAMultiDatasourceTurn(t *testing.T) {
+	single := toolQueryData(false, false)
+	if _, ok := single.InputSchema["properties"].(map[string]interface{})["joins_on"]; ok {
+		t.Fatal("a single-datasource turn has nothing to join across; its tool definition must be unchanged")
+	}
+	multi := toolQueryData(true, false)
+	spec, ok := multi.InputSchema["properties"].(map[string]interface{})["joins_on"].(map[string]interface{})
+	if !ok {
+		t.Fatal("a multi-datasource turn must offer joins_on")
+	}
+	req, _ := spec["required"].([]string)
+	if len(req) != 2 || req[0] != "source_step" || req[1] != "field" {
+		t.Fatalf("joins_on required = %v, want both halves", req)
+	}
+	props, _ := spec["properties"].(map[string]interface{})
+	if _, ok := props["source_step"]; !ok {
+		t.Fatal("joins_on must declare source_step")
+	}
+	if _, ok := props["field"]; !ok {
+		t.Fatal("joins_on must declare field")
+	}
+}
+
+// --- argument parsing (both paths) -------------------------------------
+
+// gollmToolCall wraps a query_data tool input as the provider delivers it.
+func gollmToolCall(input map[string]any) gollm.ToolCall {
+	return gollm.ToolCall{ID: "c1", Name: string(actQuery), Input: input}
+}
+
+func TestToolCallToAction_JoinsOn(t *testing.T) {
+	base := map[string]any{"query": "SELECT 1"}
+	with := func(j any) map[string]any {
+		in := map[string]any{"query": "SELECT 1"}
+		in["joins_on"] = j
+		return in
+	}
+
+	t.Run("absent is not an error", func(t *testing.T) {
+		act, err := toolCallToAction(gollmToolCall(base))
+		if err != nil || act.JoinsOn != nil {
+			t.Fatalf("act=%+v err=%v; an omitted declaration is allowed", act, err)
+		}
+	})
+	t.Run("complete is carried through", func(t *testing.T) {
+		act, err := toolCallToAction(gollmToolCall(with(map[string]any{"source_step": " q1 ", "field": " user_id "})))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if act.JoinsOn == nil || act.JoinsOn.SourceStep != "q1" || act.JoinsOn.Field != "user_id" {
+			t.Fatalf("JoinsOn = %+v, want the trimmed halves", act.JoinsOn)
+		}
+	})
+	t.Run("empty object is the same as absent", func(t *testing.T) {
+		act, err := toolCallToAction(gollmToolCall(with(map[string]any{})))
+		if err != nil || act.JoinsOn != nil {
+			t.Fatalf("act=%+v err=%v", act, err)
+		}
+	})
+	for _, tc := range []struct {
+		name string
+		in   any
+	}{
+		{"missing field", map[string]any{"source_step": "q1"}},
+		{"missing source_step", map[string]any{"field": "user_id"}},
+		{"blank field", map[string]any{"source_step": "q1", "field": "  "}},
+		{"not an object", "q1.user_id"},
+	} {
+		t.Run(tc.name+" is rejected", func(t *testing.T) {
+			// Half a declaration reads like a checked hop and is not one.
+			if _, err := toolCallToAction(gollmToolCall(with(tc.in))); err == nil {
+				t.Fatal("want an error")
+			}
+		})
+	}
+}
+
+func TestParseTurnAction_JoinsOn(t *testing.T) {
+	t.Run("plain key", func(t *testing.T) {
+		act, err := parseTurnAction(`{"query":"SELECT 1","datasource_id":"wh_b","joins_on":{"source_step":"q1","field":"user_id"}}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if act.JoinsOn == nil || act.JoinsOn.SourceStep != "q1" || act.JoinsOn.Field != "user_id" {
+			t.Fatalf("JoinsOn = %+v", act.JoinsOn)
+		}
+	})
+	t.Run("tool envelope", func(t *testing.T) {
+		act, err := parseTurnAction(`{"name":"query_data","input":{"query":"SELECT 1","joins_on":{"source_step":"q2","field":"order_id"}}}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if act.JoinsOn == nil || act.JoinsOn.SourceStep != "q2" || act.JoinsOn.Field != "order_id" {
+			t.Fatalf("JoinsOn = %+v", act.JoinsOn)
+		}
+	})
+	t.Run("absent", func(t *testing.T) {
+		act, err := parseTurnAction(`{"query":"SELECT 1"}`)
+		if err != nil || act.JoinsOn != nil {
+			t.Fatalf("act=%+v err=%v", act, err)
+		}
+	})
+	t.Run("half declared is rejected", func(t *testing.T) {
+		if _, err := parseTurnAction(`{"query":"SELECT 1","joins_on":{"source_step":"q1"}}`); err == nil {
+			t.Fatal("want an error for a declaration missing its field")
+		}
+	})
+	t.Run("empty object is the same as absent", func(t *testing.T) {
+		act, err := parseTurnAction(`{"query":"SELECT 1","joins_on":{}}`)
+		if err != nil || act.JoinsOn != nil {
+			t.Fatalf("act=%+v err=%v", act, err)
+		}
+	})
+}
+
+// --- the prompt --------------------------------------------------------
+
+func TestPrompt_TellsAMultiDatasourceTurnToDeclareItsHop(t *testing.T) {
+	rt := &ProjectRuntime{Datasources: []DatasourceInfo{{ID: "wh_a"}, {ID: "wh_b"}}, PrimaryID: "wh_a"}
+	multi, _ := rt.resolveTurnRouting("")
+	if !strings.Contains(buildSystemPrompt(rt, multi, Config{}, false), "joins_on") {
+		t.Fatal("a turn that can hop must be told how to declare the hop")
+	}
+	// A turn with one datasource cannot hop, so its prompt must not gain a word.
+	single := &ProjectRuntime{Datasources: []DatasourceInfo{{ID: "wh_a"}}, PrimaryID: "wh_a"}
+	pinned, _ := single.resolveTurnRouting("")
+	if strings.Contains(buildSystemPrompt(single, pinned, Config{}, false), "joins_on") {
+		t.Fatal("a single-datasource prompt must be unchanged")
+	}
+}
+
+// --- end to end through the loop ---------------------------------------
+
+// hopTurn drives a two-hop turn: q1 on wh_a, then a second query on wh_b
+// carrying whatever joins_on clause the caller supplies.
+func hopTurn(t *testing.T, joins string) (*fakeStore, *testutil.MockWarehouseProvider) {
+	t.Helper()
+	whA := testutil.NewMockWarehouseProvider("sales")
+	whA.DefaultResult = &gowarehouse.QueryResult{
+		Columns: []string{"user_id"},
+		Rows:    []map[string]interface{}{{"user_id": int64(7)}},
+	}
+	whB := testutil.NewMockWarehouseProvider("crm")
+	rt := twoDatasourceRuntime(&scriptedProvider{responses: []string{
+		`{"query":"SELECT user_id FROM sales.orders","datasource_id":"wh_a"}`,
+		`{"query":"SELECT flagged FROM crm.users WHERE user_id IN (7)","datasource_id":"wh_b"` + joins + `}`,
+		`{"answer":"done"}`,
+	}}, whA, whB, nil, nil)
+	return runMW(t, rt, TurnRequest{}, nil), whB
+}
+
+func summaryOf(t *testing.T, store *fakeStore, i int) QuerySummary {
+	t.Helper()
+	sum, ok := store.events[i].Output.(QuerySummary)
+	if !ok {
+		t.Fatalf("event %d output is %T, want a QuerySummary", i, store.events[i].Output)
+	}
+	return sum
+}
+
+func TestExecQuery_UndeclaredSecondHopIsReturnedButNotVerified(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	tracked := captureJoinTelemetry(t)
+
+	store, whB := hopTurn(t, "")
+	if len(whB.Calls) != 1 {
+		t.Fatalf("the query must still run — an omitted declaration never blocks: %d calls", len(whB.Calls))
+	}
+	if len(store.events) != 2 {
+		t.Fatalf("want two query events, got %d", len(store.events))
+	}
+	// The first hop had nothing before it, so it says nothing about scope.
+	if first := summaryOf(t, store, 0); first.Scoped != nil {
+		t.Fatalf("the first hop must stamp no verdict, got %v", *first.Scoped)
+	}
+	second := summaryOf(t, store, 1)
+	if second.Scoped == nil || *second.Scoped {
+		t.Fatalf("Scoped = %v, want false", second.Scoped)
+	}
+	if !strings.Contains(second.ScopeNote, "joins_on") {
+		t.Fatalf("ScopeNote = %q", second.ScopeNote)
+	}
+	if len(*tracked) != 1 || (*tracked)[0] != "undeclared/"+joinOutcomeUndeclared {
+		t.Fatalf("tracked %v", *tracked)
+	}
+}
+
+func TestExecQuery_DeclaredAndVerifiedHopIsScoped(t *testing.T) {
+	wireValidator(t, func(_ context.Context, req agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		if req.SourceDatasourceID != "wh_a" || req.TargetDatasourceID != "wh_b" || req.Field != "user_id" {
+			t.Fatalf("validator saw %+v", req)
+		}
+		return agentplugin.JoinKeyVerdict{Verified: true, Detail: "shared customer key"}, nil
+	})
+	tracked := captureJoinTelemetry(t)
+
+	store, whB := hopTurn(t, `,"joins_on":{"source_step":"q1","field":"user_id"}`)
+	if len(whB.Calls) != 1 {
+		t.Fatalf("the query should have run, got %d calls", len(whB.Calls))
+	}
+	second := summaryOf(t, store, 1)
+	if second.Scoped == nil || !*second.Scoped {
+		t.Fatalf("Scoped = %v, want true", second.Scoped)
+	}
+	if second.ScopeNote != "" {
+		t.Fatalf("a verified hop needs no note, got %q", second.ScopeNote)
+	}
+	// The claim is persisted next to the query it qualifies.
+	if got, _ := store.events[1].Args["joins_on"].(map[string]any); got == nil || got["field"] != "user_id" {
+		t.Fatalf("the declaration must be recorded on the event, got %v", store.events[1].Args["joins_on"])
+	}
+	if len(*tracked) != 1 || (*tracked)[0] != "declared/"+joinOutcomeVerified {
+		t.Fatalf("tracked %v", *tracked)
+	}
+}
+
+func TestExecQuery_ContradictoryDeclarationRunsNoQuery(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	tracked := captureJoinTelemetry(t)
+
+	store, whB := hopTurn(t, `,"joins_on":{"source_step":"q1","field":"nonexistent"}`)
+	if len(whB.Calls) != 0 {
+		t.Fatalf("a contradictory declaration must cost no warehouse work, got %d calls", len(whB.Calls))
+	}
+	if len(store.events) != 2 {
+		t.Fatalf("want two events (the hop and the rejection), got %d", len(store.events))
+	}
+	rej := store.events[1]
+	if rej.Error == "" || !strings.Contains(rej.Error, "nonexistent") {
+		t.Fatalf("the rejection must be recorded with its reason, got %q", rej.Error)
+	}
+	if rej.Output != nil {
+		t.Fatalf("a rejected query produced no result: %v", rej.Output)
+	}
+	if len(*tracked) != 1 || (*tracked)[0] != "declared/"+joinOutcomeRejectedField {
+		t.Fatalf("tracked %v", *tracked)
+	}
+}
+
+func TestExecQuery_RejectedDeclarationDoesNotGroundTheTurn(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	whA := testutil.NewMockWarehouseProvider("sales")
+	whB := testutil.NewMockWarehouseProvider("crm")
+	rt := twoDatasourceRuntime(&scriptedProvider{responses: []string{
+		// The very first action declares a join to a step that does not exist.
+		`{"query":"SELECT 1 FROM crm.users","datasource_id":"wh_b","joins_on":{"source_step":"q1","field":"user_id"}}`,
+		`{"answer":"done"}`,
+	}}, whA, whB, nil, nil)
+
+	store := runMW(t, rt, TurnRequest{}, nil)
+	if len(whB.Calls) != 0 {
+		t.Fatalf("no query should have run, got %d", len(whB.Calls))
+	}
+	// A rejected call observed no data, so it must not unlock the answer.
+	if store.final.Status != "declined" {
+		t.Fatalf("status = %q; an ungrounded turn must not answer", store.final.Status)
+	}
+}

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -515,6 +515,29 @@ func TestPrompt_TextPathShowsTheExactJoinsOnJSON(t *testing.T) {
 	}
 }
 
+// TestPrompt_TextPathShowsTheFormOnAMixedShapeTurn covers the branch this epic
+// actually exists for: a SQL datasource alongside a cube. The vocabulary block
+// forks on shape, so the form has to be on both forks — and a mixed turn is the
+// one most likely to hop, since a cube is enrichment and cannot answer alone.
+func TestPrompt_TextPathShowsTheFormOnAMixedShapeTurn(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		datasources []DatasourceInfo
+	}{
+		{"sql beside a cube", []DatasourceInfo{{ID: "wh_a"}, cubeDatasource("wh_b")}},
+		{"every datasource a cube", []DatasourceInfo{cubeDatasource("wh_a"), cubeDatasource("wh_b")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &ProjectRuntime{Datasources: tc.datasources, PrimaryID: tc.datasources[0].ID}
+			routing, _ := rt.resolveTurnRouting("")
+			got := buildSystemPrompt(rt, routing, Config{}, false)
+			if !strings.Contains(got, `"joins_on":{"source_step":"q1","field":"user_id"}`) {
+				t.Fatalf("the form must appear on this branch too:\n%s", got)
+			}
+		})
+	}
+}
+
 func TestPrompt_TellsAMultiDatasourceTurnToDeclareItsHop(t *testing.T) {
 	rt := &ProjectRuntime{Datasources: []DatasourceInfo{{ID: "wh_a"}, {ID: "wh_b"}}, PrimaryID: "wh_a"}
 	multi, _ := rt.resolveTurnRouting("")

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -19,12 +19,21 @@ import (
 // columns a later hop could carry across.
 func twoHopState() *turnState {
 	return &turnState{
-		req: TurnRequest{ProjectID: "p1"},
+		req:   TurnRequest{ProjectID: "p1"},
+		round: 2,
 		querySummariesByID: map[string]QuerySummary{
 			"q1": {Step: "q1", Columns: []string{"user_id", "spend"}},
 		},
-		queryStepDatasource: map[string]string{"q1": "wh_a"},
+		queryStepsByID: map[string]queryStep{"q1": {datasource: "wh_a", round: 1}},
 	}
+}
+
+// sameBatchState is a turn whose q1 was issued in the round now executing — the
+// model wrote both queries before seeing either result.
+func sameBatchState() *turnState {
+	st := twoHopState()
+	st.queryStepsByID["q1"] = queryStep{datasource: "wh_a", round: st.round}
+	return st
 }
 
 func wireValidator(t *testing.T, fn agentplugin.JoinKeyValidatorFunc) {
@@ -68,7 +77,7 @@ func TestResolveJoinScope_SingleDatasourceTurnStampsNothing(t *testing.T) {
 }
 
 func TestResolveJoinScope_FirstQueryOfATurnStampsNothing(t *testing.T) {
-	st := &turnState{req: TurnRequest{ProjectID: "p1"}}
+	st := &turnState{req: TurnRequest{ProjectID: "p1"}, round: 1}
 	js := st.resolveJoinScope(context.Background(), "wh_a", nil)
 	if js.scoped != nil || js.outcome != "" {
 		t.Fatalf("the first query of a turn has nothing to have joined to: %+v", js)
@@ -153,12 +162,12 @@ func TestResolveJoinScope_RejectsADeclarationThatContradictsTheTurn(t *testing.T
 
 func TestResolveJoinScope_UnknownStepIsRejectedEvenWhenTheTurnHasNoStepsYet(t *testing.T) {
 	agentplugin.ResetJoinKeyValidatorForTest()
-	st := &turnState{req: TurnRequest{ProjectID: "p1"}}
+	st := &turnState{req: TurnRequest{ProjectID: "p1"}, round: 1}
 	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "user_id"})
 	if js.reject == "" {
 		t.Fatal("a declaration citing a step that cannot exist must be rejected")
 	}
-	if !strings.Contains(js.reject, "no query has produced a result yet") {
+	if !strings.Contains(js.reject, "no query result is available to join on yet") {
 		t.Fatalf("rejection should say the turn has no steps, got %q", js.reject)
 	}
 }
@@ -607,5 +616,108 @@ func TestExecQuery_RejectedDeclarationDoesNotGroundTheTurn(t *testing.T) {
 	// A rejected call observed no data, so it must not unlock the answer.
 	if store.final.Status != "declined" {
 		t.Fatalf("status = %q; an ungrounded turn must not answer", store.final.Status)
+	}
+}
+
+// --- same-batch tool calls ---------------------------------------------
+
+func TestResolveJoinScope_RejectsAJoinOnAStepIssuedInTheSameBatch(t *testing.T) {
+	wireValidator(t, func(context.Context, agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		t.Fatal("a step the model has not seen must be rejected without consulting the report")
+		return agentplugin.JoinKeyVerdict{}, nil
+	})
+	st := sameBatchState()
+
+	js := st.resolveJoinScope(context.Background(), "wh_b", &joinDeclaration{SourceStep: "q1", Field: "user_id"})
+	if js.reject == "" {
+		t.Fatalf("want a rejection, got %+v", js)
+	}
+	if js.scoped != nil {
+		t.Fatalf("a rejected query stamps no verdict, got %v", *js.scoped)
+	}
+	if js.outcome != joinOutcomeRejectedBatch {
+		t.Fatalf("outcome = %q, want %q", js.outcome, joinOutcomeRejectedBatch)
+	}
+	if !strings.Contains(js.reject, "same step") {
+		t.Fatalf("the rejection must say why the values could not have come from it, got %q", js.reject)
+	}
+}
+
+func TestResolveJoinScope_SameBatchQueriesAreNotACrossDatasourceHop(t *testing.T) {
+	agentplugin.ResetJoinKeyValidatorForTest()
+	st := sameBatchState()
+
+	// Two independent queries issued together against different datasources.
+	// Neither could have filtered on the other, so neither is caveated.
+	js := st.resolveJoinScope(context.Background(), "wh_b", nil)
+	if js.scoped != nil {
+		t.Fatalf("scoped = %v, want nil — these queries never touched each other", *js.scoped)
+	}
+	if js.note != "" || js.outcome != "" {
+		t.Fatalf("want an entirely empty verdict, got %+v", js)
+	}
+}
+
+func TestDescribeQuerySteps_OmitsStepsTheModelHasNotSeen(t *testing.T) {
+	st := sameBatchState()
+	if got := st.describeQuerySteps(); strings.Contains(got, "q1") {
+		t.Fatalf("a repair message must not point at a step the next check rejects: %q", got)
+	}
+	st = twoHopState()
+	if got := st.describeQuerySteps(); !strings.Contains(got, "q1") {
+		t.Fatalf("an observed step must be offered: %q", got)
+	}
+}
+
+// TestExecQuery_BatchedHopIsNeitherCertifiedNorCaveated drives the NATIVE tools
+// path with two query_data calls in ONE assistant response — the shape that
+// makes the round rule matter, and the one the JSON-text path cannot produce.
+func TestExecQuery_BatchedHopIsNeitherCertifiedNorCaveated(t *testing.T) {
+	wireValidator(t, func(context.Context, agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		t.Fatal("a batched declaration must be rejected before the report is consulted")
+		return agentplugin.JoinKeyVerdict{}, nil
+	})
+	tracked := captureJoinTelemetry(t)
+
+	whA := testutil.NewMockWarehouseProvider("sales")
+	whB := testutil.NewMockWarehouseProvider("crm")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		{
+			StopReason: "tool_use",
+			ToolCalls: []gollm.ToolCall{
+				{ID: "a", Name: string(actQuery), Input: map[string]any{"query": "SELECT user_id FROM sales.orders", "datasource_id": "wh_a"}},
+				{ID: "b", Name: string(actQuery), Input: map[string]any{"query": "SELECT flagged FROM crm.users", "datasource_id": "wh_b",
+					"joins_on": map[string]any{"source_step": "q1", "field": "user_id"}}},
+			},
+			Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5},
+		},
+		toolCall(string(actAnswer), map[string]any{"text": "done"}),
+	}}
+	rt := twoDatasourceRuntime(p, whA, whB, nil, nil)
+	ensureToolProvider()
+	rt.AIClient.SetProvenance("p1", "", "test-tools")
+
+	store := &fakeStore{}
+	(&runner{cfg: mwConfig(), store: store}).run(context.Background(),
+		rt, TurnRequest{TurnID: "t1", SessionID: "s1", ProjectID: "p1", Question: "q"})
+
+	if len(store.events) != 2 {
+		t.Fatalf("want two query events, got %d: %+v", len(store.events), store.events)
+	}
+	// The first ran; the second declared a join on a result that did not exist
+	// when the model wrote it, so it is rejected rather than certified.
+	if store.events[1].Error == "" {
+		t.Fatalf("the batched declaration should have been rejected, got %+v", store.events[1])
+	}
+	if len(whB.Calls) != 0 {
+		t.Fatalf("the rejected query must not reach the warehouse, got %d calls", len(whB.Calls))
+	}
+	if len(*tracked) != 1 || (*tracked)[0] != "declared/"+joinOutcomeRejectedBatch {
+		t.Fatalf("tracked %v", *tracked)
+	}
+	// And the first query, whose only company was issued alongside it, carries
+	// no cross-datasource caveat.
+	if sum := summaryOf(t, store, 0); sum.Scoped != nil {
+		t.Fatalf("the first query of a batch has nothing before it: scoped = %v", *sum.Scoped)
 	}
 }

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -804,3 +804,74 @@ func TestExecQuery_APanickingValidatorDegradesTheTurnInsteadOfKillingIt(t *testi
 		t.Fatalf("tracked %v", *tracked)
 	}
 }
+
+// TestJoinsOn_BothPathsAgree runs the same declarations through the native tool
+// parser and the JSON-text parser and requires identical verdicts.
+//
+// They diverged once: the text path decoded into a typed struct, so a real
+// attempt spelled with the wrong keys lost every key it had and arrived looking
+// like no attempt at all — no repair for the model, and a turn filed as an
+// undeclared hop in the very measurement that decides whether undeclared hops
+// get refused.
+func TestJoinsOn_BothPathsAgree(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		joins   string
+		wantErr bool
+		want    *joinDeclaration
+	}{
+		{name: "complete", joins: `{"source_step":"q1","field":"user_id"}`, want: &joinDeclaration{SourceStep: "q1", Field: "user_id"}},
+		{name: "absent", joins: ``},
+		{name: "null", joins: `null`},
+		{name: "empty object", joins: `{}`},
+		{name: "missing field", joins: `{"source_step":"q1"}`, wantErr: true},
+		{name: "missing source_step", joins: `{"field":"user_id"}`, wantErr: true},
+		{name: "blank halves", joins: `{"source_step":"  ","field":"  "}`, wantErr: true},
+		{name: "wrong key names entirely", joins: `{"step":"q1","column":"user_id"}`, wantErr: true},
+		{name: "one right key, one wrong", joins: `{"source_step":"q1","column":"user_id"}`, wantErr: true},
+		{name: "not an object", joins: `"q1.user_id"`, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Text path.
+			payload := `{"query":"SELECT 1"}`
+			if tc.joins != "" {
+				payload = `{"query":"SELECT 1","joins_on":` + tc.joins + `}`
+			}
+			textAct, textErr := parseTurnAction(payload)
+
+			// Native tool path.
+			in := map[string]any{"query": "SELECT 1"}
+			if tc.joins != "" && tc.joins != "null" {
+				var v any
+				if err := json.Unmarshal([]byte(tc.joins), &v); err != nil {
+					t.Fatalf("bad fixture: %v", err)
+				}
+				in["joins_on"] = v
+			}
+			toolAct, toolErr := toolCallToAction(gollmToolCall(in))
+
+			if (textErr != nil) != tc.wantErr {
+				t.Fatalf("text path err = %v, wantErr = %v", textErr, tc.wantErr)
+			}
+			if (toolErr != nil) != tc.wantErr {
+				t.Fatalf("tool path err = %v, wantErr = %v", toolErr, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			for _, got := range []struct {
+				path string
+				decl *joinDeclaration
+			}{{"text", textAct.JoinsOn}, {"tool", toolAct.JoinsOn}} {
+				switch {
+				case tc.want == nil && got.decl != nil:
+					t.Fatalf("%s path: JoinsOn = %+v, want nil", got.path, got.decl)
+				case tc.want != nil && got.decl == nil:
+					t.Fatalf("%s path: JoinsOn = nil, want %+v", got.path, tc.want)
+				case tc.want != nil && *got.decl != *tc.want:
+					t.Fatalf("%s path: JoinsOn = %+v, want %+v", got.path, got.decl, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -779,3 +779,28 @@ func TestExecQuery_BatchInALaterRoundIsStillNotObserved(t *testing.T) {
 		t.Fatalf("the rejected query must not reach the warehouse, got %d calls", len(whB.Calls))
 	}
 }
+
+func TestExecQuery_APanickingValidatorDegradesTheTurnInsteadOfKillingIt(t *testing.T) {
+	wireValidator(t, func(context.Context, agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		panic("the report blew up")
+	})
+	tracked := captureJoinTelemetry(t)
+
+	store, whB := hopTurn(t, `,"joins_on":{"source_step":"q1","field":"user_id"}`)
+
+	// The user asked a question; a broken report is not a reason not to answer
+	// it, only a reason not to certify the join.
+	if len(whB.Calls) != 1 {
+		t.Fatalf("the query should still have run, got %d calls", len(whB.Calls))
+	}
+	second := summaryOf(t, store, 1)
+	if second.Scoped == nil || *second.Scoped {
+		t.Fatalf("Scoped = %v, want false", second.Scoped)
+	}
+	if !strings.Contains(second.ScopeNote, "panicked") {
+		t.Fatalf("ScopeNote = %q, want it to say the check failed", second.ScopeNote)
+	}
+	if len(*tracked) != 1 || (*tracked)[0] != "declared/"+joinOutcomeValidatorError {
+		t.Fatalf("tracked %v", *tracked)
+	}
+}

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -24,7 +24,9 @@ func twoHopState() *turnState {
 		querySummariesByID: map[string]QuerySummary{
 			"q1": {Step: "q1", Columns: []string{"user_id", "spend"}},
 		},
-		queryStepsByID: map[string]queryStep{"q1": {datasource: "wh_a", round: 1}},
+		queryStepsByID: map[string]queryStep{
+			"q1": {datasource: "wh_a", columns: []string{"user_id", "spend"}, round: 1},
+		},
 	}
 }
 
@@ -32,7 +34,7 @@ func twoHopState() *turnState {
 // model wrote both queries before seeing either result.
 func sameBatchState() *turnState {
 	st := twoHopState()
-	st.queryStepsByID["q1"] = queryStep{datasource: "wh_a", round: st.round}
+	st.queryStepsByID["q1"] = queryStep{datasource: "wh_a", columns: []string{"user_id", "spend"}, round: st.round}
 	return st
 }
 
@@ -719,5 +721,59 @@ func TestExecQuery_BatchedHopIsNeitherCertifiedNorCaveated(t *testing.T) {
 	// no cross-datasource caveat.
 	if sum := summaryOf(t, store, 0); sum.Scoped != nil {
 		t.Fatalf("the first query of a batch has nothing before it: scoped = %v", *sum.Scoped)
+	}
+}
+
+// TestExecQuery_BatchInALaterRoundIsStillNotObserved pins that a step records
+// the round it actually ran in. A turn whose first round runs one query and
+// whose SECOND round batches two more is the only shape that can tell a real
+// round from a hardcoded one: with a constant, the batched q2 would look like
+// an earlier result and q3's declaration on it would be accepted.
+func TestExecQuery_BatchInALaterRoundIsStillNotObserved(t *testing.T) {
+	wireValidator(t, func(context.Context, agentplugin.JoinKeyRequest) (agentplugin.JoinKeyVerdict, error) {
+		t.Fatal("a step from this same round must be rejected before the report is consulted")
+		return agentplugin.JoinKeyVerdict{}, nil
+	})
+
+	whA := testutil.NewMockWarehouseProvider("sales")
+	whA.DefaultResult = &gowarehouse.QueryResult{
+		Columns: []string{"user_id"},
+		Rows:    []map[string]interface{}{{"user_id": int64(7)}},
+	}
+	whB := testutil.NewMockWarehouseProvider("crm")
+	p := &scriptedToolProvider{responses: []gollm.ChatResponse{
+		// Round 1: one query, observed normally.
+		toolCall(string(actQuery), map[string]any{"query": "SELECT user_id FROM sales.a", "datasource_id": "wh_a"}),
+		// Round 2: two queries at once; the second cites the first of THIS batch.
+		{
+			StopReason: "tool_use",
+			ToolCalls: []gollm.ToolCall{
+				{ID: "a", Name: string(actQuery), Input: map[string]any{"query": "SELECT user_id FROM sales.b", "datasource_id": "wh_a"}},
+				{ID: "b", Name: string(actQuery), Input: map[string]any{"query": "SELECT flagged FROM crm.users", "datasource_id": "wh_b",
+					"joins_on": map[string]any{"source_step": "q2", "field": "user_id"}}},
+			},
+			Usage: gollm.Usage{InputTokens: 10, OutputTokens: 5},
+		},
+		toolCall(string(actAnswer), map[string]any{"text": "done"}),
+	}}
+	rt := twoDatasourceRuntime(p, whA, whB, nil, nil)
+	ensureToolProvider()
+	rt.AIClient.SetProvenance("p1", "", "test-tools")
+
+	store := &fakeStore{}
+	(&runner{cfg: mwConfig(), store: store}).run(context.Background(),
+		rt, TurnRequest{TurnID: "t1", SessionID: "s1", ProjectID: "p1", Question: "q"})
+
+	if len(store.events) != 3 {
+		t.Fatalf("want three query events, got %d", len(store.events))
+	}
+	if store.events[2].Error == "" {
+		t.Fatalf("a declaration on a step from this same round must be rejected, got %+v", store.events[2])
+	}
+	if !strings.Contains(store.events[2].Error, "same step") {
+		t.Fatalf("rejection = %q, want it to name the reason", store.events[2].Error)
+	}
+	if len(whB.Calls) != 0 {
+		t.Fatalf("the rejected query must not reach the warehouse, got %d calls", len(whB.Calls))
 	}
 }

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -932,3 +932,43 @@ func TestJoinsOn_BothPathsAgree(t *testing.T) {
 		})
 	}
 }
+
+// TestParseTurnAction_EnvelopeStubDoesNotHideARealDeclaration covers a payload
+// carrying BOTH a tool envelope and a top-level joins_on stub. A stub is how a
+// model spells "none", so it must not outrank the declaration beside it — the
+// hop would be filed as undeclared with the declaration sitting right there.
+func TestParseTurnAction_EnvelopeStubDoesNotHideARealDeclaration(t *testing.T) {
+	for _, stub := range []string{`null`, `{}`, `{"source_step":"","field":""}`} {
+		t.Run(stub, func(t *testing.T) {
+			act, err := parseTurnAction(`{"name":"query_data","joins_on":` + stub +
+				`,"input":{"query":"SELECT 1","joins_on":{"source_step":"q1","field":"user_id"}}}`)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if act.JoinsOn == nil {
+				t.Fatal("the envelope's real declaration must survive the stub")
+			}
+			if act.JoinsOn.SourceStep != "q1" || act.JoinsOn.Field != "user_id" {
+				t.Fatalf("JoinsOn = %+v", act.JoinsOn)
+			}
+		})
+	}
+	// A malformed top-level value keeps precedence: it carries content, so it
+	// is an attempt, and the model gets it corrected rather than silently
+	// replaced by the envelope's.
+	if _, err := parseTurnAction(`{"name":"query_data","joins_on":{"step":"q1"},` +
+		`"input":{"query":"SELECT 1","joins_on":{"source_step":"q1","field":"user_id"}}}`); err == nil {
+		t.Fatal("a top-level attempt with wrong keys must be corrected, not overwritten")
+	}
+
+	// A real top-level declaration still outranks the envelope's, as every
+	// other key-driven field does.
+	act, err := parseTurnAction(`{"name":"query_data","joins_on":{"source_step":"q2","field":"order_id"},` +
+		`"input":{"query":"SELECT 1","joins_on":{"source_step":"q1","field":"user_id"}}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if act.JoinsOn == nil || act.JoinsOn.SourceStep != "q2" {
+		t.Fatalf("JoinsOn = %+v, want the top-level declaration to win", act.JoinsOn)
+	}
+}

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -481,6 +481,40 @@ func TestParseTurnAction_JoinsOn(t *testing.T) {
 
 // --- the prompt --------------------------------------------------------
 
+// TestPrompt_TextPathShowsTheExactJoinsOnJSON pins that the shape appears where
+// the model must reproduce it from prose alone. The parser refuses a wrong
+// shape; a refusal the prompt gives no way to satisfy is a dead end.
+func TestPrompt_TextPathShowsTheExactJoinsOnJSON(t *testing.T) {
+	rt := &ProjectRuntime{Datasources: []DatasourceInfo{{ID: "wh_a"}, {ID: "wh_b"}}, PrimaryID: "wh_a"}
+	multi, _ := rt.resolveTurnRouting("")
+
+	text := buildSystemPrompt(rt, multi, Config{}, false)
+	for _, want := range []string{`"joins_on":{"source_step":"q1","field":"user_id"}`, "source_step", "field"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("the text prompt must show %q, since nothing else tells it the key names:\n%s", want, text)
+		}
+	}
+	// A declaration the parser accepts must be constructible from the prompt.
+	act, err := parseTurnAction(`{"query":"SELECT 1","datasource_id":"wh_b","joins_on":{"source_step":"q1","field":"user_id"}}`)
+	if err != nil || act.JoinsOn == nil {
+		t.Fatalf("the documented form must parse: act=%+v err=%v", act, err)
+	}
+
+	// The native path carries the contract in the tool schema instead, so its
+	// prompt is not widened with a form the model cannot get wrong there.
+	tools := buildSystemPromptForTools(rt, multi, Config{}, false)
+	if strings.Contains(tools, `"joins_on":{"source_step"`) {
+		t.Fatalf("the tools prompt should not repeat the JSON form:\n%s", tools)
+	}
+
+	// A turn that cannot hop gains nothing at all.
+	single := &ProjectRuntime{Datasources: []DatasourceInfo{{ID: "wh_a"}}, PrimaryID: "wh_a"}
+	pinned, _ := single.resolveTurnRouting("")
+	if strings.Contains(buildSystemPrompt(single, pinned, Config{}, false), "joins_on") {
+		t.Fatal("a single-datasource prompt must be unchanged")
+	}
+}
+
 func TestPrompt_TellsAMultiDatasourceTurnToDeclareItsHop(t *testing.T) {
 	rt := &ProjectRuntime{Datasources: []DatasourceInfo{{ID: "wh_a"}, {ID: "wh_b"}}, PrimaryID: "wh_a"}
 	multi, _ := rt.resolveTurnRouting("")

--- a/services/agent/internal/askserve/joins_test.go
+++ b/services/agent/internal/askserve/joins_test.go
@@ -186,9 +186,13 @@ func TestResolveJoinScope_VerifiedJoinIsScopedAndSaysNothingMore(t *testing.T) {
 	if js.scoped == nil || !*js.scoped {
 		t.Fatalf("scoped = %v, want true", js.scoped)
 	}
-	// Nothing to correct, so nothing is said: the observation exists to warn.
-	if js.note != "" {
-		t.Fatalf("a verified join needs no note, got %q", js.note)
+	// Verified is a claim about the KEY. The note must say so, because silence
+	// would read as certification of something never checked.
+	if !strings.Contains(js.note, "a shared customer key") {
+		t.Fatalf("the note must carry the report's own words, got %q", js.note)
+	}
+	if !strings.Contains(js.note, "your declaration") {
+		t.Fatalf("the note must say the filter itself was not checked, got %q", js.note)
 	}
 	want := agentplugin.JoinKeyRequest{ProjectID: "p1", SourceDatasourceID: "wh_a", TargetDatasourceID: "wh_b", Field: "user_id"}
 	if seen != want {
@@ -292,17 +296,15 @@ func TestJoinScopeTrack_ReportsOnlyWhenTheQuestionArose(t *testing.T) {
 
 // --- observation rendering ---------------------------------------------
 
-func TestObservation_OmitsTheScopeLineWhenThereIsNothingToSay(t *testing.T) {
+func TestObservation_SaysNothingAboutScopeOnASingleDatasourceTurn(t *testing.T) {
+	// The verdict never arises, so the observation must be byte-identical to
+	// what every existing single-datasource turn already renders.
 	sum := QuerySummary{Step: "q1", RowCount: 1, Columns: []string{"n"}, Preview: []map[string]interface{}{{"n": 1}}}
-	scoped := true
-	withVerdict := sum
-	withVerdict.Scoped = &scoped
-
-	if sum.observation() != withVerdict.observation() {
-		t.Fatalf("a verified result must read exactly like an unremarkable one:\n%q\nvs\n%q", sum.observation(), withVerdict.observation())
-	}
-	if strings.Contains(sum.observation(), "verified") {
-		t.Fatalf("nothing about scope belongs in an ordinary observation: %q", sum.observation())
+	obs := sum.observation()
+	for _, word := range []string{"scope", "Scope", "join", "Join", "datasource"} {
+		if strings.Contains(obs, word) {
+			t.Fatalf("nothing about scope belongs in an ordinary observation (%q): %q", word, obs)
+		}
 	}
 }
 
@@ -566,8 +568,8 @@ func TestExecQuery_DeclaredAndVerifiedHopIsScoped(t *testing.T) {
 	if second.Scoped == nil || !*second.Scoped {
 		t.Fatalf("Scoped = %v, want true", second.Scoped)
 	}
-	if second.ScopeNote != "" {
-		t.Fatalf("a verified hop needs no note, got %q", second.ScopeNote)
+	if !strings.Contains(second.ScopeNote, "not something checked here") {
+		t.Fatalf("a verified hop must still say what was NOT checked, got %q", second.ScopeNote)
 	}
 	// The claim is persisted next to the query it qualifies.
 	if got, _ := store.events[1].Args["joins_on"].(map[string]any); got == nil || got["field"] != "user_id" {

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -94,12 +94,12 @@ type turnState struct {
 	// querySummariesByID maps a step id to the query summary the chart validator
 	// grounds against, for O(1) lookup of a chart's referenced source.
 	querySummariesByID map[string]QuerySummary
-	// queryStepDatasource maps a step id to the datasource that step ran
-	// against, so a joins_on declaration can be checked against where its
-	// values actually came from. Kept beside the summaries rather than on them
+	// queryStepsByID maps a step id to where and when that query ran, so a
+	// joins_on declaration can be checked against what the model could
+	// actually have observed. Kept beside the summaries rather than on them
 	// because it is turn bookkeeping, not part of the persisted result — the
-	// tool event already records each query's datasource.
-	queryStepDatasource map[string]string
+	// tool event already records each query's datasource and round.
+	queryStepsByID map[string]queryStep
 	// chartsEnabled is the per-turn entitlement (caller EnableCharts AND the ops
 	// kill-switch). It gates EXECUTION, not just tool offering: the text-fallback
 	// parser accepts render_chart regardless, and a provider can return an
@@ -729,10 +729,10 @@ func (r *runner) execQuery(ctx context.Context, rt *ProjectRuntime, st *turnStat
 		st.querySummariesByID = make(map[string]QuerySummary)
 	}
 	st.querySummariesByID[sum.Step] = sum
-	if st.queryStepDatasource == nil {
-		st.queryStepDatasource = make(map[string]string)
+	if st.queryStepsByID == nil {
+		st.queryStepsByID = make(map[string]queryStep)
 	}
-	st.queryStepDatasource[sum.Step] = dsID
+	st.queryStepsByID[sum.Step] = queryStep{datasource: dsID, round: st.round}
 	if sum.chartable() {
 		st.queriesChartable++
 	}

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -732,7 +732,7 @@ func (r *runner) execQuery(ctx context.Context, rt *ProjectRuntime, st *turnStat
 	if st.queryStepsByID == nil {
 		st.queryStepsByID = make(map[string]queryStep)
 	}
-	st.queryStepsByID[sum.Step] = queryStep{datasource: dsID, round: st.round}
+	st.queryStepsByID[sum.Step] = queryStep{datasource: dsID, columns: sum.Columns, round: st.round}
 	if sum.chartable() {
 		st.queriesChartable++
 	}

--- a/services/agent/internal/askserve/loop.go
+++ b/services/agent/internal/askserve/loop.go
@@ -94,6 +94,12 @@ type turnState struct {
 	// querySummariesByID maps a step id to the query summary the chart validator
 	// grounds against, for O(1) lookup of a chart's referenced source.
 	querySummariesByID map[string]QuerySummary
+	// queryStepDatasource maps a step id to the datasource that step ran
+	// against, so a joins_on declaration can be checked against where its
+	// values actually came from. Kept beside the summaries rather than on them
+	// because it is turn bookkeeping, not part of the persisted result — the
+	// tool event already records each query's datasource.
+	queryStepDatasource map[string]string
 	// chartsEnabled is the per-turn entitlement (caller EnableCharts AND the ops
 	// kill-switch). It gates EXECUTION, not just tool offering: the text-fallback
 	// parser accepts render_chart regardless, and a provider can return an
@@ -631,12 +637,30 @@ func (r *runner) execQuery(ctx context.Context, rt *ProjectRuntime, st *turnStat
 		Name:  string(actQuery),
 		Args:  map[string]any{"sql": act.Query, "purpose": act.Purpose, "datasource_id": dsID},
 	}
+	if act.JoinsOn != nil {
+		// Persisted whether or not it holds up: what the model claimed is the
+		// measurement, and a rejected claim is as much a data point as a
+		// confirmed one.
+		ev.Args["joins_on"] = map[string]any{"source_step": act.JoinsOn.SourceStep, "field": act.JoinsOn.Field}
+	}
 	if derr != nil {
 		// Record what the model asked for so the transcript shows the bad id.
 		ev.Args["datasource_id"] = strings.TrimSpace(act.Datasource)
 		ev.Error = derr.Error()
 		r.emit(ctx, st, ev)
 		return fmt.Sprintf("Query rejected: %s. Target a valid datasource_id from the DATASOURCES list.", derr.Error())
+	}
+
+	// Where this query stands relative to the datasources already queried this
+	// turn. Resolved BEFORE the query runs so a declaration that contradicts
+	// the turn costs no warehouse work, and so the result can never be
+	// summarised without the scope verdict that belongs to it.
+	js := st.resolveJoinScope(ctx, dsID, act.JoinsOn)
+	js.track(act.JoinsOn != nil)
+	if js.reject != "" {
+		ev.Error = js.reject
+		r.emit(ctx, st, ev)
+		return "Query rejected: " + js.reject
 	}
 
 	// NB: we deliberately do NOT call the executor's SetStep here. The runtime
@@ -697,12 +721,18 @@ func (r *runner) execQuery(ctx context.Context, rt *ProjectRuntime, st *turnStat
 	// preview, so a truncated result — whose preview omits rows — cannot ground).
 	st.queryStepSeq++
 	sum.Step = fmt.Sprintf("q%d", st.queryStepSeq)
+	sum.Scoped = js.scoped
+	sum.ScopeNote = js.note
 	ev.Args["step"] = sum.Step
 	ev.Output = sum
 	if st.querySummariesByID == nil {
 		st.querySummariesByID = make(map[string]QuerySummary)
 	}
 	st.querySummariesByID[sum.Step] = sum
+	if st.queryStepDatasource == nil {
+		st.queryStepDatasource = make(map[string]string)
+	}
+	st.queryStepDatasource[sum.Step] = dsID
 	if sum.chartable() {
 		st.queriesChartable++
 	}

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -45,9 +45,11 @@ func buildSystemPrompt(rt *ProjectRuntime, routing turnRouting, cfg Config, char
 		if !shapes.allCube {
 			b.WriteString(`  {"thinking":"...","datasource_id":"<id>","lookup_schema":["dataset.table_a"]}` + "  — get columns + sample rows for tables in one datasource\n")
 		}
+		writeJoinsOnForm(&b)
 	case routing.multi:
 		b.WriteString(`  {"thinking":"...","datasource_id":"<id>","query":"SELECT ...","purpose":"what this answers"}` + "  — run a read-only SQL query against one datasource\n")
 		b.WriteString(`  {"thinking":"...","datasource_id":"<id>","lookup_schema":["dataset.table_a"]}` + "  — get columns + sample rows for tables in one datasource\n")
+		writeJoinsOnForm(&b)
 	case shapes.anyCube:
 		b.WriteString(`  {"thinking":"...","query":"...","purpose":"what this answers"}` + "  — run a read-only query, written in this source's query language\n")
 	default:
@@ -338,6 +340,19 @@ func writeDatasourcesSection(b *strings.Builder, routing turnRouting) {
 	}
 	b.WriteString("- To combine datasources, do it in HOPS: query one datasource, then use a SMALL set of the result values (e.g. the top-N ids you observed) as literal filters in a follow-up query on another datasource. Keep the crossed set small — only values you have actually observed in a result this turn. Do not attempt a cross-datasource join in a single query.\n")
 	b.WriteString("- On that follow-up query, set joins_on to the step you took the values from and the column they came from. The same-looking id in two datasources is not always the same thing; declaring it is what gets the join key checked, and a result whose hop was never declared comes back marked as not verified.\n")
+}
+
+// writeJoinsOnForm shows the exact JSON a joins_on declaration must take.
+//
+// Only on the text path, and only for a turn that can hop. The native path
+// carries the same contract in the tool schema, where the model cannot get the
+// key names wrong; here the shape exists nowhere else, and prose alone invites
+// `"joins_on":"q1.user_id"` or `{"step":..,"column":..}` — both of which the
+// parser now refuses. Describing a required form without showing it is how a
+// refusal becomes a dead end rather than a correction.
+func writeJoinsOnForm(b *strings.Builder) {
+	b.WriteString(`  …plus "joins_on":{"source_step":"q1","field":"user_id"} on a query that filters on values from an earlier step against ANOTHER datasource` +
+		" — exactly those two keys: the q<N> id of that step, and the column IN ITS RESULT the values came from. Omit joins_on entirely otherwise.\n")
 }
 
 // writeCubeCatalogLine renders one catalog entry's shape and language.

--- a/services/agent/internal/askserve/prompt.go
+++ b/services/agent/internal/askserve/prompt.go
@@ -337,6 +337,7 @@ func writeDatasourcesSection(b *strings.Builder, routing turnRouting) {
 		b.WriteString("- Pick the datasource whose contents match the question. Use search_tables (it spans all datasources and tags each table with its datasource) when you're unsure which one holds what.\n")
 	}
 	b.WriteString("- To combine datasources, do it in HOPS: query one datasource, then use a SMALL set of the result values (e.g. the top-N ids you observed) as literal filters in a follow-up query on another datasource. Keep the crossed set small — only values you have actually observed in a result this turn. Do not attempt a cross-datasource join in a single query.\n")
+	b.WriteString("- On that follow-up query, set joins_on to the step you took the values from and the column they came from. The same-looking id in two datasources is not always the same thing; declaring it is what gets the join key checked, and a result whose hop was never declared comes back marked as not verified.\n")
 }
 
 // writeCubeCatalogLine renders one catalog entry's shape and language.

--- a/services/agent/internal/askserve/summarize.go
+++ b/services/agent/internal/askserve/summarize.go
@@ -40,16 +40,28 @@ type QuerySummary struct {
 	// Persisted with the tool event, so a turn answered from a degraded result
 	// is identifiable afterwards rather than only in the moment.
 	Quality []gowarehouse.QualityCaveat `json:"quality,omitempty" bson:"quality,omitempty"`
-	// Scoped says whether this result was verified as restricted to the rows
-	// the turn observed on ANOTHER datasource. It is set only on a query made
+	// Scoped says whether the key this result's hop was declared to join on is
+	// a real key between the two datasources. It is set only on a query made
 	// after a different datasource was queried in the same turn; nil — the
 	// normal case, and every single-datasource turn — means the question never
 	// arose, so an existing turn's persisted summary is unchanged.
 	//
-	// True requires a positive answer from a join-key report. False is not an
-	// accusation: it covers an undeclared hop, a report that does not list the
-	// declared field, and a report that could not be reached. ScopeNote says
-	// which, and is what the model is shown.
+	// Read what true claims precisely, because it is narrower than the name
+	// suggests. It says a join-key report positively named the declared field
+	// as binding these two datasources. It does NOT say this query applied
+	// that key: that the query filtered on the values observed in the earlier
+	// step is the model's declaration, and nothing here re-checks it.
+	//
+	// Nothing here CAN re-check it. The only available evidence would be the
+	// query text, and matching a field or a value against query text is what
+	// this epic's #375 established is not evidence at all — a request-shaped
+	// query contains the name while filtering by nothing. A weaker claim
+	// honestly stated beats a stronger one resting on a check that does not
+	// work, which is the same rule the tenant filter now follows.
+	//
+	// False is not an accusation either: it covers an undeclared hop, a report
+	// that does not list the declared field, and a report that could not be
+	// reached. ScopeNote says which, and is what the model is shown.
 	//
 	// It deliberately does not affect chartability, unlike Quality. These rows
 	// are a faithful result of the query that ran; what is unverified is what

--- a/services/agent/internal/askserve/summarize.go
+++ b/services/agent/internal/askserve/summarize.go
@@ -50,6 +50,12 @@ type QuerySummary struct {
 	// accusation: it covers an undeclared hop, a report that does not list the
 	// declared field, and a report that could not be reached. ScopeNote says
 	// which, and is what the model is shown.
+	//
+	// It deliberately does not affect chartability, unlike Quality. These rows
+	// are a faithful result of the query that ran; what is unverified is what
+	// the filter values MEAN across two sources. Withholding the chart would
+	// also stop charts working on the second hop of every existing SQL turn,
+	// which is the behaviour this was required not to change.
 	Scoped    *bool  `json:"scoped,omitempty" bson:"scoped,omitempty"`
 	ScopeNote string `json:"scope_note,omitempty" bson:"scope_note,omitempty"`
 }

--- a/services/agent/internal/askserve/summarize.go
+++ b/services/agent/internal/askserve/summarize.go
@@ -40,6 +40,18 @@ type QuerySummary struct {
 	// Persisted with the tool event, so a turn answered from a degraded result
 	// is identifiable afterwards rather than only in the moment.
 	Quality []gowarehouse.QualityCaveat `json:"quality,omitempty" bson:"quality,omitempty"`
+	// Scoped says whether this result was verified as restricted to the rows
+	// the turn observed on ANOTHER datasource. It is set only on a query made
+	// after a different datasource was queried in the same turn; nil — the
+	// normal case, and every single-datasource turn — means the question never
+	// arose, so an existing turn's persisted summary is unchanged.
+	//
+	// True requires a positive answer from a join-key report. False is not an
+	// accusation: it covers an undeclared hop, a report that does not list the
+	// declared field, and a report that could not be reached. ScopeNote says
+	// which, and is what the model is shown.
+	Scoped    *bool  `json:"scoped,omitempty" bson:"scoped,omitempty"`
+	ScopeNote string `json:"scope_note,omitempty" bson:"scope_note,omitempty"`
 }
 
 // summarizeResult turns an executor result into a bounded QuerySummary,
@@ -117,6 +129,13 @@ func (s QuerySummary) observation() string {
 	if s.Note != "" {
 		b.WriteString(s.Note)
 		b.WriteByte('\n')
+	}
+	// Before the source's own caveats, so that when a result carries both, the
+	// stronger statement — the source saying these rows are not the answer —
+	// is the one left in the tail position the loop reserves for corrections.
+	// With no caveats to follow it this note holds that position itself.
+	if s.ScopeNote != "" {
+		b.WriteString("\n" + s.ScopeNote + "\n")
 	}
 	// Last, and as an instruction. A model that has already read the rows and
 	// the preview needs to be told what they are NOT before it starts

--- a/services/agent/internal/askserve/tools.go
+++ b/services/agent/internal/askserve/tools.go
@@ -52,6 +52,17 @@ func toolQueryData(multi, hasCube bool) gollm.ToolDefinition {
 		desc += " This project has multiple datasources — set datasource_id to the one this query runs against (a single query cannot span datasources; " +
 			"to combine datasources, query one, then use its result values as literal filters in a follow-up query on another)."
 		props["datasource_id"] = map[string]interface{}{"type": "string", "description": "The datasource this query runs against (see the DATASOURCES list). Defaults to the primary if omitted."}
+		props["joins_on"] = map[string]interface{}{
+			"type": "object",
+			"description": "Set this when the query filters on values you read out of an EARLIER query against a DIFFERENT datasource, naming where those values came from. " +
+				"It is how a cross-datasource hop gets its join key checked: declared and confirmed, the result is marked scoped; left out, the result is returned but marked as not verified against the other datasource. " +
+				"Omit it for a query that stands on its own.",
+			"properties": map[string]interface{}{
+				"source_step": map[string]interface{}{"type": "string", "description": "The q<N> id of the earlier query you took the values from, e.g. \"q1\"."},
+				"field":       map[string]interface{}{"type": "string", "description": "The column IN THAT RESULT whose values this query filters on — the name as it appeared there, not the name it has in this datasource."},
+			},
+			"required": []string{"source_step", "field"},
+		}
 	}
 	return gollm.ToolDefinition{
 		Name:        string(actQuery),
@@ -315,7 +326,11 @@ func toolCallToAction(tc gollm.ToolCall) (*turnAction, error) {
 		if strings.TrimSpace(q) == "" {
 			return nil, fmt.Errorf("query_data requires a non-empty %q argument", "query")
 		}
-		return &turnAction{Kind: actQuery, Query: q, Purpose: getStr("purpose"), Datasource: getStr("datasource_id")}, nil
+		joins, jerr := joinsFromToolInput(tc.Input["joins_on"])
+		if jerr != nil {
+			return nil, jerr
+		}
+		return &turnAction{Kind: actQuery, Query: q, Purpose: getStr("purpose"), Datasource: getStr("datasource_id"), JoinsOn: joins}, nil
 	case actLookup:
 		tables := toStringSlice(tc.Input["tables"])
 		if len(tables) == 0 {
@@ -388,4 +403,33 @@ func toInt(v interface{}) int {
 		return int(n)
 	}
 	return 0
+}
+
+// joinsFromToolInput reads the optional joins_on argument of a query_data tool
+// call. An absent or null argument is not an error — the declaration is
+// optional. A present one missing either half IS: half a declaration says
+// values were carried across without saying from where, which is no more
+// checkable than saying nothing and reads as though it were.
+func joinsFromToolInput(v interface{}) (*joinDeclaration, error) {
+	if v == nil {
+		return nil, nil
+	}
+	obj, ok := v.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("query_data %q must be an object with %q and %q", "joins_on", "source_step", "field")
+	}
+	if len(obj) == 0 {
+		return nil, nil
+	}
+	str := func(k string) string {
+		if s, ok := obj[k].(string); ok {
+			return strings.TrimSpace(s)
+		}
+		return ""
+	}
+	step, field := str("source_step"), str("field")
+	if step == "" || field == "" {
+		return nil, fmt.Errorf("query_data %q requires both %q (the q<N> id of the earlier query) and %q (the column in that result the values came from); omit joins_on entirely if this query stands on its own", "joins_on", "source_step", "field")
+	}
+	return &joinDeclaration{SourceStep: step, Field: field}, nil
 }


### PR DESCRIPTION
Part of #252 (W5 — join-key validation). Second half of the direction on cross-datasource hops; the first half shipped in #375.

## The problem

A turn combines datasources in hops: query one, then filter another by values read out of that result. Whether the hop is sound turns on something no amount of looking at the query can settle — that the field those values came from names the same entities on both sides. An `order_id` that is an order id in the warehouse and a session id in the analytics source produces a perfectly well-formed answer about the wrong rows, and nothing in the result says so.

## What this adds

**`joins_on: {source_step, field}`** — an optional argument on `query_data`, offered only on a multi-datasource turn, where the model says which earlier step it took the values from and which column they came from. `field` is the **source-side** name deliberately: that is the one the model actually observed, so the claim can be checked against what that step returned.

**A result now says whether its scope was verified.** `QuerySummary.Scoped` is set only on a query made after a *different* datasource was queried in the same turn — nil, and therefore absent from the persisted summary and the observation, on every single-datasource turn and on the first hop of a multi one.

| | outcome |
|---|---|
| declared, and a join-key report confirms the field | `scoped: true`, nothing added to the observation |
| declared, but no report / the report lists other keys / the report is unreachable | `scoped: false` + a note saying which |
| **not** declared, on a turn that already queried another datasource | `scoped: false` + a note naming `joins_on` |
| declared, but self-contradictory | the query is **rejected** before it runs |

**Omission never blocks** — that was the explicit constraint, and it is what keeps the existing SQL multi-hop path working unchanged. A *self-contradictory* declaration is a different thing and is rejected: naming a step that never ran, a step on this same datasource, or a column that step never returned is a false claim the turn can check, and the rejection hands back what is needed to repair it (the real step ids, the real columns). It costs no warehouse work — the verdict resolves before the connection is acquired.

**`libs/go-common/agentplugin`** gains the seam the connect-time binding report plugs into. It has to live outside `internal/`, and it is deliberately one-sided: `Verified: true` requires a report to positively name the field; an absent report, an unindexed datasource, and a validator that errors all land on false, because none of them proves the join is *wrong* either. With nothing wired — a platform-only deployment — every declared join comes back unverified rather than fine.

**Telemetry** (`cross_datasource_query`, coarse and id-free: `declared` + `outcome`) is the evidence for the follow-up already scheduled — tightening an undeclared cross-datasource filter from a caveat to a refusal, once the numbers show the model populates the declaration reliably. It carries no field name, datasource id, or project.

## Verification

- `make build`, `make lint-go` (0 issues), `make lint-docs`, both module suites, `-count=2` on the touched packages. CI green; `MERGEABLE / CLEAN`.
- **Mutation-tested throughout, six batches.** It found four things the reviewer did not: a hardcoded step round that every test accepted, an unreachable guard, an untested cube branch, and a line that provably cannot change behaviour (deleted rather than kept as defence). Two survivors are genuine **equivalent mutants**: swapping `hasJSONPayload` for a length check on `null` reaches the same answer by a different route, and clearing the verdict inside the panic recover is unobservable because a panicking call never assigned it. Recorded as equivalent rather than counted as covered.
- Three known `-count=2` failures in `libs/go-common/llm` and one in `libs/go-common/mongodb` (a local port collision) are pre-existing on the bridge — verified unmodified there.

## Review history — seven Codex rounds at `xhigh`, the last one clean

Five P2s and a P3, every one valid and fixed:

| # | Finding | |
|---|---|---|
| 1 | Same-batch tool calls read as observed | Could stamp `scoped: true` on a hop that provably never happened, and caveat two independent queries that never touched each other |
| 2 | `scoped` claimed more than it verified | Narrowed the claim. The suggested remedy — check the query text for the observed values — is the bug #375 removed, so it was deliberately not built |
| 3 | A plugin panic could kill the agent | A turn goroutine has no recover; a nil map in a validator would take down every concurrent turn over a question whose honest answer was "cannot tell" |
| 4 | The text parser silently dropped malformed declarations | Filed real attempts as non-attempts in the telemetry meant to decide whether attempts can be relied on |
| 5 | The text prompt never showed the shape #4 made mandatory | A refusal the prompt gives no way to satisfy. Created by the previous fix |
| 6 | A leftover envelope stub outranked a real declaration | #4's failure reached another way; separated precedence from validity |

**Round 7 is clean.** It ran to completion on `e584b9b` and reported no findings: *"I did not identify any discrete correctness issues introduced by this patch. The added join-key validation path appears covered by targeted tests and preserves existing single-datasource behavior."* An earlier attempt at round 7 had died on the Codex account's usage limit — worth noting because that failure exits 0 and prints a review-shaped tail, so an interrupted round reads exactly like a clean one unless you go looking for the error string. Before quota returned I also re-read the whole diff myself and found one thing: the file-level comment enumerated the rejections and had gone stale as rejections were added. Fixed here.

## Follow-up

The enterprise side wires `datasources/binding` into the seam and documents the hop in `docs/multi-warehouse.md`. Until it lands, a declared join is checked for provenance but not compatibility — and says so.

— Co-coded with Jale 🤖

