### PR TITLE
feat(agent): record which catalog items are dimensions (#252 W5)

### DIFF
--- a/services/agent/internal/database/catalog_cache_integration_test.go
+++ b/services/agent/internal/database/catalog_cache_integration_test.go
@@ -6,8 +6,19 @@ import (
 	"context"
 	"testing"
 
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
+
+// dims renders refs as dimension items, which is what these cases are about —
+// the kind matters only to the tests that name it.
+func dims(refs ...string) []gowarehouse.CatalogItem {
+	out := make([]gowarehouse.CatalogItem, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, gowarehouse.CatalogItem{Ref: r, Kind: gowarehouse.ItemKindDimension})
+	}
+	return out
+}
 
 const catalogTestProject = "catalog-cache-proj"
 
@@ -21,7 +32,7 @@ func TestAgentInteg_CatalogCache_RoundTrip(t *testing.T) {
 	r := NewSchemaCacheRepository(db)
 
 	refs := []string{"sessions", "activeUsers", "sessionDefaultChannelGroup"}
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", refs); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims(refs...)); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
 
@@ -58,7 +69,7 @@ func TestAgentInteg_CatalogCache_NotReadAsTableSchemas(t *testing.T) {
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", []string{"sessions"}); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions")); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
 
@@ -94,7 +105,7 @@ func TestAgentInteg_CatalogCache_SaveOfEitherKindReplacesTheOther(t *testing.T) 
 		}); err != nil {
 			t.Fatalf("Save: %v", err)
 		}
-		if err := r.SaveCatalog(ctx, catalogTestProject, "moved", "hash-a", []string{"sessions"}); err != nil {
+		if err := r.SaveCatalog(ctx, catalogTestProject, "moved", "hash-a", dims("sessions")); err != nil {
 			t.Fatalf("SaveCatalog: %v", err)
 		}
 
@@ -112,7 +123,7 @@ func TestAgentInteg_CatalogCache_SaveOfEitherKindReplacesTheOther(t *testing.T) 
 	})
 
 	t.Run("a table save retracts the catalog", func(t *testing.T) {
-		if err := r.SaveCatalog(ctx, catalogTestProject, "moved-back", "hash-b", []string{"sessions"}); err != nil {
+		if err := r.SaveCatalog(ctx, catalogTestProject, "moved-back", "hash-b", dims("sessions")); err != nil {
 			t.Fatalf("SaveCatalog: %v", err)
 		}
 		if err := r.Save(ctx, catalogTestProject, "moved-back", "hash-b", map[string]models.TableSchema{
@@ -144,10 +155,10 @@ func TestAgentInteg_CatalogCache_ResaveReplaces(t *testing.T) {
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", []string{"sessions", "retiredMetric"}); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions", "retiredMetric")); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", []string{"sessions"}); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions")); err != nil {
 		t.Fatalf("SaveCatalog (resave): %v", err)
 	}
 
@@ -171,7 +182,7 @@ func TestAgentInteg_CatalogCache_EmptySaveClearsPriorRefs(t *testing.T) {
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", []string{"sessions", "retiredMetric"}); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions", "retiredMetric")); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
 	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", nil); err != nil {
@@ -184,5 +195,103 @@ func TestAgentInteg_CatalogCache_EmptySaveClearsPriorRefs(t *testing.T) {
 	}
 	if len(refs) != 0 {
 		t.Errorf("refs = %v, want none — an empty save must retract the previous catalog, not be ignored", refs)
+	}
+}
+
+// A catalog names dimensions and metrics in one flat list, and a source can
+// spell them alike — a GA4 custom metric and a custom event-scoped dimension
+// are both customEvent:<name>. Anything asking "could this field identify a
+// record?" therefore cannot read Refs: it would hand back a measure as though
+// the question had been answered.
+func TestAgentInteg_CatalogCache_KeepsDimensionsApartFromMetrics(t *testing.T) {
+	db, cleanup := setupMongoDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewSchemaCacheRepository(db)
+
+	items := []gowarehouse.CatalogItem{
+		{Ref: "sessionDefaultChannelGroup", Kind: gowarehouse.ItemKindDimension},
+		{Ref: "customEvent:crm_id", Kind: gowarehouse.ItemKindDimension},
+		{Ref: "sessions", Kind: gowarehouse.ItemKindMetric},
+		{Ref: "customEvent:score", Kind: gowarehouse.ItemKindMetric},
+	}
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", items); err != nil {
+		t.Fatalf("SaveCatalog: %v", err)
+	}
+
+	// Everything is still searchable.
+	refs, err := r.FindCatalog(ctx, catalogTestProject, "ga", "hash-a")
+	if err != nil {
+		t.Fatalf("FindCatalog: %v", err)
+	}
+	if len(refs) != 4 {
+		t.Errorf("FindCatalog = %v, want all four items", refs)
+	}
+
+	got, err := r.FindCatalogDimensions(ctx, catalogTestProject, "ga", "hash-a")
+	if err != nil {
+		t.Fatalf("FindCatalogDimensions: %v", err)
+	}
+	want := []string{"sessionDefaultChannelGroup", "customEvent:crm_id"}
+	if len(got) != len(want) {
+		t.Fatalf("FindCatalogDimensions = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("FindCatalogDimensions[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// A row written before dimension_refs existed knows nothing about kinds, and
+// that is not the same as knowing there are no dimensions. Falling back to Refs
+// would answer with metrics; answering nothing makes the datasource read as
+// unindexed for this question until it is indexed again, which is the safe
+// direction and the only honest one.
+func TestAgentInteg_CatalogCache_ALegacyRowReportsNoDimensions(t *testing.T) {
+	db, cleanup := setupMongoDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewSchemaCacheRepository(db)
+
+	if _, err := db.Collection(CollectionSchemaCache).InsertOne(ctx, CatalogCacheEntry{
+		ProjectID:     catalogTestProject,
+		WarehouseID:   "ga",
+		WarehouseHash: "hash-legacy",
+		EntryKind:     catalogEntryKind,
+		Refs:          []string{"sessions", "customEvent:score"},
+	}); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	got, err := r.FindCatalogDimensions(ctx, catalogTestProject, "ga", "hash-legacy")
+	if err != nil {
+		t.Fatalf("FindCatalogDimensions: %v", err)
+	}
+	if got != nil {
+		t.Errorf("FindCatalogDimensions = %v, want nil for a row that never recorded kinds", got)
+	}
+}
+
+// A catalog of nothing but metrics has no dimensions, which is a real answer
+// and not the legacy one — but they read alike, and both are safe: the caller
+// treats each as "nothing to bind on".
+func TestAgentInteg_CatalogCache_AMetricOnlyCatalogYieldsNoDimensions(t *testing.T) {
+	db, cleanup := setupMongoDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	r := NewSchemaCacheRepository(db)
+
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-m", []gowarehouse.CatalogItem{
+		{Ref: "sessions", Kind: gowarehouse.ItemKindMetric},
+	}); err != nil {
+		t.Fatalf("SaveCatalog: %v", err)
+	}
+	got, err := r.FindCatalogDimensions(ctx, catalogTestProject, "ga", "hash-m")
+	if err != nil {
+		t.Fatalf("FindCatalogDimensions: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("FindCatalogDimensions = %v, want none", got)
 	}
 }

--- a/services/agent/internal/database/catalog_cache_integration_test.go
+++ b/services/agent/internal/database/catalog_cache_integration_test.go
@@ -6,19 +6,12 @@ import (
 	"context"
 	"testing"
 
-	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
 
-// dims renders refs as dimension items, which is what these cases are about —
-// the kind matters only to the tests that name it.
-func dims(refs ...string) []gowarehouse.CatalogItem {
-	out := make([]gowarehouse.CatalogItem, 0, len(refs))
-	for _, r := range refs {
-		out = append(out, gowarehouse.CatalogItem{Ref: r, Kind: gowarehouse.ItemKindDimension})
-	}
-	return out
-}
+// dims is refs that are all dimensions, which is what these cases are about —
+// the split matters only to the tests that name it.
+func dims(refs ...string) []string { return refs }
 
 const catalogTestProject = "catalog-cache-proj"
 
@@ -32,7 +25,7 @@ func TestAgentInteg_CatalogCache_RoundTrip(t *testing.T) {
 	r := NewSchemaCacheRepository(db)
 
 	refs := []string{"sessions", "activeUsers", "sessionDefaultChannelGroup"}
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims(refs...)); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims(refs...), dims(refs...)); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
 
@@ -69,7 +62,7 @@ func TestAgentInteg_CatalogCache_NotReadAsTableSchemas(t *testing.T) {
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions")); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions"), dims("sessions")); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
 
@@ -105,7 +98,7 @@ func TestAgentInteg_CatalogCache_SaveOfEitherKindReplacesTheOther(t *testing.T) 
 		}); err != nil {
 			t.Fatalf("Save: %v", err)
 		}
-		if err := r.SaveCatalog(ctx, catalogTestProject, "moved", "hash-a", dims("sessions")); err != nil {
+		if err := r.SaveCatalog(ctx, catalogTestProject, "moved", "hash-a", dims("sessions"), dims("sessions")); err != nil {
 			t.Fatalf("SaveCatalog: %v", err)
 		}
 
@@ -123,7 +116,7 @@ func TestAgentInteg_CatalogCache_SaveOfEitherKindReplacesTheOther(t *testing.T) 
 	})
 
 	t.Run("a table save retracts the catalog", func(t *testing.T) {
-		if err := r.SaveCatalog(ctx, catalogTestProject, "moved-back", "hash-b", dims("sessions")); err != nil {
+		if err := r.SaveCatalog(ctx, catalogTestProject, "moved-back", "hash-b", dims("sessions"), dims("sessions")); err != nil {
 			t.Fatalf("SaveCatalog: %v", err)
 		}
 		if err := r.Save(ctx, catalogTestProject, "moved-back", "hash-b", map[string]models.TableSchema{
@@ -155,10 +148,10 @@ func TestAgentInteg_CatalogCache_ResaveReplaces(t *testing.T) {
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions", "retiredMetric")); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions", "retiredMetric"), nil); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions")); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions"), dims("sessions")); err != nil {
 		t.Fatalf("SaveCatalog (resave): %v", err)
 	}
 
@@ -182,10 +175,10 @@ func TestAgentInteg_CatalogCache_EmptySaveClearsPriorRefs(t *testing.T) {
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions", "retiredMetric")); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", dims("sessions", "retiredMetric"), nil); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", nil); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", nil, nil); err != nil {
 		t.Fatalf("SaveCatalog(empty): %v", err)
 	}
 
@@ -209,23 +202,19 @@ func TestAgentInteg_CatalogCache_KeepsDimensionsApartFromMetrics(t *testing.T) {
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	items := []gowarehouse.CatalogItem{
-		{Ref: "sessionDefaultChannelGroup", Kind: gowarehouse.ItemKindDimension},
-		{Ref: "customEvent:crm_id", Kind: gowarehouse.ItemKindDimension},
-		{Ref: "sessions", Kind: gowarehouse.ItemKindMetric},
-		{Ref: "customEvent:score", Kind: gowarehouse.ItemKindMetric},
-	}
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", items); err != nil {
+	refs := []string{"sessionDefaultChannelGroup", "customEvent:crm_id", "sessions", "customEvent:score"}
+	dimensions := []string{"sessionDefaultChannelGroup", "customEvent:crm_id"}
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-a", refs, dimensions); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
 
 	// Everything is still searchable.
-	refs, err := r.FindCatalog(ctx, catalogTestProject, "ga", "hash-a")
+	got0, err := r.FindCatalog(ctx, catalogTestProject, "ga", "hash-a")
 	if err != nil {
 		t.Fatalf("FindCatalog: %v", err)
 	}
-	if len(refs) != 4 {
-		t.Errorf("FindCatalog = %v, want all four items", refs)
+	if len(got0) != 4 {
+		t.Errorf("FindCatalog = %v, want all four items", got0)
 	}
 
 	got, err := r.FindCatalogDimensions(ctx, catalogTestProject, "ga", "hash-a")
@@ -282,9 +271,7 @@ func TestAgentInteg_CatalogCache_AMetricOnlyCatalogYieldsNoDimensions(t *testing
 	ctx := context.Background()
 	r := NewSchemaCacheRepository(db)
 
-	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-m", []gowarehouse.CatalogItem{
-		{Ref: "sessions", Kind: gowarehouse.ItemKindMetric},
-	}); err != nil {
+	if err := r.SaveCatalog(ctx, catalogTestProject, "ga", "hash-m", []string{"sessions"}, nil); err != nil {
 		t.Fatalf("SaveCatalog: %v", err)
 	}
 	got, err := r.FindCatalogDimensions(ctx, catalogTestProject, "ga", "hash-m")

--- a/services/agent/internal/database/schema_cache_repo.go
+++ b/services/agent/internal/database/schema_cache_repo.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -313,6 +314,22 @@ type CatalogCacheEntry struct {
 	EntryKind     string    `bson:"entry_kind"`
 	Refs          []string  `bson:"refs"`
 	CachedAt      time.Time `bson:"cached_at"`
+
+	// DimensionRefs are the subset of Refs that identify or group rows, as
+	// opposed to measuring them.
+	//
+	// Kept separately because Refs alone cannot answer "could this field
+	// identify a record?" — a catalog names dimensions and metrics in one flat
+	// list, and a source may spell them alike: a GA4 custom metric and a custom
+	// event-scoped dimension are both customEvent:<name>. Anything deciding
+	// whether a field can bind two datasources has to read this rather than
+	// Refs, because a metric is a measure and joining on one is meaningless.
+	//
+	// Omitted when empty, and absent entirely on rows written before this
+	// existed. A reader must treat absence as "not known", never as "no
+	// dimensions" — the two are opposite answers and only a re-index tells
+	// them apart.
+	DimensionRefs []string `bson:"dimension_refs,omitempty"`
 }
 
 // notCatalogCond matches a table entry: one written without an entry_kind.
@@ -349,7 +366,7 @@ func (r *SchemaCacheRepository) clearDatasourceCache(ctx context.Context, projec
 // entry_kind, so they are matched by its absence and are unaffected.
 const catalogEntryKind = "catalog"
 
-// SaveCatalog records the refs a catalog source currently offers.
+// SaveCatalog records the items a catalog source currently offers.
 //
 // The refs are what makes a catalog datasource usable downstream: they are
 // the authority for "this datasource, at this config, offers exactly these
@@ -357,7 +374,7 @@ const catalogEntryKind = "catalog"
 // left in the shared vector collection by a datasource that has since been
 // removed — the index is not self-cleaning, and only a cache entry keyed by
 // the current config hash can say what is current.
-func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, refs []string) error {
+func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, items []gowarehouse.CatalogItem) error {
 	if projectID == "" {
 		return errors.New("projectID is required")
 	}
@@ -376,8 +393,17 @@ func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, ware
 	if err := r.clearDatasourceCache(ctx, projectID, warehouseID); err != nil {
 		return err
 	}
-	if len(refs) == 0 {
+	if len(items) == 0 {
 		return nil
+	}
+
+	refs := make([]string, 0, len(items))
+	var dimensions []string
+	for _, it := range items {
+		refs = append(refs, it.Ref)
+		if it.Kind == gowarehouse.ItemKindDimension {
+			dimensions = append(dimensions, it.Ref)
+		}
 	}
 
 	_, err := r.col().InsertOne(ctx, CatalogCacheEntry{
@@ -386,6 +412,7 @@ func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, ware
 		WarehouseHash: warehouseHash,
 		EntryKind:     catalogEntryKind,
 		Refs:          refs,
+		DimensionRefs: dimensions,
 		CachedAt:      time.Now().UTC(),
 	})
 	if err != nil {
@@ -420,4 +447,36 @@ func (r *SchemaCacheRepository) FindCatalog(ctx context.Context, projectID, ware
 		return nil, fmt.Errorf("catalog cache find: %w", err)
 	}
 	return entry.Refs, nil
+}
+
+// FindCatalogDimensions returns the subset of a catalog's items that identify
+// or group rows, or nil when nothing is known.
+//
+// Nil is returned for a row written before dimension_refs existed as well as
+// for no row at all, and both mean the same thing to a caller: this datasource
+// is not indexed as far as this question is concerned. Falling back to Refs
+// would be worse than answering nothing — it would hand back metrics as though
+// they had been checked.
+func (r *SchemaCacheRepository) FindCatalogDimensions(ctx context.Context, projectID, warehouseID, warehouseHash string) ([]string, error) {
+	if projectID == "" || warehouseHash == "" {
+		return nil, nil
+	}
+	if warehouseID == "" {
+		warehouseID = models.DefaultWarehouseID
+	}
+
+	var entry CatalogCacheEntry
+	err := r.col().FindOne(ctx, bson.M{
+		"project_id":     projectID,
+		"warehouse_id":   warehouseIDCond(warehouseID),
+		"warehouse_hash": warehouseHash,
+		"entry_kind":     catalogEntryKind,
+	}).Decode(&entry)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("catalog dimensions find: %w", err)
+	}
+	return entry.DimensionRefs, nil
 }

--- a/services/agent/internal/database/schema_cache_repo.go
+++ b/services/agent/internal/database/schema_cache_repo.go
@@ -8,7 +8,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -366,7 +365,8 @@ func (r *SchemaCacheRepository) clearDatasourceCache(ctx context.Context, projec
 // entry_kind, so they are matched by its absence and are unaffected.
 const catalogEntryKind = "catalog"
 
-// SaveCatalog records the items a catalog source currently offers.
+// SaveCatalog records the refs a catalog source currently offers, and which of
+// them identify or group rows rather than measuring them.
 //
 // The refs are what makes a catalog datasource usable downstream: they are
 // the authority for "this datasource, at this config, offers exactly these
@@ -374,7 +374,7 @@ const catalogEntryKind = "catalog"
 // left in the shared vector collection by a datasource that has since been
 // removed — the index is not self-cleaning, and only a cache entry keyed by
 // the current config hash can say what is current.
-func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, items []gowarehouse.CatalogItem) error {
+func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, refs, dimensionRefs []string) error {
 	if projectID == "" {
 		return errors.New("projectID is required")
 	}
@@ -393,17 +393,8 @@ func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, ware
 	if err := r.clearDatasourceCache(ctx, projectID, warehouseID); err != nil {
 		return err
 	}
-	if len(items) == 0 {
+	if len(refs) == 0 {
 		return nil
-	}
-
-	refs := make([]string, 0, len(items))
-	var dimensions []string
-	for _, it := range items {
-		refs = append(refs, it.Ref)
-		if it.Kind == gowarehouse.ItemKindDimension {
-			dimensions = append(dimensions, it.Ref)
-		}
 	}
 
 	_, err := r.col().InsertOne(ctx, CatalogCacheEntry{
@@ -412,7 +403,7 @@ func (r *SchemaCacheRepository) SaveCatalog(ctx context.Context, projectID, ware
 		WarehouseHash: warehouseHash,
 		EntryKind:     catalogEntryKind,
 		Refs:          refs,
-		DimensionRefs: dimensions,
+		DimensionRefs: dimensionRefs,
 		CachedAt:      time.Now().UTC(),
 	})
 	if err != nil {

--- a/services/agent/internal/discovery/analysis_step_picker.go
+++ b/services/agent/internal/discovery/analysis_step_picker.go
@@ -185,12 +185,12 @@ func (p *AnalysisStepPicker) Pick(ctx context.Context, area AnalysisArea, allSte
 	// 1. Vector hits.
 	areaQuery := buildAreaQueryText(area)
 	applog.WithFields(applog.Fields{
-		"area":         area.ID,
+		"area":          area.ID,
 		"area_keywords": len(area.Keywords),
-		"top_k":        topK,
-		"min_score":    minScore,
+		"top_k":         topK,
+		"min_score":     minScore,
 		"budget_tokens": budgetTokens,
-		"total_steps":  len(allSteps),
+		"total_steps":   len(allSteps),
 	}).Debug("analysis_step_picker: starting pick for area")
 
 	hits, err := p.Search(ctx, areaQuery, RunStepIndexSearchOpts{TopK: topK, MinScore: 0}) // we'll filter ourselves so we can record dropped
@@ -345,13 +345,13 @@ func (p *AnalysisStepPicker) Pick(ctx context.Context, area AnalysisArea, allSte
 
 	finalSize := estimate(stepsFromPicked(pickedList))
 	applog.WithFields(applog.Fields{
-		"area":             area.ID,
-		"vector_hits":      len(hits),
-		"picked":           len(pickedList),
-		"dropped":          len(dropped),
+		"area":               area.ID,
+		"vector_hits":        len(hits),
+		"picked":             len(pickedList),
+		"dropped":            len(dropped),
 		"trimmed_for_budget": preTrimCount - len(pickedList),
-		"rendered_chars":   finalSize,
-		"rendered_tokens":  finalSize / charsPerToken,
+		"rendered_chars":     finalSize,
+		"rendered_tokens":    finalSize / charsPerToken,
 	}).Info("analysis_step_picker: pick result")
 	return &PickResult{
 		Picked:       pickedList,

--- a/services/agent/internal/discovery/estimate.go
+++ b/services/agent/internal/discovery/estimate.go
@@ -120,7 +120,7 @@ func (o *Orchestrator) EstimateCost(ctx context.Context, opts EstimateOptions) (
 
 	// Validation phase: per insight (estimate 2 insights per area)
 	estimatedInsights := numAreas * 2
-	validationInputPerInsight := 500  // verification query prompt
+	validationInputPerInsight := 500 // verification query prompt
 	validationOutputPerInsight := 200
 	validationInputTokens := estimatedInsights * validationInputPerInsight
 	validationOutputTokens := estimatedInsights * validationOutputPerInsight
@@ -219,8 +219,8 @@ func (o *Orchestrator) EstimateCost(ctx context.Context, opts EstimateOptions) (
 	}
 
 	applog.WithFields(applog.Fields{
-		"total_usd":    fmt.Sprintf("$%.4f", totalCost),
-		"llm_usd":      fmt.Sprintf("$%.4f", llmCostUSD),
+		"total_usd":     fmt.Sprintf("$%.4f", totalCost),
+		"llm_usd":       fmt.Sprintf("$%.4f", llmCostUSD),
 		"warehouse_usd": fmt.Sprintf("$%.4f", warehouseCostUSD),
 		"input_tokens":  totalInputTokens,
 		"output_tokens": totalOutputTokens,

--- a/services/agent/internal/discovery/orchestrator_catalog_test.go
+++ b/services/agent/internal/discovery/orchestrator_catalog_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
 
@@ -25,7 +24,7 @@ func (c *catalogStubCache) FindCatalog(context.Context, string, string, string) 
 	return c.refs, nil
 }
 
-func (c *catalogStubCache) SaveCatalog(context.Context, string, string, string, []gowarehouse.CatalogItem) error {
+func (c *catalogStubCache) SaveCatalog(context.Context, string, string, string, []string, []string) error {
 	return nil
 }
 

--- a/services/agent/internal/discovery/orchestrator_catalog_test.go
+++ b/services/agent/internal/discovery/orchestrator_catalog_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
 
@@ -24,7 +25,7 @@ func (c *catalogStubCache) FindCatalog(context.Context, string, string, string) 
 	return c.refs, nil
 }
 
-func (c *catalogStubCache) SaveCatalog(context.Context, string, string, string, []string) error {
+func (c *catalogStubCache) SaveCatalog(context.Context, string, string, string, []gowarehouse.CatalogItem) error {
 	return nil
 }
 

--- a/services/agent/internal/discovery/orchestrator_persist_test.go
+++ b/services/agent/internal/discovery/orchestrator_persist_test.go
@@ -25,14 +25,14 @@ type fakeDiscoveryLogPersister struct {
 	gotDiscoveryID []string
 	gotRunIDs      []string
 
-	gotExploration  []models.ExplorationStep
-	gotAnalysis     []models.AnalysisStep
-	gotValidation   []models.ValidationResult
-	gotRecommend    *models.RecommendationStep
+	gotExploration []models.ExplorationStep
+	gotAnalysis    []models.AnalysisStep
+	gotValidation  []models.ValidationResult
+	gotRecommend   *models.RecommendationStep
 
-	saveExplorationErr   error
-	saveAnalysisErr      error
-	saveValidationErr    error
+	saveExplorationErr    error
+	saveAnalysisErr       error
+	saveValidationErr     error
 	saveRecommendationErr error
 }
 

--- a/services/agent/internal/discovery/orchestrator_test.go
+++ b/services/agent/internal/discovery/orchestrator_test.go
@@ -576,10 +576,10 @@ func TestBuildPreviousContext_NotesRelevanceFilter(t *testing.T) {
 
 func TestInferColumnCategory(t *testing.T) {
 	tests := []struct {
-		name     string
-		colName  string
-		colType  string
-		wantCat  string
+		name    string
+		colName string
+		colType string
+		wantCat string
 	}{
 		{"user_id is primary_key", "user_id", "STRING", "primary_key"},
 		{"player_id is primary_key", "player_id", "STRING", "primary_key"},
@@ -617,11 +617,11 @@ func TestInferColumnCategory(t *testing.T) {
 
 func TestCategorizeColumn(t *testing.T) {
 	tests := []struct {
-		name     string
-		col      models.ColumnInfo
-		wantKey  bool
-		wantMet  bool
-		wantDim  bool
+		name    string
+		col     models.ColumnInfo
+		wantKey bool
+		wantMet bool
+		wantDim bool
 	}{
 		{
 			name:    "primary key",

--- a/services/agent/internal/discovery/phase_embed_index_test.go
+++ b/services/agent/internal/discovery/phase_embed_index_test.go
@@ -32,16 +32,16 @@ func (m *mockEmbeddingProvider) Embed(_ context.Context, texts []string) ([][]fl
 	return result, nil
 }
 
-func (m *mockEmbeddingProvider) Dimensions() int        { return m.dims }
-func (m *mockEmbeddingProvider) ModelName() string       { return m.model }
+func (m *mockEmbeddingProvider) Dimensions() int                  { return m.dims }
+func (m *mockEmbeddingProvider) ModelName() string                { return m.model }
 func (m *mockEmbeddingProvider) Validate(_ context.Context) error { return nil }
 
 // mockVectorStore implements vectorstore.Provider for testing.
 type mockVectorStore struct {
-	upserted  []vectorstore.Point
-	dupes     []vectorstore.SearchResult
-	ensured   bool
-	deleted   []string
+	upserted []vectorstore.Point
+	dupes    []vectorstore.SearchResult
+	ensured  bool
+	deleted  []string
 }
 
 func (m *mockVectorStore) Upsert(_ context.Context, points []vectorstore.Point) error {
@@ -87,14 +87,14 @@ func TestDenormalizeInsights(t *testing.T) {
 		Category:  "match3",
 		Insights: []models.Insight{
 			{
-				ID:           "orig-1",
-				AnalysisArea: "churn",
-				Name:         "High churn at Level 45",
-				Description:  "Players leaving",
-				Severity:     "high",
+				ID:            "orig-1",
+				AnalysisArea:  "churn",
+				Name:          "High churn at Level 45",
+				Description:   "Players leaving",
+				Severity:      "high",
 				AffectedCount: 12450,
-				Confidence:   0.85,
-				DiscoveredAt: time.Now(),
+				Confidence:    0.85,
+				DiscoveredAt:  time.Now(),
 			},
 			{
 				ID:           "orig-2",
@@ -413,8 +413,8 @@ func TestRunPhaseEmbedIndex_DenormalizeOnly(t *testing.T) {
 	store := &mockEmbedIndexStore{}
 	// No embeddingProvider or vectorStore — should denormalize only
 	o := &Orchestrator{
-		embedIndexStore:   store,
-		statusReporter:    &StatusReporter{},
+		embedIndexStore: store,
+		statusReporter:  &StatusReporter{},
 	}
 
 	result := &models.DiscoveryResult{

--- a/services/agent/internal/discovery/prompt_subs_test.go
+++ b/services/agent/internal/discovery/prompt_subs_test.go
@@ -13,9 +13,9 @@ import (
 // returns zero-values; this is sufficient because the helper does
 // not call any other method.
 type fakeProvider struct {
-	dialect      string
-	quoteOpen    string
-	quoteClose   string
+	dialect    string
+	quoteOpen  string
+	quoteClose string
 }
 
 func (f *fakeProvider) Query(context.Context, string, map[string]interface{}) (*gowarehouse.QueryResult, error) {
@@ -31,15 +31,15 @@ func (f *fakeProvider) GetTableSchema(context.Context, string) (*gowarehouse.Tab
 func (f *fakeProvider) GetTableSchemaInDataset(context.Context, string, string) (*gowarehouse.TableSchema, error) {
 	return nil, nil
 }
-func (f *fakeProvider) GetDataset() string             { return "" }
-func (f *fakeProvider) SQLDialect() string             { return f.dialect }
-func (f *fakeProvider) SQLFixPrompt() string           { return "" }
+func (f *fakeProvider) GetDataset() string                     { return "" }
+func (f *fakeProvider) SQLDialect() string                     { return f.dialect }
+func (f *fakeProvider) SQLFixPrompt() string                   { return "" }
 func (f *fakeProvider) ValidateReadOnly(context.Context) error { return nil }
 func (f *fakeProvider) ValidateSQL(context.Context, string) error {
 	return nil
 }
 func (f *fakeProvider) HealthCheck(context.Context) error { return nil }
-func (f *fakeProvider) Close() error                           { return nil }
+func (f *fakeProvider) Close() error                      { return nil }
 func (f *fakeProvider) QuoteRef(parts ...string) string {
 	return gowarehouse.QuotePartsWith(f.quoteOpen, f.quoteClose, parts)
 }

--- a/services/agent/internal/discovery/run_step_index.go
+++ b/services/agent/internal/discovery/run_step_index.go
@@ -224,14 +224,14 @@ func (r *runStepIndex) Upsert(ctx context.Context, step models.ExplorationStep) 
 		return fmt.Errorf("run_step_index: upsert step %d: %w", step.Step, err)
 	}
 	applog.WithFields(applog.Fields{
-		"run_id":           r.runID,
-		"step":             step.Step,
-		"row_count":        step.RowCount,
-		"has_error":        step.Error != "",
-		"text_chars":       len(text),
-		"embed_dims":       len(vec),
-		"embed_ms":         upsertStart.Sub(embedStart).Milliseconds(),
-		"upsert_ms":        time.Since(upsertStart).Milliseconds(),
+		"run_id":     r.runID,
+		"step":       step.Step,
+		"row_count":  step.RowCount,
+		"has_error":  step.Error != "",
+		"text_chars": len(text),
+		"embed_dims": len(vec),
+		"embed_ms":   upsertStart.Sub(embedStart).Milliseconds(),
+		"upsert_ms":  time.Since(upsertStart).Milliseconds(),
 	}).Debug("run_step_index: step indexed")
 	return nil
 }
@@ -308,15 +308,15 @@ func (r *runStepIndex) Search(ctx context.Context, areaQuery string, opts RunSte
 		bottomScore = hits[len(hits)-1].Score
 	}
 	applog.WithFields(applog.Fields{
-		"run_id":      r.runID,
-		"query":       truncateForLog(q, 80),
-		"top_k":       opts.TopK,
-		"min_score":   opts.MinScore,
-		"hits":        len(hits),
-		"top_score":   topScore,
+		"run_id":       r.runID,
+		"query":        truncateForLog(q, 80),
+		"top_k":        opts.TopK,
+		"min_score":    opts.MinScore,
+		"hits":         len(hits),
+		"top_score":    topScore,
 		"bottom_score": bottomScore,
-		"embed_ms":    queryStart.Sub(embedStart).Milliseconds(),
-		"query_ms":    time.Since(queryStart).Milliseconds(),
+		"embed_ms":     queryStart.Sub(embedStart).Milliseconds(),
+		"query_ms":     time.Since(queryStart).Milliseconds(),
 	}).Debug("run_step_index: search completed")
 	return hits, nil
 }
@@ -532,4 +532,3 @@ func truncateForLog(s string, n int) string {
 	}
 	return s[:n] + "…"
 }
-

--- a/services/agent/internal/discovery/run_step_index_test.go
+++ b/services/agent/internal/discovery/run_step_index_test.go
@@ -105,7 +105,7 @@ func (f *fakeStepEmbedder) Embed(ctx context.Context, texts []string) ([][]float
 	}
 	return out, nil
 }
-func (f *fakeStepEmbedder) Dimensions() int  { return f.dims }
+func (f *fakeStepEmbedder) Dimensions() int   { return f.dims }
 func (f *fakeStepEmbedder) ModelName() string { return f.model }
 
 func newFakes(t *testing.T) (*fakeRunStepClient, *fakeStepEmbedder, RunStepIndex) {
@@ -389,8 +389,8 @@ func TestRunStepIndex_Drop_PropagatesError(t *testing.T) {
 func TestSweepOrphanRunStepIndexes_DropsOrphans(t *testing.T) {
 	c := &fakeRunStepClient{
 		listResp: []string{
-			"decisionbox_schema_p1",                 // not a run collection — leave alone
-			RunStepIndexCollectionName("RUN_LIVE"),  // keep
+			"decisionbox_schema_p1",                  // not a run collection — leave alone
+			RunStepIndexCollectionName("RUN_LIVE"),   // keep
 			RunStepIndexCollectionName("RUN_ORPHAN"), // drop
 			RunStepIndexCollectionName("RUN_OLD"),    // drop
 		},

--- a/services/agent/internal/discovery/schema_cache.go
+++ b/services/agent/internal/discovery/schema_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/database"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
 
@@ -26,8 +27,15 @@ type SchemaCache interface {
 // that consume it.
 type CatalogCache interface {
 	FindCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string) ([]string, error)
-	SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, refs []string) error
+	SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, items []warehouse.CatalogItem) error
 }
+
+// The real cache must satisfy it. Asserted at compile time because every use of
+// this interface is a type assertion: a repository that stops matching does not
+// fail to build, it silently stops being a CatalogCache, and the index run then
+// remembers nothing while reporting success. Changing SaveCatalog's signature
+// did exactly that to two test fakes, which is how this line came to be here.
+var _ CatalogCache = (*database.SchemaCacheRepository)(nil)
 
 // CatalogRefsFor reads a datasource's catalog refs from the cache, returning
 // nil when there are none to read.

--- a/services/agent/internal/discovery/schema_cache.go
+++ b/services/agent/internal/discovery/schema_cache.go
@@ -27,7 +27,7 @@ type SchemaCache interface {
 // that consume it.
 type CatalogCache interface {
 	FindCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string) ([]string, error)
-	SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, items []warehouse.CatalogItem) error
+	SaveCatalog(ctx context.Context, projectID, warehouseID, warehouseHash string, refs, dimensionRefs []string) error
 }
 
 // The real cache must satisfy it. Asserted at compile time because every use of

--- a/services/agent/internal/discovery/schema_indexer.go
+++ b/services/agent/internal/discovery/schema_indexer.go
@@ -553,11 +553,9 @@ func (si *SchemaIndexer) buildCatalogIndex(ctx context.Context, opts IndexOption
 	// usable index that consumers will treat as unindexed until the next run,
 	// which is the safe direction. Losing the points would not be.
 	if cc, ok := si.Cache.(CatalogCache); ok && si.WarehouseHash != "" {
-		refs := make([]string, 0, len(indexable))
-		for _, it := range indexable {
-			refs = append(refs, it.Ref)
-		}
-		if err := cc.SaveCatalog(ctx, opts.ProjectID, si.WarehouseID, si.WarehouseHash, refs); err != nil {
+		// The items rather than their refs: the cache records which of them are
+		// dimensions, and that is only knowable here.
+		if err := cc.SaveCatalog(ctx, opts.ProjectID, si.WarehouseID, si.WarehouseHash, indexable); err != nil {
 			applog.WithError(err).Warn("schema_indexer: catalog cache save failed; consumers will treat this datasource as unindexed until the next run")
 		}
 	}

--- a/services/agent/internal/discovery/schema_indexer.go
+++ b/services/agent/internal/discovery/schema_indexer.go
@@ -391,7 +391,7 @@ func (si *SchemaIndexer) retractCatalog(ctx context.Context, projectID string) {
 		}
 	}
 	if cc, ok := si.Cache.(CatalogCache); ok && si.WarehouseHash != "" {
-		if err := cc.SaveCatalog(ctx, projectID, si.WarehouseID, si.WarehouseHash, nil); err != nil {
+		if err := cc.SaveCatalog(ctx, projectID, si.WarehouseID, si.WarehouseHash, nil, nil); err != nil {
 			applog.WithError(err).Warn("schema_indexer: could not retract this datasource's cached catalog; removed items may stay authorised until the next successful index")
 		}
 	}
@@ -426,6 +426,66 @@ func indexableCatalogItems(items []gowarehouse.CatalogItem) (kept []gowarehouse.
 		kept = append(kept, it)
 	}
 	return kept, len(items) - len(kept)
+}
+
+// saveCatalogCache records what this run indexed, so consumers can tell a live
+// catalog item from one left behind by a datasource that has since changed.
+//
+// Best-effort: a failure leaves a usable index that consumers treat as
+// unindexed until the next run, which is the safe direction. It takes the whole
+// catalog as well as the indexed subset because the dimensions are a judgement
+// over both — see dimensionRefs.
+func (si *SchemaIndexer) saveCatalogCache(ctx context.Context, projectID string, catalog, indexed []gowarehouse.CatalogItem) {
+	cc, ok := si.Cache.(CatalogCache)
+	if !ok || si.WarehouseHash == "" {
+		return
+	}
+	refs := make([]string, 0, len(indexed))
+	for _, it := range indexed {
+		refs = append(refs, it.Ref)
+	}
+	if err := cc.SaveCatalog(ctx, projectID, si.WarehouseID, si.WarehouseHash, refs, dimensionRefs(catalog, indexed)); err != nil {
+		applog.WithError(err).Warn("schema_indexer: catalog cache save failed; consumers will treat this datasource as unindexed until the next run")
+	}
+}
+
+// dimensionRefs is the subset of indexed refs that identify or group rows.
+//
+// It exists because a catalog's names do not say which kind an item is — a GA4
+// custom metric and a custom event-scoped dimension are both
+// customEvent:<name> — and anything asking "could this field bind two sources?"
+// must not answer yes about a measure.
+//
+// Derived from the WHOLE catalog rather than from the indexable subset, which
+// is deduplicated by ref and keeps the first item it saw: a source that listed
+// a metric before a dimension of the same name would otherwise decide this by
+// its own ordering. A ref the source gives more than one kind is left out
+// entirely — it is calling one name two things, and neither answer is safe to
+// hand to something deciding whether a field identifies a record.
+//
+// Intersected with what was indexed, in that order, so the result is stable and
+// never names an item nothing can read: a dimension the credential cannot query
+// is dropped upstream and must not reappear here.
+func dimensionRefs(catalog, indexed []gowarehouse.CatalogItem) []string {
+	kinds := make(map[string]map[string]bool, len(catalog))
+	for _, it := range catalog {
+		if it.Ref == "" {
+			continue
+		}
+		if kinds[it.Ref] == nil {
+			kinds[it.Ref] = map[string]bool{}
+		}
+		kinds[it.Ref][it.Kind] = true
+	}
+
+	out := make([]string, 0, len(indexed))
+	for _, it := range indexed {
+		k := kinds[it.Ref]
+		if len(k) == 1 && k[gowarehouse.ItemKindDimension] {
+			out = append(out, it.Ref)
+		}
+	}
+	return out
 }
 
 // buildCatalogIndex is BuildIndex for a source that describes itself with a
@@ -552,13 +612,7 @@ func (si *SchemaIndexer) buildCatalogIndex(ctx context.Context, opts IndexOption
 	// Best-effort, and deliberately after the upsert: a failure here leaves a
 	// usable index that consumers will treat as unindexed until the next run,
 	// which is the safe direction. Losing the points would not be.
-	if cc, ok := si.Cache.(CatalogCache); ok && si.WarehouseHash != "" {
-		// The items rather than their refs: the cache records which of them are
-		// dimensions, and that is only knowable here.
-		if err := cc.SaveCatalog(ctx, opts.ProjectID, si.WarehouseID, si.WarehouseHash, indexable); err != nil {
-			applog.WithError(err).Warn("schema_indexer: catalog cache save failed; consumers will treat this datasource as unindexed until the next run")
-		}
-	}
+	si.saveCatalogCache(ctx, opts.ProjectID, items, indexable)
 
 	// Close out progress. The catalog path has no per-item leg to report
 	// against — one metadata read, one embedding batch, one upsert — so the

--- a/services/agent/internal/discovery/schema_indexer_catalog_test.go
+++ b/services/agent/internal/discovery/schema_indexer_catalog_test.go
@@ -29,7 +29,11 @@ func (c *retractingCache) FindCatalog(context.Context, string, string, string) (
 	return nil, nil
 }
 
-func (c *retractingCache) SaveCatalog(_ context.Context, _, _, _ string, refs []string) error {
+func (c *retractingCache) SaveCatalog(_ context.Context, _, _, _ string, items []gowarehouse.CatalogItem) error {
+	refs := make([]string, 0, len(items))
+	for _, it := range items {
+		refs = append(refs, it.Ref)
+	}
 	c.saved = append(c.saved, refs)
 	c.savedOnce = true
 	return nil

--- a/services/agent/internal/discovery/schema_indexer_catalog_test.go
+++ b/services/agent/internal/discovery/schema_indexer_catalog_test.go
@@ -21,20 +21,18 @@ type stubCatalog struct {
 // retractingCache records catalog saves so a retraction can be observed.
 type retractingCache struct {
 	stubCache
-	saved     [][]string
-	savedOnce bool
+	saved           [][]string
+	savedDimensions [][]string
+	savedOnce       bool
 }
 
 func (c *retractingCache) FindCatalog(context.Context, string, string, string) ([]string, error) {
 	return nil, nil
 }
 
-func (c *retractingCache) SaveCatalog(_ context.Context, _, _, _ string, items []gowarehouse.CatalogItem) error {
-	refs := make([]string, 0, len(items))
-	for _, it := range items {
-		refs = append(refs, it.Ref)
-	}
+func (c *retractingCache) SaveCatalog(_ context.Context, _, _, _ string, refs, dimensionRefs []string) error {
 	c.saved = append(c.saved, refs)
+	c.savedDimensions = append(c.savedDimensions, dimensionRefs)
 	c.savedOnce = true
 	return nil
 }
@@ -293,5 +291,101 @@ func TestBuildCatalogIndex_DoesNotRetractWhenTheCatalogCouldNotBeRead(t *testing
 	}
 	if cache.savedOnce {
 		t.Error("a failed read must not retract the previous catalog — it is not evidence the source changed")
+	}
+}
+
+// TestDimensionRefs pins the rule that decides whether a catalog item can be a
+// join key, which is a question the item's NAME cannot answer.
+func TestDimensionRefs(t *testing.T) {
+	dim := func(ref string) gowarehouse.CatalogItem {
+		return gowarehouse.CatalogItem{Ref: ref, Kind: gowarehouse.ItemKindDimension, Text: "d"}
+	}
+	metric := func(ref string) gowarehouse.CatalogItem {
+		return gowarehouse.CatalogItem{Ref: ref, Kind: gowarehouse.ItemKindMetric, Text: "m"}
+	}
+
+	t.Run("dimensions are kept and metrics are not", func(t *testing.T) {
+		catalog := []gowarehouse.CatalogItem{dim("country"), metric("sessions")}
+		got := dimensionRefs(catalog, catalog)
+		if len(got) != 1 || got[0] != "country" {
+			t.Errorf("dimensionRefs = %v, want [country]", got)
+		}
+	})
+
+	t.Run("a ref the source gives two kinds is left out either way round", func(t *testing.T) {
+		// The indexable subset is deduplicated by ref and keeps the FIRST item
+		// it saw, so reading kinds from it would let the source's own ordering
+		// decide whether customEvent:score can identify a record.
+		for _, order := range [][]gowarehouse.CatalogItem{
+			{dim("customEvent:score"), metric("customEvent:score")},
+			{metric("customEvent:score"), dim("customEvent:score")},
+		} {
+			indexed, _ := indexableCatalogItems(order)
+			if got := dimensionRefs(order, indexed); len(got) != 0 {
+				t.Errorf("dimensionRefs = %v for %s-first, want none: the source calls one name two things",
+					got, order[0].Kind)
+			}
+		}
+	})
+
+	t.Run("a dimension nothing can read is not offered as a key", func(t *testing.T) {
+		// An item the credential cannot query is dropped before indexing, and
+		// naming it here would offer a key no query could ever use.
+		blocked := dim("customUser:crm_id")
+		blocked.Unavailable = "the credential cannot read this custom definition"
+		catalog := []gowarehouse.CatalogItem{dim("country"), blocked}
+
+		indexed, _ := indexableCatalogItems(catalog)
+		got := dimensionRefs(catalog, indexed)
+		for _, ref := range got {
+			if ref == "customUser:crm_id" {
+				t.Errorf("dimensionRefs = %v, want the unqueryable dimension left out", got)
+			}
+		}
+	})
+
+	t.Run("the order follows what was indexed", func(t *testing.T) {
+		catalog := []gowarehouse.CatalogItem{dim("b"), metric("m"), dim("a")}
+		indexed, _ := indexableCatalogItems(catalog)
+		got := dimensionRefs(catalog, indexed)
+		if len(got) != 2 || got[0] != "b" || got[1] != "a" {
+			t.Errorf("dimensionRefs = %v, want [b a]", got)
+		}
+	})
+}
+
+// The index run must record the dimensions alongside the refs, or the cache
+// cannot answer the question they exist for. Tested at the save rather than
+// through buildCatalogIndex, whose success path needs a live vector store.
+func TestSaveCatalogCache_RecordsRefsAndDimensionsSeparately(t *testing.T) {
+	cache := &retractingCache{}
+	si := &SchemaIndexer{Cache: cache, WarehouseHash: "hash-a"}
+
+	catalog := []gowarehouse.CatalogItem{
+		{Ref: "country", Kind: gowarehouse.ItemKindDimension, Text: "the country"},
+		{Ref: "sessions", Kind: gowarehouse.ItemKindMetric, Text: "the sessions"},
+	}
+	indexed, _ := indexableCatalogItems(catalog)
+	si.saveCatalogCache(context.Background(), "p1", catalog, indexed)
+
+	if len(cache.saved) != 1 || len(cache.saved[0]) != 2 {
+		t.Fatalf("saved refs = %v, want both items — retrieval still sees the whole catalog", cache.saved)
+	}
+	if len(cache.savedDimensions) != 1 || len(cache.savedDimensions[0]) != 1 ||
+		cache.savedDimensions[0][0] != "country" {
+		t.Errorf("saved dimensions = %v, want [country]", cache.savedDimensions)
+	}
+}
+
+func TestSaveCatalogCache_WithoutAHashSavesNothing(t *testing.T) {
+	// The hash is what makes an entry answer for one configuration. Writing
+	// without it would leave a row nothing can invalidate.
+	cache := &retractingCache{}
+	si := &SchemaIndexer{Cache: cache}
+
+	si.saveCatalogCache(context.Background(), "p1", nil, nil)
+
+	if cache.savedOnce {
+		t.Error("a catalog was cached with no config hash to key it by")
 	}
 }

--- a/services/agent/internal/discovery/validation_phase_test.go
+++ b/services/agent/internal/discovery/validation_phase_test.go
@@ -242,9 +242,9 @@ func TestRecoverRelatedInsightIDs_BackfillsMissingAndAllBad(t *testing.T) {
 		{ID: "02665b9e-468f-41eb-b50e-28702b95e999"},
 	}
 	recs := []models.Recommendation{
-		{ID: "r1", RelatedInsightIDs: nil},                                        // missing
-		{ID: "r2", RelatedInsightIDs: []string{}},                                 // empty
-		{ID: "r3", RelatedInsightIDs: []string{"cat:crit:slug", "another-slug"}},  // all bad
+		{ID: "r1", RelatedInsightIDs: nil},                                       // missing
+		{ID: "r2", RelatedInsightIDs: []string{}},                                // empty
+		{ID: "r3", RelatedInsightIDs: []string{"cat:crit:slug", "another-slug"}}, // all bad
 	}
 	out, stats := recoverRelatedInsightIDs(recs, insights)
 	if len(out) != 3 {


### PR DESCRIPTION
The catalog cache kept only the refs a catalog source offers, so nothing downstream could tell a **measure** from something that **identifies a record**. This adds the distinction.

## Why it matters

The two are not separable by name. A GA4 custom metric and a custom event-scoped dimension are both `customEvent:<name>`, so a metric called `score` is indistinguishable from a dimension called `score`. Anything asking *"could this field bind two datasources?"* was therefore free to answer yes about a number — and joining on a measure is meaningless.

Found by a Codex review of the query-time join-key work (#252 W5), which reads this cache. It applies to the connect-time binding report too, which has been reading the same untyped list.

## What changed

- **`SaveCatalog` takes the items rather than their refs.** The kind is only knowable at the index run, and the indexer already had it — it was throwing it away one line before the call.
- **`dimension_refs` is written alongside `refs`.** `Refs` is untouched, so retrieval and the staleness authority keep seeing the whole catalog. Nothing that reads `refs` today changes behaviour.
- **`FindCatalogDimensions` reads them**, and returns `nil` for a row written before this existed. That is deliberately the same answer as "no row at all": a legacy row *knows nothing about kinds*, which is not the same as knowing there are no dimensions, and falling back to `refs` would hand back metrics as though the question had been answered. A caller sees the datasource as unindexed for this question until it is indexed again — the safe direction, and the only honest one. The absence rule lives in the accessor so no consumer has to rediscover it.
- **A compile-time assertion that the repository satisfies `CatalogCache`.** Every use of that interface is a type assertion, so an implementation that stops matching doesn't fail to build — it silently stops being a `CatalogCache`, and the index run then remembers nothing while reporting success. Changing `SaveCatalog`'s signature did exactly that to two test fakes, and the unit suite caught it as two unrelated-looking failures. The assertion turns that into a build error.

## Verification

- `make build`, `make test-go`, `make lint-go` — clean. (`libs/go-common/mongodb`'s `TestNewClient_UnreachableHost` fails locally on a port collision; it is unrelated and fails the same way on the base branch.)
- Three new integration tests against a real Mongo (`-tags integration`): dimensions kept apart from metrics while `refs` still holds all four items, a legacy row reporting no dimensions, and a metric-only catalog. Existing catalog-cache integration tests updated to the new signature and still passing.

## Review

Two Codex rounds at `xhigh`; the second clean.

R1 (P2) caught the dimensions being derived from the *indexable* subset, which is deduplicated by ref and keeps the first item it saw — so a source listing a metric before a dimension of the same name would have dropped that dimension, and the other order would have kept it. The answer depended on the order a provider happened to return its catalog in, which is not a fact about the data.

They now come from the whole catalog, and a ref the source gives **more than one kind is left out entirely** rather than resolved by position: the source is calling one name two things, and neither answer is safe to hand to something deciding whether a field identifies a record. (Codex suggested reading kinds pre-dedupe, which fixes the dropped dimension but makes the ambiguous case *more* permissive — the wrong direction for a check whose only dangerous failure is a false yes.)

That fix also moved the save into `saveCatalogCache`, because `buildCatalogIndex`'s success path needs a live vector store: an inline block there could only ever have been checked by reading it.

## Note on rollout

Existing catalog rows carry no `dimension_refs`, so consumers of the new accessor treat those datasources as not-yet-known until their next index run. That is intentional — see above — and affects nothing that reads `refs`.

Part of #252

— Co-coded with Jale 🤖

