### PR TITLE
feat(models): ask for a table identifier only where tables exist (#252 W9)

### DIFF
--- a/docs/concepts/domain-packs.md
+++ b/docs/concepts/domain-packs.md
@@ -46,6 +46,13 @@ that reads correctly and asks for queries the source cannot answer. A shape
 that is neither of the two above is rejected when the pack is saved, rather
 than stored and silently matching nothing.
 
+Shape also decides one validation rule. Every pack's exploration prompt must
+carry `{{SCHEMA_INFO}}` and `{{ANALYSIS_AREAS}}`, but `{{DATASET}}` — the
+dataset and schema names the prompt qualifies its tables with — is asked only
+of a pack written for an `entities` source. A cube has no tables to name, so
+requiring it there would be a rule no pack could satisfy. A cube pack that
+includes the placeholder anyway is still valid; nothing substitutes it.
+
 ## Three-Level Hierarchy
 
 ```

--- a/docs/concepts/domain-packs.md
+++ b/docs/concepts/domain-packs.md
@@ -53,6 +53,13 @@ of a pack written for an `entities` source. A cube has no tables to name, so
 requiring it there would be a rule no pack could satisfy. A cube pack that
 includes the placeholder anyway is still valid; nothing substitutes it.
 
+Shape also has to agree with the data source. Creating a project pairs a pack
+with a data source for the first time, and a pairing of different shapes is
+refused there: a cube pack seeded into a warehouse project produces prompts
+that ask for queries the source cannot answer, with no error to notice. A pack
+with no shape counts as `entities`, so every project created from the existing
+corpus is unaffected.
+
 ## Three-Level Hierarchy
 
 ```

--- a/services/api/internal/handler/project_pack_shape_test.go
+++ b/services/api/internal/handler/project_pack_shape_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -129,5 +130,98 @@ func TestPackShapeMismatch_NoDatasourceIsNotAMismatch(t *testing.T) {
 	pack := &models.DomainPack{Slug: "analytics", Shape: gowarehouse.ShapeCube}
 	if msg := packShapeMismatch(pack, models.WarehouseConfig{}); msg != "" {
 		t.Errorf("a project with no data source should not be a mismatch: %s", msg)
+	}
+}
+
+// TestSettingsEdit_RefusesAPackTheNewDatasourceDoesNotMatch closes the gap the
+// create-time check cannot see.
+//
+// A project may be created before it has a data source — that is how the
+// product is set up — and its pack is seeded then, with nothing to disagree
+// with. The pairing only becomes checkable when the data source arrives, which
+// for a single-datasource project is this settings edit.
+func TestSettingsEdit_RefusesAPackTheNewDatasourceDoesNotMatch(t *testing.T) {
+	tables := shapeProbe(t, "probe_edit_tables", gowarehouse.ShapeEntities)
+	cube := shapeProbe(t, "probe_edit_cube", gowarehouse.ShapeCube)
+
+	edit := func(t *testing.T, packShape gowarehouse.SourceShape, provider string) *httptest.ResponseRecorder {
+		t.Helper()
+		pack := testDomainPack("gaming", "match3")
+		pack.Shape = packShape
+		packRepo := newMockDomainPackRepo()
+		packRepo.add(pack)
+
+		projRepo := newMockProjectRepo()
+		h := NewProjectsHandler(projRepo, packRepo)
+
+		// Created with no data source, exactly as the blank-project flow does.
+		p := &models.Project{Name: "p", Domain: "gaming", Category: "match3"}
+		if err := projRepo.Create(context.Background(), p); err != nil {
+			t.Fatalf("seeding the project: %v", err)
+		}
+
+		body := fmt.Sprintf(`{"warehouse": {"provider": %q, "datasets": ["d1"]}}`, provider)
+		req := httptest.NewRequest("PUT", "/api/v1/projects/"+p.ID, strings.NewReader(body))
+		req.SetPathValue("id", p.ID)
+		w := httptest.NewRecorder()
+		h.Update(w, req)
+		return w
+	}
+
+	t.Run("cube pack, table data source", func(t *testing.T) {
+		w := edit(t, gowarehouse.ShapeCube, tables)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), string(gowarehouse.ShapeCube)) {
+			t.Errorf("the refusal does not name the pack's shape: %s", w.Body.String())
+		}
+	})
+
+	t.Run("table pack, cube data source", func(t *testing.T) {
+		if w := edit(t, gowarehouse.ShapeEntities, cube); w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	// The ordinary edit every existing project makes. A guard that refused this
+	// would break connecting a warehouse to any project in the product.
+	t.Run("table pack, table data source", func(t *testing.T) {
+		if w := edit(t, "", tables); w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("cube pack, cube data source", func(t *testing.T) {
+		if w := edit(t, gowarehouse.ShapeCube, cube); w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// TestSettingsEdit_AMissingPackDoesNotBlockTheEdit pins the direction this
+// guard fails in, which is the opposite of the one in packShapeMismatch.
+//
+// The pack may have been deleted or renamed since the project was created.
+// Refusing an unrelated settings edit over that would be a worse outcome than
+// the mismatch being guarded against, and the customer would have no way to
+// act on it.
+func TestSettingsEdit_AMissingPackDoesNotBlockTheEdit(t *testing.T) {
+	tables := shapeProbe(t, "probe_edit_nopack", gowarehouse.ShapeEntities)
+
+	projRepo := newMockProjectRepo()
+	h := NewProjectsHandler(projRepo, newMockDomainPackRepo()) // empty corpus
+	p := &models.Project{Name: "p", Domain: "deleted-since", Category: "match3"}
+	if err := projRepo.Create(context.Background(), p); err != nil {
+		t.Fatalf("seeding the project: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"warehouse": {"provider": %q, "datasets": ["d1"]}}`, tables)
+	req := httptest.NewRequest("PUT", "/api/v1/projects/"+p.ID, strings.NewReader(body))
+	req.SetPathValue("id", p.ID)
+	w := httptest.NewRecorder()
+	h.Update(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
 }

--- a/services/api/internal/handler/project_pack_shape_test.go
+++ b/services/api/internal/handler/project_pack_shape_test.go
@@ -1,0 +1,133 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/api/models"
+)
+
+// shapeProbe registers a warehouse provider of a given shape that can carry a
+// project on its own, so a create using it is refused for shape or accepted,
+// never refused for having nothing to anchor on.
+func shapeProbe(t *testing.T, name string, shape gowarehouse.SourceShape) string {
+	t.Helper()
+	slug := fmt.Sprintf("%s_%d", name, probeSeq.Add(1))
+	gowarehouse.RegisterWithMeta(slug, func(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) {
+		return nil, fmt.Errorf("probe provider is not constructible")
+	}, gowarehouse.ProviderMeta{
+		Name:           slug,
+		Dialect:        "Probe SQL",
+		DefaultPricing: &gowarehouse.WarehousePricing{CostModel: "per_query"},
+		Capability: gowarehouse.Capability{
+			CanAnchor: gowarehouse.Anchoring(true),
+			Shape:     shape,
+		},
+	})
+	return slug
+}
+
+// createWithPack posts a single-datasource create using the given provider and
+// a pack of the given shape, and returns the recorder.
+func createWithPack(t *testing.T, provider string, packShape gowarehouse.SourceShape) *httptest.ResponseRecorder {
+	t.Helper()
+	pack := testDomainPack("gaming", "match3")
+	pack.Shape = packShape
+
+	packRepo := newMockDomainPackRepo()
+	packRepo.add(pack)
+	h := NewProjectsHandler(newMockProjectRepo(), packRepo)
+
+	body := fmt.Sprintf(`{
+		"name": "p", "domain": "gaming", "category": "match3",
+		"warehouse": {"provider": %q, "datasets": ["d1"]},
+		"llm": {"provider": "claude", "model": "claude-sonnet-4-6"}
+	}`, provider)
+	req := httptest.NewRequest("POST", "/api/v1/projects", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Create(w, req)
+	return w
+}
+
+// TestCreate_RefusesACubePackOnATableProject is the hole that opens the moment
+// a cube pack can be saved at all.
+//
+// The domain list the picker reads is every published pack, and a generated
+// pack is published — so the first cube pack in the corpus is offered to a
+// customer creating a BigQuery project. Its prompts tell the model to choose
+// metrics and dimensions against a source that has tables, which produces a
+// discovery run that fails without erroring.
+func TestCreate_RefusesACubePackOnATableProject(t *testing.T) {
+	tables := shapeProbe(t, "probe_shape_tables", gowarehouse.ShapeEntities)
+	w := createWithPack(t, tables, gowarehouse.ShapeCube)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	// The refusal has to name both halves, or the customer cannot tell whether
+	// the pack or the data source is the thing they picked wrongly.
+	body := w.Body.String()
+	for _, want := range []string{string(gowarehouse.ShapeCube), string(gowarehouse.ShapeEntities), "gaming"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the refusal does not mention %q: %s", want, body)
+		}
+	}
+}
+
+// TestCreate_RefusesATablePackOnACubeProject is the same pairing the other way
+// round. It is the less likely direction — a cube cannot normally carry a
+// project — but the rule is about the pairing, not about which half is odd.
+func TestCreate_RefusesATablePackOnACubeProject(t *testing.T) {
+	cube := shapeProbe(t, "probe_shape_cube", gowarehouse.ShapeCube)
+	if w := createWithPack(t, cube, gowarehouse.ShapeEntities); w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreate_AcceptsAMatchingPair pins that the guard is a shape check and not
+// a ban on cube packs. Both matched pairings must go through, or the check has
+// simply moved the blocker somewhere new.
+func TestCreate_AcceptsAMatchingPair(t *testing.T) {
+	for _, shape := range []gowarehouse.SourceShape{gowarehouse.ShapeEntities, gowarehouse.ShapeCube} {
+		provider := shapeProbe(t, "probe_shape_match", shape)
+		if w := createWithPack(t, provider, shape); w.Code != http.StatusCreated {
+			t.Errorf("shape %q: status = %d, want 201; body: %s", shape, w.Code, w.Body.String())
+		}
+	}
+}
+
+// TestCreate_AnUndeclaredShapeIsTableShaped covers the entire existing corpus.
+// No pack written before shape was recorded carries the field, and every one
+// of them targets tables — resolving that to "no shape" would refuse every
+// project create in the product.
+func TestCreate_AnUndeclaredShapeIsTableShaped(t *testing.T) {
+	tables := shapeProbe(t, "probe_shape_legacy", gowarehouse.ShapeEntities)
+	if w := createWithPack(t, tables, ""); w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestPackShapeMismatch_UnknownProviderKeepsTheCheck pins the direction the
+// helper fails in. A provider this build cannot resolve is read as
+// table-shaped — the default applied everywhere else — so an unregistered
+// spelling refuses a cube pack rather than waving it through.
+func TestPackShapeMismatch_UnknownProviderKeepsTheCheck(t *testing.T) {
+	pack := &models.DomainPack{Slug: "analytics", Shape: gowarehouse.ShapeCube}
+	primary := models.WarehouseConfig{Provider: "not-registered-anywhere"}
+	if msg := packShapeMismatch(pack, primary); msg == "" {
+		t.Error("an unresolvable provider should keep the check, not skip it")
+	}
+}
+
+// TestPackShapeMismatch_NoDatasourceIsNotAMismatch: nothing has been chosen
+// for the pack to disagree with, and the anchoring guards own that case. A
+// mismatch reported here would refuse it with the wrong reason.
+func TestPackShapeMismatch_NoDatasourceIsNotAMismatch(t *testing.T) {
+	pack := &models.DomainPack{Slug: "analytics", Shape: gowarehouse.ShapeCube}
+	if msg := packShapeMismatch(pack, models.WarehouseConfig{}); msg != "" {
+		t.Errorf("a project with no data source should not be a mismatch: %s", msg)
+	}
+}

--- a/services/api/internal/handler/projects.go
+++ b/services/api/internal/handler/projects.go
@@ -575,6 +575,15 @@ func (h *ProjectsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		if !rejectUnanchoredProject(w, []models.WarehouseConfig{incoming.Warehouse}, telemetry.AnchoringAtSettingsEdit, existing.ID) {
 			return
 		}
+		// The pairing is checked wherever it changes, and this is the other
+		// place it does. A project created before it had a datasource was
+		// seeded from its pack with nothing to disagree with; the shape only
+		// becomes checkable here, one edit later — which is also the flow a
+		// customer takes when they set the project up before connecting
+		// anything.
+		if !h.rejectPackShapeMismatch(r.Context(), w, existing.Domain, incoming.Warehouse) {
+			return
+		}
 		existing.Warehouse = incoming.Warehouse
 	}
 	if incoming.LLM.Provider != "" {
@@ -744,19 +753,6 @@ func (h *ProjectsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// rejectUnanchoredProject refuses a datasource set in which nothing can carry
-// the project, writing a 400 and returning false.
-//
-// An EMPTY set passes. A project with no datasources yet is how every project
-// starts, and refusing it here would make the product unusable to say
-// something true; the run paths refuse an empty set on their own terms.
-//
-// What is refused is a set that HAS datasources, none of which is a system of
-// record. Such a project reaches the agent looking perfectly healthy and
-// produces analysis that restates what the source's own reporting already
-// shows — confidently, and with no error anyone would connect to the cause.
-// Refusing at configuration time is the only point where the message can name
-// the fix.
 // packShapeMismatch reports why a domain pack cannot seed this project's
 // prompts, or "" when it can.
 //
@@ -792,6 +788,42 @@ func packShapeMismatch(pack *models.DomainPack, primary models.WarehouseConfig) 
 	return fmt.Sprintf(
 		"domain pack %q is written for a %s data source, but this project's data source is %s; choose a pack written for %s",
 		pack.Slug, got, want, want)
+}
+
+// rejectUnanchoredProject refuses a datasource set in which nothing can carry
+// the project, writing a 400 and returning false.
+//
+// An EMPTY set passes. A project with no datasources yet is how every project
+// starts, and refusing it here would make the product unusable to say
+// something true; the run paths refuse an empty set on their own terms.
+//
+// What is refused is a set that HAS datasources, none of which is a system of
+// record. Such a project reaches the agent looking perfectly healthy and
+// produces analysis that restates what the source's own reporting already
+// shows — confidently, and with no error anyone would connect to the cause.
+// Refusing at configuration time is the only point where the message can name
+// the fix.
+// rejectPackShapeMismatch is packShapeMismatch over a project's saved pack
+// slug, writing a 400 and returning false on a mismatch.
+//
+// A pack that cannot be loaded is not a refusal. The pack may have been
+// deleted or renamed since the project was created, and blocking an unrelated
+// settings edit on that would be a worse outcome than the mismatch it is
+// guarding against — which the create path already catches for every project
+// that had a datasource to check.
+func (h *ProjectsHandler) rejectPackShapeMismatch(ctx context.Context, w http.ResponseWriter, domain string, wh models.WarehouseConfig) bool {
+	if h.domainPackRepo == nil || domain == "" {
+		return true
+	}
+	pack, err := h.domainPackRepo.GetBySlug(ctx, domain)
+	if err != nil || pack == nil {
+		return true
+	}
+	if msg := packShapeMismatch(pack, wh); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return false
+	}
+	return true
 }
 
 func rejectUnanchoredProject(w http.ResponseWriter, whs []models.WarehouseConfig, at, projectID string) bool {

--- a/services/api/internal/handler/projects.go
+++ b/services/api/internal/handler/projects.go
@@ -261,20 +261,6 @@ func (h *ProjectsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		p.Language = cleanLang
 	}
 
-	// Seed default prompts from domain pack.
-	if p.Prompts == nil && h.domainPackRepo != nil {
-		pack, err := h.domainPackRepo.GetBySlug(r.Context(), p.Domain)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load domain pack: "+err.Error())
-			return
-		}
-		if pack == nil {
-			writeError(w, http.StatusBadRequest, "domain pack not found: "+p.Domain)
-			return
-		}
-		SeedProjectPrompts(&p, pack)
-	}
-
 	// Reject a split-brain body that sets BOTH the legacy `warehouse` field and
 	// the new `warehouses` slice. EffectiveWarehouses() would silently pick the
 	// slice and persist a divergent legacy field, so any code still reading
@@ -322,6 +308,30 @@ func (h *ProjectsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		p.Warehouse.ID = ""
 		p.Warehouses = nil
 		p.PrimaryWarehouseID = ""
+	}
+
+	// Seed default prompts from domain pack.
+	//
+	// After the warehouse checks above, not before them, because the pack has
+	// to agree with the datasource it will be run against and neither the
+	// split-brain body nor an unanchored project has a settled answer to
+	// "which datasource is that". Nothing between here and the decode reads
+	// prompts, so the move costs nothing.
+	if p.Prompts == nil && h.domainPackRepo != nil {
+		pack, err := h.domainPackRepo.GetBySlug(r.Context(), p.Domain)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load domain pack: "+err.Error())
+			return
+		}
+		if pack == nil {
+			writeError(w, http.StatusBadRequest, "domain pack not found: "+p.Domain)
+			return
+		}
+		if msg := packShapeMismatch(pack, p.PrimaryWarehouse()); msg != "" {
+			writeError(w, http.StatusBadRequest, msg)
+			return
+		}
+		SeedProjectPrompts(&p, pack)
 	}
 
 	// Plan-gate: provider allow-list. Self-hosted Noop permits everything.
@@ -747,6 +757,43 @@ func (h *ProjectsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // shows — confidently, and with no error anyone would connect to the cause.
 // Refusing at configuration time is the only point where the message can name
 // the fix.
+// packShapeMismatch reports why a domain pack cannot seed this project's
+// prompts, or "" when it can.
+//
+// A pack's prompts are written for one shape of source and are not portable
+// across shapes. An entities pack tells the model to select from tables and
+// names them through {{DATASET}}; a cube pack tells it to choose metrics and
+// dimensions and has no dataset to name. Seeding either into a project whose
+// primary datasource is the other shape yields a discovery run that reads
+// correctly and asks for queries the source cannot answer — a failure with no
+// error attached, which is the expensive kind.
+//
+// This could not happen while every pack was table-shaped. It became
+// reachable the moment a cube pack could be saved, so it is checked at the
+// one place a pack and a datasource are first paired. It is not a validator
+// rule: a pack is not invalid for being cube-shaped, it is only wrong HERE.
+//
+// A project with no datasource is not a mismatch — nothing has been chosen to
+// disagree with. An unregistered provider is read as table-shaped, the same
+// default the rest of the system applies, so an unknown spelling keeps the
+// check rather than waving a pack through.
+func packShapeMismatch(pack *models.DomainPack, primary models.WarehouseConfig) string {
+	if pack == nil || primary.Provider == "" {
+		return ""
+	}
+	want := gowarehouse.ShapeEntities
+	if meta, ok := gowarehouse.GetProviderMeta(primary.Provider); ok {
+		want = meta.EffectiveShape()
+	}
+	got := pack.EffectiveShape()
+	if got == want {
+		return ""
+	}
+	return fmt.Sprintf(
+		"domain pack %q is written for a %s data source, but this project's data source is %s; choose a pack written for %s",
+		pack.Slug, got, want, want)
+}
+
 func rejectUnanchoredProject(w http.ResponseWriter, whs []models.WarehouseConfig, at, projectID string) bool {
 	if len(whs) == 0 || models.AnyAnchors(whs) {
 		return true

--- a/services/api/models/domainpack_validator.go
+++ b/services/api/models/domainpack_validator.go
@@ -19,11 +19,23 @@ var DomainPackSlugRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 // failure.
 //
 // This is the single source of truth for "is this pack persistable"
-// — the dashboard's PUT /api/v1/domain-packs/{slug} handler runs
-// it, the seed-loading flow runs it, and the enterprise packgen
-// plugin's auto-fix loop runs it (via its own import) so a
-// generated pack that would later be rejected at save time is
-// caught at generation time instead.
+// — the dashboard's POST / PUT / import handlers run it, and the
+// enterprise packgen plugin's auto-fix loop runs it so a generated
+// pack that would later be rejected at save time is caught at
+// generation time instead.
+//
+// The seed loader deliberately does NOT: built-in packs ship in the
+// binary, so a failure there is a build-time mistake rather than
+// something an operator can act on at startup, and refusing to seed
+// leaves a fresh install with no packs at all.
+//
+// The pack's OWN shape decides the shape-dependent checks here. That
+// is right for a save: the pack being persisted is the pack, and it
+// is the shape pack selection will later key on, so a pack labelled
+// cube is one asked cube questions ever after. It is wrong mid-
+// generation, where the shape comes from the target datasource and
+// the model's raw output carries none — see
+// ValidateDomainPackForTarget.
 //
 // Checks:
 //   - slug shape (DomainPackSlugRegex, min length 2)
@@ -31,13 +43,35 @@ var DomainPackSlugRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 //   - a declared source shape is one this build knows (absent is legal)
 //   - base prompts non-empty
 //   - required template placeholders: {{PROFILE}} in base_context;
-//     {{DATASET}}, {{SCHEMA_INFO}}, {{ANALYSIS_AREAS}} in exploration;
+//     {{SCHEMA_INFO}}, {{ANALYSIS_AREAS}} in exploration;
 //     {{INSIGHTS_DATA}} in recommendations — substituted by the
 //     discovery agent at run-time and required by the agent's
-//     prompt-rendering pipeline.
+//     prompt-rendering pipeline. {{DATASET}} joins them for every
+//     target but a cube; see requiresTableIdentifier.
 //   - at least one base analysis area; every area (base and
 //     per-category) has id + name + prompt + at least one keyword.
 func ValidateDomainPack(pack *DomainPack) error {
+	return ValidateDomainPackForTarget(pack, pack.EffectiveShape())
+}
+
+// ValidateDomainPackForTarget is ValidateDomainPack with the shape
+// supplied by the caller rather than read from the pack.
+//
+// The distinction is load-bearing exactly once: inside packgen's
+// synth retry loop, where the thing being validated is the model's
+// raw output. A generator never emits `shape` — it is not in the
+// output schema and is stripped from the example pack — so reading
+// the pack's own field there resolves every target to the default
+// and leaves a cube's requirements as unsatisfiable as they were
+// before this existed. Worse, it would let a hallucinated
+// `"shape": "cube"` in the model's output switch the SQL checks off
+// for a pack destined for a warehouse.
+//
+// Relaxing, not inverting: a cube-targeted pack that carries
+// {{DATASET}} anyway still passes. The placeholder is harmless
+// where nothing substitutes it, and the generator's prompt is what
+// stops asking for it, not this.
+func ValidateDomainPackForTarget(pack *DomainPack, target warehouse.SourceShape) error {
 	if pack.Slug == "" {
 		return fmt.Errorf("slug is required")
 	}
@@ -81,7 +115,7 @@ func ValidateDomainPack(pack *DomainPack) error {
 	if !strings.Contains(pack.Prompts.Base.BaseContext, "{{PROFILE}}") {
 		return fmt.Errorf("base_context must contain {{PROFILE}} template variable")
 	}
-	if !strings.Contains(pack.Prompts.Base.Exploration, "{{DATASET}}") {
+	if requiresTableIdentifier(target) && !strings.Contains(pack.Prompts.Base.Exploration, "{{DATASET}}") {
 		return fmt.Errorf("exploration must contain {{DATASET}} template variable")
 	}
 	if !strings.Contains(pack.Prompts.Base.Exploration, "{{SCHEMA_INFO}}") {
@@ -112,6 +146,26 @@ func ValidateDomainPack(pack *DomainPack) error {
 	}
 
 	return nil
+}
+
+// requiresTableIdentifier reports whether a pack written for this target
+// must name the tables it queries.
+//
+// {{DATASET}} is substituted with the connected datasource's dataset or
+// schema names, so the exploration prompt can say which tables exist to
+// query. A cube has none: a query there is a choice of metrics and
+// dimensions against a property, and there is no identifier to qualify
+// them with. Demanding the placeholder of such a pack is not a rule the
+// generator can meet by trying harder — there is nothing for it to say —
+// so it fails validation, exhausts its auto-fix budget, and produces
+// nothing.
+//
+// Asked of everything that is not a cube, rather than of an allow-list of
+// SQL shapes. A shape this build has never heard of is table-shaped until
+// proven otherwise, which fails toward keeping the check rather than
+// silently dropping it.
+func requiresTableIdentifier(target warehouse.SourceShape) bool {
+	return target != warehouse.ShapeCube
 }
 
 func validateAnalysisArea(area PackAnalysisArea, label string) error {

--- a/services/api/models/domainpack_validator_shape_test.go
+++ b/services/api/models/domainpack_validator_shape_test.go
@@ -1,0 +1,140 @@
+package models
+
+import (
+	"strings"
+	"testing"
+
+	warehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+)
+
+// noDatasetPack is the minimal valid pack with the table-identifier
+// placeholder taken out of its exploration prompt — a pack written for a
+// source that has no tables to name.
+func noDatasetPack(t *testing.T) *DomainPack {
+	t.Helper()
+	pack := testDomainPack("analytics", "web")
+	pack.Prompts.Base.Exploration = "Explore using {{SCHEMA_INFO}} areas: {{ANALYSIS_AREAS}}"
+	pack.AnalysisAreas.Base[0].Prompt = "Analyze the property: {{QUERY_RESULTS}}"
+	return pack
+}
+
+// TestValidate_CubePackNeedsNoDataset is the blocker this change removes.
+//
+// {{DATASET}} is substituted with the datasource's dataset or schema names.
+// A cube has neither, so the requirement is not merely unmet on such a pack
+// — it is unsatisfiable, and a generator asked to satisfy it re-rolls until
+// its auto-fix budget is gone.
+func TestValidate_CubePackNeedsNoDataset(t *testing.T) {
+	pack := noDatasetPack(t)
+	pack.Shape = warehouse.ShapeCube
+	if err := ValidateDomainPack(pack); err != nil {
+		t.Errorf("a cube-shaped pack without {{DATASET}} should save: %v", err)
+	}
+}
+
+// TestValidate_CubePackMayStillCarryDataset pins that this relaxes the rule
+// rather than inverting it. The placeholder is harmless where nothing
+// substitutes it, and the generator's prompt is what stops asking for it —
+// so a pack that carries one anyway must not become unsavable.
+func TestValidate_CubePackMayStillCarryDataset(t *testing.T) {
+	pack := testDomainPack("analytics", "web")
+	pack.Shape = warehouse.ShapeCube
+	if err := ValidateDomainPack(pack); err != nil {
+		t.Errorf("a cube pack carrying {{DATASET}} should still save: %v", err)
+	}
+}
+
+// TestValidate_TableTargetStillRequiresDataset asserts the SQL rule is
+// untouched, in both spellings of table-shaped: declared entities, and the
+// absent shape that every pack in the existing corpus carries.
+func TestValidate_TableTargetStillRequiresDataset(t *testing.T) {
+	for _, shape := range []warehouse.SourceShape{warehouse.ShapeEntities, ""} {
+		pack := noDatasetPack(t)
+		pack.Shape = shape
+		err := ValidateDomainPack(pack)
+		if err == nil || !strings.Contains(err.Error(), "{{DATASET}}") {
+			t.Errorf("shape %q: should still require {{DATASET}}, got %v", shape, err)
+		}
+	}
+}
+
+// TestValidateForTarget_ShapeComesFromTheCaller is the case the exported
+// no-target form cannot serve, and the reason this signature exists.
+//
+// Mid-generation the pack is the model's raw output, which never carries
+// shape: it is not in the output schema and it is stripped from the example
+// pack the model imitates. Reading the pack's own field there resolves every
+// target to the default, which would leave the cube requirement exactly as
+// unsatisfiable as it was before this change — the same way W9's first
+// enterprise attempt did nothing.
+func TestValidateForTarget_ShapeComesFromTheCaller(t *testing.T) {
+	pack := noDatasetPack(t)
+	if pack.Shape != "" {
+		t.Fatalf("this test is about a pack with no shape, got %q", pack.Shape)
+	}
+	if err := ValidateDomainPackForTarget(pack, warehouse.ShapeCube); err != nil {
+		t.Errorf("a cube target should not demand {{DATASET}} of an unlabelled pack: %v", err)
+	}
+}
+
+// TestValidateForTarget_TargetBeatsAHallucinatedShape is the other half of
+// the same reason. A generator that invents "shape": "cube" in its output
+// must not thereby switch the SQL checks off for a pack destined for a
+// warehouse — the target is the fact, the pack's field is a claim.
+func TestValidateForTarget_TargetBeatsAHallucinatedShape(t *testing.T) {
+	pack := noDatasetPack(t)
+	pack.Shape = warehouse.ShapeCube
+	err := ValidateDomainPackForTarget(pack, warehouse.ShapeEntities)
+	if err == nil || !strings.Contains(err.Error(), "{{DATASET}}") {
+		t.Errorf("a table target should require {{DATASET}} whatever the pack claims, got %v", err)
+	}
+}
+
+// TestValidateForTarget_UnknownTargetKeepsTheCheck pins the direction the
+// predicate fails in. A shape this build has never heard of is treated as
+// table-shaped, so a future spelling arriving from an older peer keeps the
+// SQL requirement rather than silently dropping it.
+func TestValidateForTarget_UnknownTargetKeepsTheCheck(t *testing.T) {
+	pack := noDatasetPack(t)
+	err := ValidateDomainPackForTarget(pack, warehouse.SourceShape("something-later"))
+	if err == nil || !strings.Contains(err.Error(), "{{DATASET}}") {
+		t.Errorf("an unknown target should keep the {{DATASET}} check, got %v", err)
+	}
+}
+
+// TestValidate_CubeRelaxesOnlyTheDataset confines the exemption. Every other
+// placeholder is substituted for a cube run exactly as it is for a SQL one —
+// the schema slice becomes the catalog descriptor, the areas and profile do
+// not change at all — so dropping any of them would break a cube pack at
+// run-time rather than accommodate it.
+func TestValidate_CubeRelaxesOnlyTheDataset(t *testing.T) {
+	cases := []struct {
+		name    string
+		break_  func(*DomainPack)
+		wantVar string
+	}{
+		{"schema info", func(p *DomainPack) {
+			p.Prompts.Base.Exploration = "Explore areas: {{ANALYSIS_AREAS}}"
+		}, "{{SCHEMA_INFO}}"},
+		{"analysis areas", func(p *DomainPack) {
+			p.Prompts.Base.Exploration = "Explore using {{SCHEMA_INFO}}"
+		}, "{{ANALYSIS_AREAS}}"},
+		{"profile", func(p *DomainPack) {
+			p.Prompts.Base.BaseContext = "Context with no profile"
+		}, "{{PROFILE}}"},
+		{"insights data", func(p *DomainPack) {
+			p.Prompts.Base.Recommendations = "Recommend from nothing"
+		}, "{{INSIGHTS_DATA}}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pack := noDatasetPack(t)
+			pack.Shape = warehouse.ShapeCube
+			tc.break_(pack)
+			err := ValidateDomainPack(pack)
+			if err == nil || !strings.Contains(err.Error(), tc.wantVar) {
+				t.Errorf("a cube pack should still require %s, got %v", tc.wantVar, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The other half of W9's blocker, and a real prerequisite for W11 rather than the loose end I previously called it.

## The problem

`models.ValidateDomainPack` hard-required `{{DATASET}}` in every pack's exploration prompt (`domainpack_validator.go:84`). That placeholder is substituted with the datasource's dataset and schema names, so the prompt can say which tables exist to query. A cube has none — a query there is a choice of metrics and dimensions against a property, with no identifier to qualify them with.

So on a cube target the rule is not *unmet*, it is **unsatisfiable**. And it is not a distant concern: enterprise `packgen/validator.go:80` calls this function inside the synth auto-fix loop, so a generated cube pack re-rolls toward a placeholder its target has no use for until the retry budget is gone. W9's enterprise half removed the `{{DIALECT}}` demand; this is the same blocker on the other placeholder, and it bites the moment a cube prompt stops asking for SQL scaffolding — which is exactly what W11's exemplar has to teach.

## 1. The validator

`ValidateDomainPackForTarget(pack, target)` takes the shape from the caller. `ValidateDomainPack(pack)` keeps its signature and delegates with the pack's own `EffectiveShape()`.

The two entry points are not redundant, and the distinction is the thing W9's first enterprise attempt got wrong:

- **At save time** the pack's own shape is authoritative. The pack being persisted *is* the pack, and its shape is what selection keys on afterwards — a pack labelled cube is asked cube questions ever after, so the label and the relaxation travel together.
- **Mid-generation** it is not. The model's raw output never carries `shape` — it is not in the output schema and W8 strips it from the example pack — so reading the pack's own field there resolves every target to the default and leaves the rule exactly as unsatisfiable as before. It would also let a hallucinated `"shape": "cube"` switch the SQL checks off for a pack destined for a warehouse. The target is a fact; the pack's field is a claim.

Relaxed, not inverted. A cube pack carrying `{{DATASET}}` anyway still passes, and every other placeholder is required of a cube exactly as before. An unknown shape is treated as table-shaped, so a spelling this build has not heard of keeps the check rather than silently dropping it.

## 2. The hole that opens behind it (Codex R1, R2)

Making a cube pack savable makes it *selectable*. The domain picker lists every published pack, and generated packs are published — so the first cube pack in the corpus is offered to a customer creating a BigQuery project, whose prompts then tell the model to choose metrics and dimensions against a source that has tables. That fails without erroring, which is the expensive kind of failure.

So the pairing is now checked wherever it changes:

- **Project create**, where a pack and a datasource are first paired. The seeding block moves below the warehouse checks, because neither a split-brain body nor an unanchored project has a settled answer to which datasource the pack must agree with.
- **The settings edit** (`PUT /projects/{id}`), because a project may be created *before* it has a datasource — that is how the product is set up — and its pack is seeded then with nothing to disagree with. The datasource arrives one edit later, which is where the pairing first becomes checkable.

This is deliberately not a validator rule. A cube pack is not invalid for being cube-shaped; it is only wrong for a particular project.

The two guards fail in opposite directions, on purpose. `packShapeMismatch` reads an unregistered provider as table-shaped, so an unknown spelling keeps the check. The settings-edit wrapper lets a pack it cannot load through, because the pack may have been deleted or renamed since the project was created and blocking an unrelated settings edit on that is worse than the mismatch.

## Not in this PR

`packgen` must pass its resolved target for the validator change to take effect; on its own it is inert for the generator. That is the enterprise half and lands next. Stated plainly because the shape of the mistake here is a fix that looks complete and does nothing — which is precisely what W9's first attempt was.

The multi-datasource warehouse-management flow is not covered. It does not need to be today: a cube cannot anchor, a project's primary must be able to carry it, and the project-level pack is the primary's — so the primary stays table-shaped whatever is added beside it.

## Verified

- `go build ./...`, `go vet`, `gofmt` clean; `services/agent` and `libs/go-common` still build
- `go test ./...` across the **whole** `services/api` module, twice, not a `-run` filter
- 14 new tests. Validator: the cube exemption, the relaxation staying a relaxation, the SQL rule intact in both spellings of table-shaped, the caller's target beating a hallucinated one, an unknown target keeping the check, the exemption confined to `{{DATASET}}`. Pairing: both mismatched directions refused at create and at the settings edit, both matched directions accepted, an undeclared shape accepted (the entire existing corpus), an unresolvable provider keeping the check, a missing pack not blocking an edit
- Mutation-checked, eight mutants, all killed: predicate always-false, always-true (the bug as it stands today), the exported form reading a constant shape, the pairing guard never firing, an unknown provider skipping the check, reading `pack.Shape` instead of `EffectiveShape()`, the settings-edit guard removed, and a missing pack refusing the edit
- Three Codex rounds; two P2s, both valid, both fixed above; round 3 clean
- CI green

Part of #252.

— Co-coded with Jale 🤖
