### PR TITLE
Playbook — Prompts page redesign + Domain Packs → Playbook UI rename (community)

### DIFF
--- a/docs/concepts/domain-packs.md
+++ b/docs/concepts/domain-packs.md
@@ -1,4 +1,7 @@
-# Domain Packs
+# Playbook / Domain Packs
+
+> In the DecisionBox dashboard these are called **Playbooks**.
+> "Playbook" and "domain pack" are the same thing — this reference keeps the name **domain pack** for the underlying JSON / API model, while the UI shows **Playbook**.
 
 Domain packs are DecisionBox's extensibility model. They define **what** the AI looks for and **how** it reasons about data for a specific industry. Without a domain pack, DecisionBox wouldn't know whether to look for churn patterns, cart abandonment rates, or supply chain bottlenecks.
 

--- a/docs/guides/creating-domain-packs.md
+++ b/docs/guides/creating-domain-packs.md
@@ -1,4 +1,6 @@
-# Creating Domain Packs
+# Creating a Playbook / Domain Pack
+
+> In the DecisionBox dashboard, domain packs are called **Playbooks** — the two names are interchangeable. This guide uses **domain pack** for the JSON / API model.
 
 A domain pack teaches DecisionBox how to analyze data for a specific industry. This guide walks through creating one.
 

--- a/docs/guides/customizing-prompts.md
+++ b/docs/guides/customizing-prompts.md
@@ -1,5 +1,7 @@
 # Customizing Prompts
 
+> In the dashboard this is the project's **Playbook** page. A project's prompts come from its domain pack, which the dashboard calls a Playbook.
+
 Every prompt in DecisionBox can be customized per-project. This lets you fine-tune how the AI reasons about your specific data without modifying the domain pack.
 
 ## How It Works

--- a/ui/dashboard/src/app/domain-packs/[slug]/page.tsx
+++ b/ui/dashboard/src/app/domain-packs/[slug]/page.tsx
@@ -69,11 +69,11 @@ export default function DomainPackEditorPage() {
     try {
       if (isNew) {
         const created = await api.createDomainPack(pack);
-        notifications.show({ title: 'Created', message: `Domain pack "${created.slug}" created`, color: 'green' });
+        notifications.show({ title: 'Created', message: `Playbook "${created.slug}" created`, color: 'green' });
         router.push(`/domain-packs/${created.slug}`);
       } else {
         await api.updateDomainPack(slug, pack);
-        notifications.show({ title: 'Saved', message: 'Domain pack updated', color: 'green' });
+        notifications.show({ title: 'Saved', message: 'Playbook updated', color: 'green' });
       }
     } catch (e) {
       notifications.show({ title: 'Error', message: (e as Error).message, color: 'red' });
@@ -170,16 +170,16 @@ export default function DomainPackEditorPage() {
 
   if (loading) return <Shell><Loader /></Shell>;
   if (error) return <Shell><Alert color="red" icon={<IconAlertCircle size={16} />}>{error}</Alert></Shell>;
-  if (!pack) return <Shell><Text>Domain pack not found</Text></Shell>;
+  if (!pack) return <Shell><Text>Playbook not found</Text></Shell>;
 
   return (
-    <Shell breadcrumb={[{ label: 'Domain Packs', href: '/domain-packs' }, { label: isNew ? 'New' : pack.name }]}>
+    <Shell breadcrumb={[{ label: 'Playbooks', href: '/domain-packs' }, { label: isNew ? 'New' : pack.name }]}>
       <Stack gap="lg">
         <Group justify="space-between">
           <Group>
             <Button variant="subtle" leftSection={<IconArrowLeft size={16} />}
               onClick={() => router.push('/domain-packs')}>Back</Button>
-            <Title order={2}>{isNew ? 'New Domain Pack' : pack.name}</Title>
+            <Title order={2}>{isNew ? 'New Playbook' : pack.name}</Title>
           </Group>
           <Button onClick={handleSave} loading={saving} leftSection={<IconCheck size={16} />}>
             {isNew ? 'Create' : 'Save'}

--- a/ui/dashboard/src/app/domain-packs/page.tsx
+++ b/ui/dashboard/src/app/domain-packs/page.tsx
@@ -71,7 +71,7 @@ export default function DomainPacksPage() {
   };
 
   const handleDelete = async (slug: string) => {
-    if (!confirm(`Delete domain pack "${slug}"? This cannot be undone. Existing projects are not affected.`)) return;
+    if (!confirm(`Delete playbook "${slug}"? This cannot be undone. Existing projects are not affected.`)) return;
     try {
       await api.deleteDomainPack(slug);
       loadPacks();
@@ -81,10 +81,10 @@ export default function DomainPacksPage() {
   };
 
   return (
-    <Shell breadcrumb={[{ label: 'Domain Packs' }]}>
+    <Shell breadcrumb={[{ label: 'Playbooks' }]}>
       <Stack gap="lg">
         <Group justify="space-between">
-          <Title order={2}>Domain Packs</Title>
+          <Title order={2}>Playbooks</Title>
           <Group gap="sm">
             <input
               type="file"
@@ -116,14 +116,14 @@ export default function DomainPacksPage() {
           </Alert>
         )}
 
-        {loading && <Text c="dimmed">Loading domain packs...</Text>}
+        {loading && <Text c="dimmed">Loading playbooks...</Text>}
 
         {!loading && !error && packs.length === 0 && (
           <Card withBorder p="xl" ta="center">
             <Stack align="center" gap="md">
               <IconPackages size={48} color="var(--mantine-color-gray-5)" />
-              <Title order={3} c="dimmed">No domain packs</Title>
-              <Text c="dimmed">Domain packs define how AI discovery works for your industry. Create one or import from a file.</Text>
+              <Title order={3} c="dimmed">No playbooks</Title>
+              <Text c="dimmed">Playbooks define how AI discovery works for your industry. Create one or import from a file.</Text>
             </Stack>
           </Card>
         )}
@@ -193,10 +193,10 @@ export default function DomainPacksPage() {
       </Stack>
 
       {/* Import Modal */}
-      <Modal opened={importOpen} onClose={() => { setImportOpen(false); setImportError(null); }} title="Import Domain Pack" size="lg">
+      <Modal opened={importOpen} onClose={() => { setImportOpen(false); setImportError(null); }} title="Import Playbook" size="lg">
         <Stack gap="md">
           <Text size="sm" c="dimmed">
-            Paste a domain pack JSON file or use the file upload button.
+            Paste a playbook JSON file or use the file upload button.
           </Text>
           <Textarea
             value={importJson}

--- a/ui/dashboard/src/app/projects/[id]/prompts/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/prompts/page.tsx
@@ -4,7 +4,7 @@ import { CSSProperties, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import {
-  ActionIcon, Alert, Badge, Button, Card, Group, Loader, Modal, NavLink, Stack, Switch,
+  ActionIcon, Alert, Badge, Button, Card, Divider, Group, Loader, Modal, NavLink, ScrollArea, Stack, Switch,
   Text, TextInput, Title, Tooltip,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
@@ -141,38 +141,54 @@ export default function PromptsPage() {
         {/* Master–detail: sections + analysis areas on the left, the selected
             prompt's editor on the right — fills the remaining height. */}
         <Group align="stretch" gap="lg" wrap="nowrap" style={{ flex: 1, minHeight: 0 }}>
-          {/* LEFT — master list */}
-          <Stack gap={2} style={{ width: 250, flexShrink: 0, overflowY: 'auto' }}>
-            <Text size="xs" fw={700} c="dimmed" tt="uppercase" mb={4}>Discovery</Text>
-            <NavLink label="Base Context" active={activeTab === 'base_context'}
-              onClick={() => setActiveTab('base_context')} />
-            <NavLink label="Exploration" active={activeTab === 'exploration'}
-              onClick={() => setActiveTab('exploration')} />
-            <NavLink label="Recommendations" active={activeTab === 'recommendations'}
-              onClick={() => setActiveTab('recommendations')} />
+          {/* LEFT — master list, a distinct bordered sidebar. The Discovery
+              items + the "Analysis areas" header stay fixed; only the areas
+              scroll (ScrollArea shows a scrollbar so it's clearly scrollable). */}
+          <Card withBorder p={0} style={{ width: 260, flexShrink: 0, display: 'flex', flexDirection: 'column' }}>
+            <Stack gap={2} p="xs" style={{ flexShrink: 0 }}>
+              <Text size="xs" fw={700} c="dimmed" tt="uppercase" mb={2} px={6}>Discovery</Text>
+              <NavLink label="Base Context" active={activeTab === 'base_context'}
+                onClick={() => setActiveTab('base_context')} />
+              <NavLink label="Exploration" active={activeTab === 'exploration'}
+                onClick={() => setActiveTab('exploration')} />
+              <NavLink label="Recommendations" active={activeTab === 'recommendations'}
+                onClick={() => setActiveTab('recommendations')} />
+            </Stack>
 
-            <Group justify="space-between" align="center" mt="md" mb={4}>
-              <Text size="xs" fw={700} c="dimmed" tt="uppercase">Analysis areas</Text>
+            <Divider />
+
+            <Group justify="space-between" align="center" px="sm" py={8} style={{ flexShrink: 0 }}>
+              <Group gap={6}>
+                <Text size="xs" fw={700} c="dimmed" tt="uppercase">Analysis areas</Text>
+                <Badge size="xs" variant="light" color="gray">{areas.length}</Badge>
+              </Group>
               <Tooltip label="Add analysis area">
                 <ActionIcon size="sm" variant="subtle" onClick={() => setAddModalOpen(true)}>
                   <IconPlus size={14} />
                 </ActionIcon>
               </Tooltip>
             </Group>
-            {areas.map(([areaId, area]) => (
-              <NavLink key={areaId} label={area.name} active={activeTab === areaId}
-                onClick={() => setActiveTab(areaId)}
-                rightSection={
-                  <Group gap={4} wrap="nowrap">
-                    {!area.enabled && <Badge size="xs" color="gray">off</Badge>}
-                    {area.is_custom && <Badge size="xs" color="violet">custom</Badge>}
-                  </Group>
-                } />
-            ))}
-            {areas.length === 0 && (
-              <Text size="xs" c="dimmed" px="xs">No analysis areas yet.</Text>
-            )}
-          </Stack>
+
+            <Divider />
+
+            <ScrollArea style={{ flex: 1, minHeight: 0 }} type="auto">
+              <Stack gap={2} p="xs">
+                {areas.map(([areaId, area]) => (
+                  <NavLink key={areaId} label={area.name} active={activeTab === areaId}
+                    onClick={() => setActiveTab(areaId)}
+                    rightSection={
+                      <Group gap={4} wrap="nowrap">
+                        {!area.enabled && <Badge size="xs" color="gray">off</Badge>}
+                        {area.is_custom && <Badge size="xs" color="violet">custom</Badge>}
+                      </Group>
+                    } />
+                ))}
+                {areas.length === 0 && (
+                  <Text size="xs" c="dimmed" px="xs" py={4}>No analysis areas yet.</Text>
+                )}
+              </Stack>
+            </ScrollArea>
+          </Card>
 
           {/* RIGHT — detail for the selected item, fills width + height */}
           <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>

--- a/ui/dashboard/src/app/projects/[id]/prompts/page.tsx
+++ b/ui/dashboard/src/app/projects/[id]/prompts/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { CSSProperties, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import {
-  ActionIcon, Alert, Badge, Button, Card, Group, Loader, Modal, Stack, Switch,
-  Tabs, Text, TextInput, Title, Tooltip,
+  ActionIcon, Alert, Badge, Button, Card, Group, Loader, Modal, NavLink, Stack, Switch,
+  Text, TextInput, Title, Tooltip,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconAlertCircle, IconArrowLeft, IconCheck, IconPlus, IconTrash } from '@tabler/icons-react';
@@ -14,6 +14,16 @@ import { api, ProjectPrompts, AnalysisAreaConfig } from '@/lib/api';
 
 // Dynamic import to avoid SSR issues with the markdown editor
 const MDEditor = dynamic(() => import('@uiw/react-md-editor'), { ssr: false });
+
+// UI-only display name for this page (nav + titles). The route path (/prompts)
+// and all code identifiers stay "prompts"; only what the user reads changes.
+const PAGE_TITLE = 'Playbook';
+
+// The detail card is a flex column that fills the master–detail row's height so
+// the editor stretches down instead of leaving dead space; editorFillStyle lets
+// the MDEditor (height="100%") fill the remaining space under the header/inputs.
+const detailCardStyle: CSSProperties = { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' };
+const editorFillStyle: CSSProperties = { flex: 1, minHeight: 0 };
 
 export default function PromptsPage() {
   const { id } = useParams<{ id: string }>();
@@ -111,13 +121,13 @@ export default function PromptsPage() {
     .sort(([, a], [, b]) => a.priority - b.priority);
 
   return (
-    <Shell>
-      <Stack gap="lg">
-        <Group justify="space-between">
+    <Shell fullWidth>
+      <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - var(--db-topbar-height))', margin: '-24px', padding: 24, overflow: 'hidden' }}>
+        <Group justify="space-between" mb="md" style={{ flexShrink: 0 }}>
           <Group>
             <Button variant="subtle" leftSection={<IconArrowLeft size={16} />}
               onClick={() => router.push(`/projects/${id}`)}>Back</Button>
-            <Title order={2}>Prompt Editor</Title>
+            <Title order={2}>{PAGE_TITLE}</Title>
           </Group>
           <Group>
             <Button variant="light" leftSection={<IconPlus size={16} />}
@@ -128,78 +138,101 @@ export default function PromptsPage() {
           </Group>
         </Group>
 
-        <Tabs value={activeTab} onChange={(v) => setActiveTab(v || 'exploration')}>
-          <Tabs.List>
-            <Tabs.Tab value="base_context">Base Context</Tabs.Tab>
-            <Tabs.Tab value="exploration">Exploration</Tabs.Tab>
-            <Tabs.Tab value="recommendations">Recommendations</Tabs.Tab>
+        {/* Master–detail: sections + analysis areas on the left, the selected
+            prompt's editor on the right — fills the remaining height. */}
+        <Group align="stretch" gap="lg" wrap="nowrap" style={{ flex: 1, minHeight: 0 }}>
+          {/* LEFT — master list */}
+          <Stack gap={2} style={{ width: 250, flexShrink: 0, overflowY: 'auto' }}>
+            <Text size="xs" fw={700} c="dimmed" tt="uppercase" mb={4}>Discovery</Text>
+            <NavLink label="Base Context" active={activeTab === 'base_context'}
+              onClick={() => setActiveTab('base_context')} />
+            <NavLink label="Exploration" active={activeTab === 'exploration'}
+              onClick={() => setActiveTab('exploration')} />
+            <NavLink label="Recommendations" active={activeTab === 'recommendations'}
+              onClick={() => setActiveTab('recommendations')} />
+
+            <Group justify="space-between" align="center" mt="md" mb={4}>
+              <Text size="xs" fw={700} c="dimmed" tt="uppercase">Analysis areas</Text>
+              <Tooltip label="Add analysis area">
+                <ActionIcon size="sm" variant="subtle" onClick={() => setAddModalOpen(true)}>
+                  <IconPlus size={14} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
             {areas.map(([areaId, area]) => (
-              <Tabs.Tab key={areaId} value={areaId}>
-                <Group gap={4}>
-                  {area.name}
-                  {!area.enabled && <Badge size="xs" color="gray">disabled</Badge>}
-                  {area.is_custom && <Badge size="xs" color="violet">custom</Badge>}
-                </Group>
-              </Tabs.Tab>
+              <NavLink key={areaId} label={area.name} active={activeTab === areaId}
+                onClick={() => setActiveTab(areaId)}
+                rightSection={
+                  <Group gap={4} wrap="nowrap">
+                    {!area.enabled && <Badge size="xs" color="gray">off</Badge>}
+                    {area.is_custom && <Badge size="xs" color="violet">custom</Badge>}
+                  </Group>
+                } />
             ))}
-          </Tabs.List>
+            {areas.length === 0 && (
+              <Text size="xs" c="dimmed" px="xs">No analysis areas yet.</Text>
+            )}
+          </Stack>
 
-          {/* Base Context */}
-          <Tabs.Panel value="base_context" pt="md">
-            <Card withBorder p="lg">
-              <Title order={4} mb="sm">Base Context (Shared)</Title>
-              <Text size="xs" c="dimmed" mb="md">
-                This context is prepended to ALL prompts — exploration, analysis, and recommendations.
-                Use it for shared instructions like project profile and previous discovery context.
-                Placeholders: {'{{PROFILE}}'}, {'{{PREVIOUS_CONTEXT}}'}
-              </Text>
-              <MDEditor
-                value={prompts.base_context}
-                onChange={(val) => setPrompts({ ...prompts, base_context: val || '' })}
-                height={400}
-                preview="edit"
-              />
-            </Card>
-          </Tabs.Panel>
+          {/* RIGHT — detail for the selected item, fills width + height */}
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+            {activeTab === 'base_context' && (
+              <Card withBorder p="lg" style={detailCardStyle}>
+                <Title order={4} mb="sm">Base Context (Shared)</Title>
+                <Text size="xs" c="dimmed" mb="md">
+                  This context is prepended to ALL prompts — exploration, analysis, and recommendations.
+                  Use it for shared instructions like project profile and previous discovery context.
+                  Placeholders: {'{{PROFILE}}'}, {'{{PREVIOUS_CONTEXT}}'}
+                </Text>
+                <div style={editorFillStyle}>
+                  <MDEditor
+                    value={prompts.base_context}
+                    onChange={(val) => setPrompts({ ...prompts, base_context: val || '' })}
+                    height="100%"
+                    preview="edit"
+                  />
+                </div>
+              </Card>
+            )}
 
-          {/* Exploration Prompt */}
-          <Tabs.Panel value="exploration" pt="md">
-            <Card withBorder p="lg">
-              <Title order={4} mb="sm">Exploration System Prompt</Title>
-              <Text size="xs" c="dimmed" mb="md">
-                This prompt guides the AI agent during autonomous data exploration.
-                It tells the agent what to look for, how to write queries, and what rules to follow.
-                Base context is automatically prepended.
-              </Text>
-              <MDEditor
-                value={prompts.exploration}
-                onChange={(val) => setPrompts({ ...prompts, exploration: val || '' })}
-                height={500}
-                preview="edit"
-              />
-            </Card>
-          </Tabs.Panel>
+            {activeTab === 'exploration' && (
+              <Card withBorder p="lg" style={detailCardStyle}>
+                <Title order={4} mb="sm">Exploration System Prompt</Title>
+                <Text size="xs" c="dimmed" mb="md">
+                  This prompt guides the AI agent during autonomous data exploration.
+                  It tells the agent what to look for, how to write queries, and what rules to follow.
+                  Base context is automatically prepended.
+                </Text>
+                <div style={editorFillStyle}>
+                  <MDEditor
+                    value={prompts.exploration}
+                    onChange={(val) => setPrompts({ ...prompts, exploration: val || '' })}
+                    height="100%"
+                    preview="edit"
+                  />
+                </div>
+              </Card>
+            )}
 
-          {/* Recommendations Prompt */}
-          <Tabs.Panel value="recommendations" pt="md">
-            <Card withBorder p="lg">
-              <Title order={4} mb="sm">Recommendations Prompt</Title>
-              <Text size="xs" c="dimmed" mb="md">
-                This prompt generates actionable recommendations from discovered insights.
-              </Text>
-              <MDEditor
-                value={prompts.recommendations}
-                onChange={(val) => setPrompts({ ...prompts, recommendations: val || '' })}
-                height={500}
-                preview="edit"
-              />
-            </Card>
-          </Tabs.Panel>
+            {activeTab === 'recommendations' && (
+              <Card withBorder p="lg" style={detailCardStyle}>
+                <Title order={4} mb="sm">Recommendations Prompt</Title>
+                <Text size="xs" c="dimmed" mb="md">
+                  This prompt generates actionable recommendations from discovered insights.
+                </Text>
+                <div style={editorFillStyle}>
+                  <MDEditor
+                    value={prompts.recommendations}
+                    onChange={(val) => setPrompts({ ...prompts, recommendations: val || '' })}
+                    height="100%"
+                    preview="edit"
+                  />
+                </div>
+              </Card>
+            )}
 
-          {/* Analysis Area Prompts */}
-          {areas.map(([areaId, area]) => (
-            <Tabs.Panel key={areaId} value={areaId} pt="md">
-              <Card withBorder p="lg">
+            {areas.map(([areaId, area]) => activeTab === areaId && (
+              <Card withBorder p="lg" key={areaId} style={detailCardStyle}>
                 <Group justify="space-between" mb="md">
                   <div>
                     <Title order={4}>{area.name}</Title>
@@ -211,7 +244,7 @@ export default function PromptsPage() {
                     {area.is_custom && (
                       <Tooltip label="Remove custom area">
                         <ActionIcon color="red" variant="light"
-                          onClick={() => removeArea(areaId)}>
+                          onClick={() => { removeArea(areaId); setActiveTab('base_context'); }}>
                           <IconTrash size={16} />
                         </ActionIcon>
                       </Tooltip>
@@ -235,30 +268,32 @@ export default function PromptsPage() {
                 <Text size="xs" c="dimmed" mb="sm">
                   Placeholders: {'{{DATASET}}'}, {'{{QUERY_RESULTS}}'}, {'{{TOTAL_QUERIES}}'}. Base context (profile + previous context) is prepended automatically.
                 </Text>
-                <MDEditor
-                  value={area.prompt}
-                  onChange={(val) => updateArea(areaId, { prompt: val || '' })}
-                  height={400}
-                  preview="edit"
-                />
+                <div style={editorFillStyle}>
+                  <MDEditor
+                    value={area.prompt}
+                    onChange={(val) => updateArea(areaId, { prompt: val || '' })}
+                    height="100%"
+                    preview="edit"
+                  />
+                </div>
               </Card>
-            </Tabs.Panel>
-          ))}
-        </Tabs>
-      </Stack>
+            ))}
+          </div>
+        </Group>
+      </div>
 
       {/* Add Custom Area Modal */}
       <Modal opened={addModalOpen} onClose={() => setAddModalOpen(false)} title="Add Custom Analysis Area">
         <Stack>
           <TextInput label="Area ID" description="Unique identifier (lowercase, no spaces)"
-            placeholder="whale_analysis" value={newAreaId}
+            placeholder="cart_abandonment" value={newAreaId}
             onChange={(e) => setNewAreaId(e.target.value)} required />
-          <TextInput label="Display Name" placeholder="Whale Analysis"
+          <TextInput label="Display Name" placeholder="Cart Abandonment"
             value={newAreaName} onChange={(e) => setNewAreaName(e.target.value)} required />
-          <TextInput label="Description" placeholder="Identify high-value spenders"
+          <TextInput label="Description" placeholder="Identify why shoppers abandon their carts"
             value={newAreaDesc} onChange={(e) => setNewAreaDesc(e.target.value)} />
           <TextInput label="Keywords" description="Comma-separated keywords for filtering queries"
-            placeholder="whale, spend, purchase, vip"
+            placeholder="cart, checkout, abandon, drop-off"
             value={newAreaKeywords} onChange={(e) => setNewAreaKeywords(e.target.value)} />
           <Button onClick={addCustomArea} disabled={!newAreaId || !newAreaName}>
             Add Area

--- a/ui/dashboard/src/components/layout/AppShell.tsx
+++ b/ui/dashboard/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import {
-  IconBook2, IconBookmark, IconHelpCircle, IconMessageCircle, IconPackages, IconSearch, IconServer, IconSettings, IconSparkles, IconStack2, IconTool,
+  IconBook2, IconBookmark, IconHelpCircle, IconMessageCircle, IconNotebook, IconPackages, IconSearch, IconServer, IconSettings, IconSparkles, IconStack2,
 } from '@tabler/icons-react';
 import { api, Project } from '@/lib/api';
 import SpotlightSearch from '@/components/common/SpotlightSearch';
@@ -205,8 +205,8 @@ export default function Shell({ children, breadcrumb, actions, fullWidth }: Shel
             />
             <NavItem
               href={`/projects/${projectId}/prompts`}
-              icon={<IconTool size={16} />}
-              label="Prompts"
+              icon={<IconNotebook size={16} />}
+              label="Playbook"
               active={isActive(`/projects/${projectId}/prompts`)}
             />
           </nav>

--- a/ui/dashboard/src/components/layout/AppShell.tsx
+++ b/ui/dashboard/src/components/layout/AppShell.tsx
@@ -224,7 +224,7 @@ export default function Shell({ children, breadcrumb, actions, fullWidth }: Shel
             <NavItem
               href="/domain-packs"
               icon={<IconPackages size={16} />}
-              label="Domain Packs"
+              label="Playbooks"
               active={pathname?.startsWith('/domain-packs') ?? false}
             />
             <NavItem


### PR DESCRIPTION
## Playbook — Prompts page redesign + "Domain Packs" → "Playbook" UI rename (community)

UI + docs companion to **decisionbox-enterprise** (same branch, `feat/prompts-ui-redesign`). Cosmetic/UI-only — no structural, route, API, or format changes.

### Prompts page → **Playbook**
- Renamed in the UI only (nav + page title via a single `PAGE_TITLE` constant, notebook icon). The `/prompts` route and all code are unchanged.
- Replaced the horizontal tabs with a **master-detail** layout: sections (Base Context / Exploration / Recommendations) + analysis areas as a bordered left sidebar (fixed headers, count badge, only the areas scroll in a `ScrollArea`); the selected prompt's editor on the right.
- `Shell fullWidth` + full-height flex so the editor fills the available width/height.
- Commerce-flavoured "add analysis area" placeholders (was gaming).

### "Domain Packs" → **Playbooks** (UI labels)
- Nav "Playbooks", `/domain-packs` list + editor pages, import modal, notifications, empty states.
- **Unchanged:** routes (`/domain-packs`, `/api/v1/domain-packs`), types (`DomainPack`), the `decisionbox-domain-pack` export format, all agent/worker code.

### Docs
- Kept "domain pack" for the JSON/API model; added the **Playbook** alias at the definitional pages (`concepts/domain-packs` → titled "Playbook / Domain Packs", `creating-domain-packs`, `customizing-prompts`). docs-lint clean.

Verified: tsc + eslint clean; live-tested on the dev stack.

— Co-coded with Jale 🤖
