### PR TITLE
feat(models): record which source shape a domain pack was written for (#252 W8)

### DIFF
--- a/docs/concepts/domain-packs.md
+++ b/docs/concepts/domain-packs.md
@@ -25,6 +25,27 @@ A domain pack provides four things:
 | **Prompts** | How the AI reasons | Markdown content (stored in MongoDB) |
 | **Profile Schema** | What context users provide | JSON Schema (stored in MongoDB) |
 
+### Source shape
+
+A pack also records the **shape** of the data source it was written for, as
+`shape` on the pack document:
+
+| Value | Means |
+|---|---|
+| `entities` | Tables or objects — rows and columns, selected from and joined. Every SQL warehouse. |
+| `cube` | Metrics and dimensions — no tables to select from; a query names what to measure and how to break it down. |
+
+The field is optional and **absent means `entities`**: every pack written
+before shape was recorded targets a table-shaped source, so the whole existing
+corpus reads correctly unedited.
+
+It is not decoration. A pack's exploration prompt and analysis areas assume a
+source organised one way, so a pack is only a useful example for another pack
+of the same shape — using one written for the other shape yields something
+that reads correctly and asks for queries the source cannot answer. A shape
+that is neither of the two above is rejected when the pack is saved, rather
+than stored and silently matching nothing.
+
 ## Three-Level Hierarchy
 
 ```

--- a/libs/go-common/warehouse/shape.go
+++ b/libs/go-common/warehouse/shape.go
@@ -24,3 +24,19 @@ func RequiresDataset(providerSlug string) bool {
 	}
 	return meta.EffectiveShape() != ShapeCube
 }
+
+// Known reports whether s names a shape this build understands.
+//
+// The zero value is deliberately NOT known: an absent shape means the source
+// never declared one, which callers resolve to ShapeEntities through their own
+// EffectiveShape — a different question from "is this spelling a shape at
+// all". Keeping the two apart is what lets a typo be rejected where it is
+// written, instead of resolving to a shape nothing matches and disabling a
+// feature with no error attached.
+func (s SourceShape) Known() bool {
+	switch s {
+	case ShapeEntities, ShapeCube:
+		return true
+	}
+	return false
+}

--- a/libs/go-common/warehouse/shape_known_test.go
+++ b/libs/go-common/warehouse/shape_known_test.go
@@ -1,0 +1,40 @@
+package warehouse
+
+import "testing"
+
+// TestSourceShape_Known covers the vocabulary check that keeps a mistyped
+// shape from being stored. The zero value is NOT known on purpose: absence
+// means the source never declared one, which each caller resolves through
+// its own EffectiveShape — a different question from whether a spelling
+// names a shape at all.
+func TestSourceShape_Known(t *testing.T) {
+	for _, tc := range []struct {
+		shape SourceShape
+		want  bool
+	}{
+		{ShapeEntities, true},
+		{ShapeCube, true},
+		{"", false},
+		{"cubes", false},
+		{"Entities", false},
+		{"table", false},
+	} {
+		if got := tc.shape.Known(); got != tc.want {
+			t.Errorf("SourceShape(%q).Known() = %v, want %v", tc.shape, got, tc.want)
+		}
+	}
+}
+
+// TestSourceShape_KnownCoversEveryDeclaredShape fails when a shape is added
+// to the vocabulary without being taught to Known — which would let a
+// legitimate new shape be rejected as a typo at every save.
+func TestSourceShape_KnownCoversEveryDeclaredShape(t *testing.T) {
+	for _, shape := range []SourceShape{ShapeEntities, ShapeCube} {
+		if !shape.Known() {
+			t.Errorf("declared shape %q is not Known", shape)
+		}
+		if (Capability{Shape: shape}).EffectiveShape() != shape {
+			t.Errorf("declared shape %q does not survive EffectiveShape", shape)
+		}
+	}
+}

--- a/services/api/models/domain_pack.go
+++ b/services/api/models/domain_pack.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	warehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+)
 
 // DomainPack represents a domain-specific analysis pack stored in MongoDB.
 // Domain packs define the prompts, analysis areas, categories, and profile
@@ -14,6 +18,18 @@ type DomainPack struct {
 	Author      string `bson:"author,omitempty" json:"author,omitempty"`
 	SourceURL   string `bson:"source_url,omitempty" json:"source_url,omitempty"`
 	IsPublished bool   `bson:"is_published" json:"is_published"`
+
+	// Shape is the source shape this pack was written for. A pack is not
+	// shape-neutral: its exploration prompt and analysis areas assume a source
+	// organised one way, and teaching a generator from a pack written for the
+	// other shape produces something that reads right and asks for queries the
+	// source cannot answer.
+	//
+	// Absent means ShapeEntities, via EffectiveShape. Every pack written before
+	// this field existed targets a table-shaped source, and a pack for any other
+	// shape cannot be authored without saying so — the same direction the
+	// provider descriptor's own default takes, for the same reason.
+	Shape warehouse.SourceShape `bson:"shape,omitempty" json:"shape,omitempty"`
 
 	Categories    []PackCategory    `bson:"categories" json:"categories"`
 	Prompts       PackPrompts       `bson:"prompts" json:"prompts"`
@@ -34,6 +50,20 @@ type DomainPack struct {
 	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
 }
 
+// EffectiveShape returns the source shape this pack was written for,
+// defaulting to ShapeEntities when the pack declares none.
+//
+// Read it rather than the field: a pack persisted before shape was recorded
+// carries no value, and treating that as "no shape" rather than "the shape
+// everything used to be" would exclude the entire existing corpus from any
+// decision that branches on it.
+func (p DomainPack) EffectiveShape() warehouse.SourceShape {
+	if p.Shape != "" {
+		return p.Shape
+	}
+	return warehouse.ShapeEntities
+}
+
 // PackCategory is a sub-type within a domain (e.g., "match3" within gaming).
 type PackCategory struct {
 	ID          string `bson:"id" json:"id"`
@@ -43,8 +73,8 @@ type PackCategory struct {
 
 // PackPrompts holds all prompt templates organized by base and category.
 type PackPrompts struct {
-	Base       BasePrompts                    `bson:"base" json:"base"`
-	Categories map[string]CategoryPrompts     `bson:"categories" json:"categories"`
+	Base       BasePrompts                `bson:"base" json:"base"`
+	Categories map[string]CategoryPrompts `bson:"categories" json:"categories"`
 }
 
 // BasePrompts contains the three required prompt templates.
@@ -61,8 +91,8 @@ type CategoryPrompts struct {
 
 // PackAnalysisAreas holds analysis areas organized by base and category.
 type PackAnalysisAreas struct {
-	Base       []PackAnalysisArea              `bson:"base" json:"base"`
-	Categories map[string][]PackAnalysisArea   `bson:"categories" json:"categories"`
+	Base       []PackAnalysisArea            `bson:"base" json:"base"`
+	Categories map[string][]PackAnalysisArea `bson:"categories" json:"categories"`
 }
 
 // PackAnalysisArea defines a single analysis area with its inline prompt.

--- a/services/api/models/domain_pack_shape_test.go
+++ b/services/api/models/domain_pack_shape_test.go
@@ -1,0 +1,118 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	warehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestEffectiveShape_AbsentIsEntities pins the default that makes the
+// existing corpus readable. Every pack persisted before shape was recorded
+// carries no value, and they are all table-shaped; resolving that to "no
+// shape" would exclude all of them from any decision that branches on it.
+func TestEffectiveShape_AbsentIsEntities(t *testing.T) {
+	var pack DomainPack
+	if got := pack.EffectiveShape(); got != warehouse.ShapeEntities {
+		t.Errorf("an undeclared shape = %q, want %q", got, warehouse.ShapeEntities)
+	}
+}
+
+// TestEffectiveShape_DeclaredWins covers both spellings, including the one
+// that equals the default — a pack that says "entities" must not be
+// distinguishable from one that says nothing, or the two would take
+// different paths for no reason a reader could see.
+func TestEffectiveShape_DeclaredWins(t *testing.T) {
+	for _, shape := range []warehouse.SourceShape{warehouse.ShapeEntities, warehouse.ShapeCube} {
+		pack := DomainPack{Shape: shape}
+		if got := pack.EffectiveShape(); got != shape {
+			t.Errorf("declared %q resolved to %q", shape, got)
+		}
+	}
+}
+
+// TestShape_AbsentStaysAbsentInBSON is the writer half of the contract the
+// readers depend on. A pack with no shape must persist with the field
+// missing, not as an empty string: a query for table-shaped packs has to
+// match the whole existing corpus, and it can only be written to match both
+// spellings if it knows which ones can occur.
+func TestShape_AbsentStaysAbsentInBSON(t *testing.T) {
+	raw, err := bson.Marshal(DomainPack{Slug: "gaming"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m bson.M
+	if err := bson.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := m["shape"]; present {
+		t.Errorf("a pack that declares no shape persisted shape=%v; it must be absent", m["shape"])
+	}
+}
+
+// TestShape_RoundTripsThroughBSONAndJSON guards the two round trips a pack
+// actually makes: the collection it is stored in, and the portable export
+// the import route reads back. A field dropped by either would be silently
+// erased by an ordinary edit rather than reported.
+func TestShape_RoundTripsThroughBSONAndJSON(t *testing.T) {
+	pack := *testDomainPack("analytics", "web")
+	pack.Shape = warehouse.ShapeCube
+
+	raw, err := bson.Marshal(pack)
+	if err != nil {
+		t.Fatalf("bson marshal: %v", err)
+	}
+	var fromBSON DomainPack
+	if err := bson.Unmarshal(raw, &fromBSON); err != nil {
+		t.Fatalf("bson unmarshal: %v", err)
+	}
+	if fromBSON.Shape != warehouse.ShapeCube {
+		t.Errorf("bson round trip lost the shape: got %q", fromBSON.Shape)
+	}
+
+	encoded, err := json.Marshal(pack)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	var fromJSON DomainPack
+	if err := json.Unmarshal(encoded, &fromJSON); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	if fromJSON.Shape != warehouse.ShapeCube {
+		t.Errorf("json round trip lost the shape: got %q", fromJSON.Shape)
+	}
+}
+
+// TestValidateDomainPack_RejectsAnUnknownShape covers the typo that would
+// otherwise persist and then match nothing wherever shape is compared —
+// a feature quietly not working, with no error to connect it to.
+func TestValidateDomainPack_RejectsAnUnknownShape(t *testing.T) {
+	pack := testDomainPack("gaming", "match3")
+	pack.Shape = "cubes"
+	err := ValidateDomainPack(pack)
+	if err == nil {
+		t.Fatal("a pack declaring an unknown shape should be rejected")
+	}
+	// The message has to name the value AND the legal ones, or the author
+	// has to go read the source to fix a typo.
+	for _, want := range []string{"cubes", string(warehouse.ShapeEntities), string(warehouse.ShapeCube)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestValidateDomainPack_AcceptsEveryKnownShapeAndAbsence pins the other
+// side: the check must not reject a pack that says nothing (the whole
+// existing corpus) or one that names a real shape.
+func TestValidateDomainPack_AcceptsEveryKnownShapeAndAbsence(t *testing.T) {
+	for _, shape := range []warehouse.SourceShape{"", warehouse.ShapeEntities, warehouse.ShapeCube} {
+		pack := testDomainPack("gaming", "match3")
+		pack.Shape = shape
+		if err := ValidateDomainPack(pack); err != nil {
+			t.Errorf("shape %q should be accepted: %v", shape, err)
+		}
+	}
+}

--- a/services/api/models/domainpack_validator.go
+++ b/services/api/models/domainpack_validator.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	warehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 )
 
 // DomainPackSlugRegex is the canonical slug shape for a saved domain
@@ -26,6 +28,7 @@ var DomainPackSlugRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 // Checks:
 //   - slug shape (DomainPackSlugRegex, min length 2)
 //   - name + at least one category, each with id + name
+//   - a declared source shape is one this build knows (absent is legal)
 //   - base prompts non-empty
 //   - required template placeholders: {{PROFILE}} in base_context;
 //     {{DATASET}}, {{SCHEMA_INFO}}, {{ANALYSIS_AREAS}} in exploration;
@@ -43,6 +46,14 @@ func ValidateDomainPack(pack *DomainPack) error {
 	}
 	if pack.Name == "" {
 		return fmt.Errorf("name is required")
+	}
+	// A declared shape must be one the build understands. An unrecognised
+	// spelling would otherwise persist happily and then match nothing wherever
+	// shape is compared, which reads as a feature quietly not working rather
+	// than as the typo it is. Absent stays legal — it means ShapeEntities.
+	if pack.Shape != "" && !pack.Shape.Known() {
+		return fmt.Errorf("shape %q is not a source shape (use %q or %q, or leave it unset for %q)",
+			pack.Shape, warehouse.ShapeEntities, warehouse.ShapeCube, warehouse.ShapeEntities)
 	}
 	if len(pack.Categories) == 0 {
 		return fmt.Errorf("at least one category is required")


### PR DESCRIPTION
Gives a domain pack somewhere to say what kind of source it was written for. First half of **#252 W8**; the selection logic that reads it is the enterprise half.

## Why

A pack is not shape-neutral. Its exploration prompt and its analysis areas assume a source organised one way — named tables with rows and columns, or metrics and dimensions with no tables at all — and nothing on the document recorded which. Anything that picks one pack as a worked example for writing another therefore cannot tell whether the example fits.

That failure is silent, which is the point. A pack written from a table-shaped example for a cube-shaped source does not error; it comes back well-formed, reads correctly, and asks for queries the source cannot answer.

## What changed

`DomainPack.Shape`, plus `EffectiveShape()` resolving an absent value to `ShapeEntities`.

**Absent means `entities`, and that default is load-bearing.** It is the entire existing corpus: every pack written before this field targets a table-shaped source, and a pack for any other shape cannot be authored without declaring itself one, since nothing else about it would work. It is the same direction — for the same reason — that `Capability.EffectiveShape()` already takes for providers.

Both struct tags carry `omitempty`, so a pack that declares nothing persists and exports with the field **missing** rather than as an empty string. A reader selecting the table-shaped corpus has to match absence, and can only be written correctly if it knows which spellings actually occur; a test pins that.

`ValidateDomainPack` rejects a shape that is neither known value. Stored, an unrecognised spelling would compare equal to nothing wherever shape is read — a feature quietly not working, with no error to connect it to. `SourceShape.Known()` holds that vocabulary beside the constants rather than in the validator, so adding a shape later does not depend on remembering a check in another module. Its zero value is deliberately *not* known: absence is not a shape, it is the lack of one, and each caller resolves it through its own `EffectiveShape`.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run ./...`, `make lint-docs` — clean. One pre-existing failure is unrelated and reproduces on a clean checkout of the base branch: `libs/go-common/mongodb.TestNewClient_UnreachableHost`, which asserts a host fails to resolve and passes only where DNS says so.
- 8 new tests. They cover the round trips rather than the getter: a pack with no shape must persist with the field *absent* (not `""`), and a declared shape must survive both BSON storage and the JSON export/import envelope — either would otherwise erase the field on an ordinary edit rather than report anything. Plus the typo rejection, every known shape and absence being accepted, and a test that fails if a shape is added to the vocabulary without being taught to `Known()`.

## Scope

This adds the field and the rules for reading it. It does **not** teach anything to select on it, and it does not touch the pack validator's SQL-shaped requirements (`{{DIALECT}}`, `{{DATASET}}`) — that is **W9**, deliberately separate.

Part of #252

— Co-coded with Jale 🤖
