### PR TITLE
fix(agent): stop telling the model every datasource is SQL

### DIFF
--- a/services/agent/internal/discovery/datasources_prompt_language_test.go
+++ b/services/agent/internal/discovery/datasources_prompt_language_test.go
@@ -1,0 +1,50 @@
+package discovery
+
+import (
+	"os"
+	"testing"
+
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
+)
+
+// sqlOnlyContext is the all-SQL multi-datasource run: the shape every
+// multi-warehouse project has today. It exercises every field the routing
+// contract renders — label, description, card, per-datasource pack areas — so
+// the golden below covers the whole section rather than its opening.
+func sqlOnlyContext() *datasourceContext {
+	return &datasourceContext{descriptors: []datasourceDescriptor{
+		{
+			id: "default", label: "Sales PG", provider: "postgres", tableCount: 4,
+			description: "orders and invoices",
+			card: &models.WarehouseCard{
+				SubjectAreas: []string{"sales", "billing"},
+				KeyEntities:  []string{"invoice", "customer"},
+				KeyMetrics:   []string{"revenue", "arpu"},
+			},
+		},
+		{
+			id: "wh_oracle", label: "Catalog", provider: "oracle", tableCount: 7,
+			description: "music catalog",
+			prompts: &models.ProjectPrompts{AnalysisAreas: map[string]models.AnalysisAreaConfig{
+				"g": {Name: "Genre Performance", Enabled: true},
+			}},
+		},
+	}}
+}
+
+// TestBuildDatasourcesPromptSection_AllSQLIsUnchanged pins the text every
+// existing multi-warehouse project receives, byte for byte.
+//
+// The golden was captured from the tree before this file existed, so a diff
+// against it is a diff against what shipped. It is a fixture, not an output:
+// regenerating it to make a failure go away deletes the only evidence that a
+// run with no non-SQL datasource still reads exactly as it did.
+func TestBuildDatasourcesPromptSection_AllSQLIsUnchanged(t *testing.T) {
+	want, err := os.ReadFile("testdata/datasources_prompt_all_sql.golden")
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := buildDatasourcesPromptSection(sqlOnlyContext()); got != string(want) {
+		t.Errorf("all-SQL routing contract changed.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/services/agent/internal/discovery/datasources_prompt_language_test.go
+++ b/services/agent/internal/discovery/datasources_prompt_language_test.go
@@ -1,11 +1,53 @@
 package discovery
 
 import (
+	"errors"
 	"os"
+	"strings"
 	"testing"
 
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
 )
+
+// Providers registered only for these tests, so language resolution runs
+// against the real registry — the thing the running process reads.
+//
+// Registered from init() rather than from a test body: the registry is
+// process-global and panics on a duplicate slug, so a registration inside a
+// test passes once and takes the package down under `go test -count=2`.
+const (
+	testSQLSlug        = "discovery-lang-sql"
+	testCubeNamedSlug  = "discovery-lang-cube-named"
+	testNativeRowsSlug = "discovery-lang-native-rows"
+)
+
+func init() {
+	factory := func(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) {
+		return nil, errors.New("registered for its metadata only")
+	}
+	// An ordinary SQL warehouse: a display dialect and no language of its own.
+	gowarehouse.RegisterWithMeta(testSQLSlug, factory, gowarehouse.ProviderMeta{
+		Name: "Lang SQL", Dialect: "PostgreSQL",
+	})
+	// A cube that names its language outright, the way GA4 does.
+	gowarehouse.RegisterWithMeta(testCubeNamedSlug, factory, gowarehouse.ProviderMeta{
+		Name:    "Lang cube",
+		Dialect: "Report Request (JSON)",
+		Capability: gowarehouse.Capability{
+			QueryLanguage: "Report Request (JSON)",
+			Shape:         gowarehouse.ShapeCube,
+			CanAnchor:     gowarehouse.Anchoring(false),
+		},
+	})
+	// A source with TABLES and its own query language — a record system with
+	// an API instead of a SQL port. Shape says nothing is unusual about it;
+	// only the language does.
+	gowarehouse.RegisterWithMeta(testNativeRowsSlug, factory, gowarehouse.ProviderMeta{
+		Name:       "Lang native rows",
+		Capability: gowarehouse.Capability{QueryLanguage: "Object Query Language"},
+	})
+}
 
 // sqlOnlyContext is the all-SQL multi-datasource run: the shape every
 // multi-warehouse project has today. It exercises every field the routing
@@ -32,13 +74,29 @@ func sqlOnlyContext() *datasourceContext {
 	}}
 }
 
+// withDatasource returns dc plus one more descriptor, leaving dc alone.
+func withDatasource(dc *datasourceContext, d datasourceDescriptor) *datasourceContext {
+	out := &datasourceContext{descriptors: append([]datasourceDescriptor{}, dc.descriptors...)}
+	out.descriptors = append(out.descriptors, d)
+	return out
+}
+
+// cubeDescriptor is a connected cube as buildDatasourceContext produces one:
+// indexed via its catalog, and therefore carrying no tables.
+func cubeDescriptor() datasourceDescriptor {
+	return datasourceDescriptor{
+		id: "wh_analytics", label: "Web Analytics", provider: testCubeNamedSlug,
+		description: "site traffic", tableCount: 0,
+	}
+}
+
 // TestBuildDatasourcesPromptSection_AllSQLIsUnchanged pins the text every
 // existing multi-warehouse project receives, byte for byte.
 //
-// The golden was captured from the tree before this file existed, so a diff
-// against it is a diff against what shipped. It is a fixture, not an output:
-// regenerating it to make a failure go away deletes the only evidence that a
-// run with no non-SQL datasource still reads exactly as it did.
+// The golden was captured from the tree before the language split existed, so
+// a diff against it is a diff against what shipped. It is a fixture, not an
+// output: regenerating it to make a failure go away deletes the only evidence
+// that a run with no non-SQL datasource still reads exactly as it did.
 func TestBuildDatasourcesPromptSection_AllSQLIsUnchanged(t *testing.T) {
 	want, err := os.ReadFile("testdata/datasources_prompt_all_sql.golden")
 	if err != nil {
@@ -46,5 +104,170 @@ func TestBuildDatasourcesPromptSection_AllSQLIsUnchanged(t *testing.T) {
 	}
 	if got := buildDatasourcesPromptSection(sqlOnlyContext()); got != string(want) {
 		t.Errorf("all-SQL routing contract changed.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestBuildDatasourcesPromptSection_OneNonSQLDatasourceRewritesTheContract is
+// the switch: connecting a source that does not speak SQL is what changes the
+// text, and nothing else does.
+func TestBuildDatasourcesPromptSection_OneNonSQLDatasourceRewritesTheContract(t *testing.T) {
+	sql := buildDatasourcesPromptSection(sqlOnlyContext())
+	if !strings.Contains(sql, "This project has multiple SQL datasources.") {
+		t.Fatalf("all-SQL run lost its opening:\n%s", sql)
+	}
+
+	mixed := buildDatasourcesPromptSection(withDatasource(sqlOnlyContext(), cubeDescriptor()))
+	if strings.Contains(mixed, "multiple SQL datasources") {
+		t.Errorf("a run carrying a non-SQL datasource still calls them all SQL:\n%s", mixed)
+	}
+	if strings.Contains(mixed, "Each SQL statement runs against") {
+		t.Errorf("a run carrying a non-SQL datasource still routes by SQL statement:\n%s", mixed)
+	}
+	if !strings.Contains(mixed, "NOT all queried in the same language") {
+		t.Errorf("mixed opening missing:\n%s", mixed)
+	}
+}
+
+// TestBuildDatasourcesPromptSection_MixedNamesEveryLanguage checks the promise
+// the mixed opening makes. "One of these is different" is not actionable — the
+// model has to be able to tell which language goes with which datasource_id,
+// so every datasource is named, the SQL ones included.
+func TestBuildDatasourcesPromptSection_MixedNamesEveryLanguage(t *testing.T) {
+	dc := &datasourceContext{descriptors: []datasourceDescriptor{
+		{id: "default", provider: testSQLSlug, tableCount: 4},
+		cubeDescriptor(),
+	}}
+	got := buildDatasourcesPromptSection(dc)
+
+	if !strings.Contains(got, "Query language: PostgreSQL\n") {
+		t.Errorf("the SQL datasource's language is not named:\n%s", got)
+	}
+	if !strings.Contains(got, "Query language: Report Request (JSON) — not SQL, which this datasource rejects\n") {
+		t.Errorf("the cube's language is not named, or does not rule SQL out:\n%s", got)
+	}
+	if n := strings.Count(got, "Query language:"); n != 2 {
+		t.Errorf("expected one language line per datasource, got %d:\n%s", n, got)
+	}
+}
+
+// TestBuildDatasourcesPromptSection_ACubeDoesNotReportZeroTables covers the
+// descriptor line for a source with nothing to count. "0 tables" is true and
+// useless: it reads as an empty or broken warehouse, and it invites the one
+// action that cannot work against this source.
+func TestBuildDatasourcesPromptSection_ACubeDoesNotReportZeroTables(t *testing.T) {
+	got := buildDatasourcesPromptSection(withDatasource(sqlOnlyContext(), cubeDescriptor()))
+
+	if strings.Contains(got, "0 tables") {
+		t.Errorf("a source with no tables is reported as having zero of them:\n%s", got)
+	}
+	if !strings.Contains(got, "NO TABLES") {
+		t.Errorf("the absence of tables is not stated:\n%s", got)
+	}
+	if !strings.Contains(got, "`lookup_schema` does not apply to it") {
+		t.Errorf("lookup_schema is not ruled out for the cube:\n%s", got)
+	}
+	// The SQL datasources keep their counts — the line is per datasource, not
+	// per run.
+	if !strings.Contains(got, "postgres, 4 tables") || !strings.Contains(got, "oracle, 7 tables") {
+		t.Errorf("a SQL datasource lost its table count:\n%s", got)
+	}
+}
+
+// TestBuildDatasourcesPromptSection_ACubeCarryingTablesKeepsTheOrdinaryLine
+// guards the claim rather than the shape. "NO TABLES" is a statement about
+// this run, so it is read off this run: if a cube-shaped source somehow
+// arrives with tables, the model can see them and the prompt must not deny
+// they exist.
+func TestBuildDatasourcesPromptSection_ACubeCarryingTablesKeepsTheOrdinaryLine(t *testing.T) {
+	d := cubeDescriptor()
+	d.tableCount = 3
+	got := buildDatasourcesPromptSection(withDatasource(sqlOnlyContext(), d))
+
+	if strings.Contains(got, "NO TABLES") {
+		t.Errorf("tables the run found are denied:\n%s", got)
+	}
+	if !strings.Contains(got, "3 tables") {
+		t.Errorf("the table count is missing:\n%s", got)
+	}
+	// It is still not SQL, whatever it is carrying.
+	if !strings.Contains(got, "not SQL, which this datasource rejects") {
+		t.Errorf("the language is no longer ruled out:\n%s", got)
+	}
+}
+
+// TestBuildDatasourcesPromptSection_TheHopRuleSurvivesTwoLanguages covers the
+// second half of the contract. The hop is taught by example, and the example
+// is SQL on both sides; on a mixed run the rule has to be stated in terms of
+// the values passed between steps, or it teaches `WHERE ... IN` as the only
+// way to receive them.
+func TestBuildDatasourcesPromptSection_TheHopRuleSurvivesTwoLanguages(t *testing.T) {
+	got := buildDatasourcesPromptSection(withDatasource(sqlOnlyContext(), cubeDescriptor()))
+
+	if !strings.Contains(got, "written in B's OWN query language") {
+		t.Errorf("step 2 does not say which language its filter is written in:\n%s", got)
+	}
+	if !strings.Contains(got, "hops between two SQL datasources") {
+		t.Errorf("the worked example is not labelled as SQL-to-SQL:\n%s", got)
+	}
+	// The rule itself is unchanged, and must be.
+	for _, want := range []string{"NO cross-datasource join", "bounded value-passing", "BOUNDED set of key values"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("mixed contract lost %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestRunHasNonSQLDatasource_ReadsTheLanguageNotTheShape is why the split is
+// on the query language. A record system with tables and its own query API is
+// entity-shaped — shape says nothing is unusual about it — and telling the
+// model it is SQL is just as wrong there as it is for a cube.
+func TestRunHasNonSQLDatasource_ReadsTheLanguageNotTheShape(t *testing.T) {
+	cases := map[string]struct {
+		providers []string
+		want      bool
+	}{
+		"all SQL":                    {[]string{testSQLSlug, testSQLSlug}, false},
+		"unregistered slugs are SQL": {[]string{"postgres", "oracle"}, false},
+		"a cube":                     {[]string{testSQLSlug, testCubeNamedSlug}, true},
+		"a bare cube, no language":   {[]string{testSQLSlug, testCubeSlug}, true},
+		"tables, but not SQL":        {[]string{testSQLSlug, testNativeRowsSlug}, true},
+	}
+	for name, tc := range cases {
+		dc := &datasourceContext{}
+		for i, p := range tc.providers {
+			dc.descriptors = append(dc.descriptors, datasourceDescriptor{id: string(rune('a' + i)), provider: p})
+		}
+		if got := runHasNonSQLDatasource(dc); got != tc.want {
+			t.Errorf("%s: runHasNonSQLDatasource = %v, want %v", name, got, tc.want)
+		}
+	}
+}
+
+// TestDatasourceQueryLanguage covers the name each datasource is given, and
+// the one answer that must never come back: a source that declared it is not
+// SQL being labelled SQL because it declared it the other way.
+func TestDatasourceQueryLanguage(t *testing.T) {
+	cases := map[string]struct {
+		slug string
+		want string
+	}{
+		"a SQL warehouse gets its dialect": {testSQLSlug, "PostgreSQL"},
+		"an unregistered slug is SQL":      {"not-registered-anywhere", "SQL"},
+		"a cube that names its language":   {testCubeNamedSlug, "Report Request (JSON) — not SQL, which this datasource rejects"},
+		"a source with tables but not SQL": {testNativeRowsSlug, "Object Query Language — not SQL, which this datasource rejects"},
+	}
+	for name, tc := range cases {
+		if got := datasourceQueryLanguage(tc.slug); got != tc.want {
+			t.Errorf("%s: datasourceQueryLanguage(%q) = %q, want %q", name, tc.slug, got, tc.want)
+		}
+	}
+
+	// A cube that names its language NOWHERE — no QueryLanguage, no display
+	// dialect. ProviderMeta.Language() answers "SQL" for it, which is the one
+	// answer this line exists to prevent; the shape has already said there is
+	// no SQL to write.
+	got := datasourceQueryLanguage(testCubeSlug)
+	if got == "SQL" || !strings.Contains(got, "not SQL") {
+		t.Errorf("a cube declaring no language was labelled %q", got)
 	}
 }

--- a/services/agent/internal/discovery/datasources_prompt_language_test.go
+++ b/services/agent/internal/discovery/datasources_prompt_language_test.go
@@ -126,6 +126,38 @@ func TestBuildDatasourcesPromptSection_OneNonSQLDatasourceRewritesTheContract(t 
 	if !strings.Contains(mixed, "NOT all queried in the same language") {
 		t.Errorf("mixed opening missing:\n%s", mixed)
 	}
+	// The contract itself has to scope lookup_schema, not only the cube's own
+	// line further down. The opening is where the model learns which actions
+	// take a datasource_id, and it named lookup_schema as one of them.
+	if !strings.Contains(mixed, "`lookup_schema` applies only to a datasource that has tables") {
+		t.Errorf("the mixed contract does not scope lookup_schema to the datasources that have tables:\n%s", mixed)
+	}
+}
+
+// TestBuildDatasourcesPromptSection_ATableSourceWithNoTablesIsNotCalledACube
+// covers the other reason a descriptor can report zero tables.
+//
+// A datasource is admitted to a run when it has tables OR a catalog, so a
+// table-shaped source whose cached schemas came back empty reaches the prompt
+// with a count of zero. Reading the count alone would describe a warehouse as
+// a metric/dimension cube and tell the model not to look up its schema — a
+// false statement about the source, in the half of the section it routes by.
+func TestBuildDatasourcesPromptSection_ATableSourceWithNoTablesIsNotCalledACube(t *testing.T) {
+	dc := &datasourceContext{descriptors: []datasourceDescriptor{
+		{id: "default", label: "Empty PG", provider: testSQLSlug, tableCount: 0},
+		cubeDescriptor(),
+	}}
+	got := buildDatasourcesPromptSection(dc)
+
+	if strings.Count(got, "NO TABLES") != 1 {
+		t.Errorf("expected only the cube to be described as having no tables:\n%s", got)
+	}
+	if !strings.Contains(got, "**`default`** (Empty PG) — "+testSQLSlug+", 0 tables\n") {
+		t.Errorf("a table-shaped datasource lost its ordinary line:\n%s", got)
+	}
+	if !strings.Contains(got, "Query language: PostgreSQL\n") {
+		t.Errorf("the table-shaped datasource is no longer named as SQL:\n%s", got)
+	}
 }
 
 // TestBuildDatasourcesPromptSection_MixedNamesEveryLanguage checks the promise

--- a/services/agent/internal/discovery/datasources_prompt_language_test.go
+++ b/services/agent/internal/discovery/datasources_prompt_language_test.go
@@ -160,6 +160,31 @@ func TestBuildDatasourcesPromptSection_ATableSourceWithNoTablesIsNotCalledACube(
 	}
 }
 
+// TestBuildDatasourcesPromptSection_ClaimsPrecedenceOverTheExamplesAboveIt
+// covers the contradiction this section inherits rather than creates.
+//
+// What precedes it is the project's own exploration prompt — its primary
+// datasource's domain pack — which teaches one action contract with worked
+// examples in one language. On a mixed run the model reads that, then reads a
+// list of datasources that do not all speak it. Naming which one wins is the
+// only part of that this section can honestly settle from where it sits, so
+// it has to actually say so.
+func TestBuildDatasourcesPromptSection_ClaimsPrecedenceOverTheExamplesAboveIt(t *testing.T) {
+	mixed := buildDatasourcesPromptSection(withDatasource(sqlOnlyContext(), cubeDescriptor()))
+	if !strings.Contains(mixed, "THIS section wins") {
+		t.Errorf("the mixed contract does not claim precedence over the examples above it:\n%s", mixed)
+	}
+	if !strings.Contains(mixed, "the `query` field carries whatever that datasource accepts") {
+		t.Errorf("the mixed contract does not say what changes and what does not:\n%s", mixed)
+	}
+	// Stated as precedence, not as "SQL loses". The project's pack is written
+	// for whichever language its primary speaks, and this sentence has to stay
+	// true if that ever stops being SQL.
+	if strings.Contains(mixed, "earlier in this prompt are SQL") {
+		t.Errorf("precedence is stated in terms of SQL rather than of language:\n%s", mixed)
+	}
+}
+
 // TestBuildDatasourcesPromptSection_MixedNamesEveryLanguage checks the promise
 // the mixed opening makes. "One of these is different" is not actionable — the
 // model has to be able to tell which language goes with which datasource_id,

--- a/services/agent/internal/discovery/orchestrator_multiwarehouse.go
+++ b/services/agent/internal/discovery/orchestrator_multiwarehouse.go
@@ -1,10 +1,10 @@
 package discovery
 
 // Multi-warehouse (multi-hop) discovery support. A project can attach
-// several SQL datasources; the exploration agent sees every datasource's
-// catalog, targets one datasource per statement via `datasource_id`, and
-// hops between them across steps (bounded value-passing — never a
-// cross-engine join). This file builds the per-datasource execution
+// several datasources — not necessarily all queried in the same language;
+// the exploration agent sees every datasource's catalog, targets one
+// datasource per query via `datasource_id`, and hops between them across
+// steps (bounded value-passing — never a cross-engine join). This file builds the per-datasource execution
 // context the orchestrator hands the exploration engine; the single-
 // warehouse path in orchestrator.go is unchanged and taken whenever a run
 // has one datasource. Design: docs/design/multi-warehouse.md §5.5, §5.9.
@@ -220,19 +220,24 @@ func (o *Orchestrator) buildGroupedCatalog(dc *datasourceContext, keywords []str
 // across datasources between steps, never join across them, plus each
 // datasource's routing card + its own domain-pack focus areas so the agent
 // applies the right playbook when it explores that datasource.
+//
+// The contract comes in two forms. A run whose datasources are all SQL gets
+// the text it has always had, unchanged. A run carrying a datasource that is
+// not queried in SQL gets one that names each datasource's language instead
+// of assuming a single one — see runHasNonSQLDatasource for why the split is
+// on the language rather than on the shape.
 func buildDatasourcesPromptSection(dc *datasourceContext) string {
+	mixed := runHasNonSQLDatasource(dc)
 	var b strings.Builder
 	b.WriteString("\n\n## Datasources (multi-warehouse)\n\n")
-	b.WriteString("This project has multiple SQL datasources. Each SQL statement runs against exactly ONE datasource: set `datasource_id` on every `query_data` and `lookup_schema` action to the datasource that owns the tables you use (omitting it targets the primary). `search_tables` spans ALL datasources and tags each result with its `datasource`.\n")
-	b.WriteString("\nA single `query_data` statement may reference ONLY tables that live in its `datasource_id`. There is NO cross-engine federation and NO cross-datasource join. To correlate data across datasources, HOP across steps with bounded value-passing:\n")
-	b.WriteString("  1. Query datasource A for a BOUNDED set of key values (top-N ids / keys / an aggregate).\n")
-	b.WriteString("  2. In the next step, query datasource B with those values inlined as literal filters (e.g. `WHERE id IN (1,2,3)`).\n")
-	b.WriteString("  WRONG (fails — invoice_line is not in the Oracle datasource):\n")
-	b.WriteString("    {\"datasource_id\":\"wh_oracle\",\"query\":\"SELECT g.name, SUM(il.unit_price) FROM CHINOOK.TRACK t JOIN public.invoice_line il ON ... JOIN CHINOOK.GENRE g ...\"}\n")
-	b.WriteString("  RIGHT (two steps): step 1 `{\"datasource_id\":\"default\",\"query\":\"SELECT track_id, SUM(unit_price*quantity) AS rev FROM public.invoice_line GROUP BY track_id ORDER BY rev DESC LIMIT 20\"}`; step 2 `{\"datasource_id\":\"wh_oracle\",\"query\":\"SELECT t.track_id, g.name FROM CHINOOK.TRACK t JOIN CHINOOK.GENRE g ON t.genre_id=g.genre_id WHERE t.track_id IN (<the 20 ids from step 1>)\"}`.\n")
+	if mixed {
+		writeMixedLanguageRouting(&b)
+	} else {
+		writeSQLRouting(&b)
+	}
 	b.WriteString("\nAvailable datasources:\n")
 	for _, d := range dc.descriptors {
-		fmt.Fprintf(&b, "\n- **`%s`**%s — %s, %d tables\n", d.id, labelSuffix(d.label), d.provider, d.tableCount)
+		writeDatasourceHeadline(&b, d, mixed)
 		if d.description != "" {
 			fmt.Fprintf(&b, "  - %s\n", d.description)
 		}
@@ -252,6 +257,120 @@ func buildDatasourcesPromptSection(dc *datasourceContext) string {
 		}
 	}
 	return b.String()
+}
+
+// runHasNonSQLDatasource reports whether any datasource on this run is queried
+// in something other than SQL — i.e. whether a blanket "these are all SQL
+// datasources" is still a true thing to tell the model.
+//
+// The split is on the LANGUAGE, not on the shape, because that is the
+// statement being made: "these are all SQL datasources" is false the moment
+// one of them accepts something else, whether or not it has tables. Shape and
+// language are separate declarations and a source may differ in either — a
+// record-shaped source with its own query API has tables and no SQL, and
+// reading its shape would call it SQL.
+//
+// The answer comes from the registry rather than from a live provider,
+// because a provider reaches this run through middleware and a wrapper that
+// does not re-expose the query seam erases the declaration. A registration
+// cannot be wrapped.
+func runHasNonSQLDatasource(dc *datasourceContext) bool {
+	for _, d := range dc.descriptors {
+		if gowarehouse.NonSQLLanguageOf(d.provider) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// datasourceQueryLanguage renders the language line's value for one
+// datasource: the name of the language its queries are written in, and, when
+// that is not SQL, the fact that SQL will be rejected.
+//
+// NonSQLLanguageOf answers first because ProviderMeta.Language() falls back to
+// "SQL" for a source that declares a shape and no language — which is exactly
+// the source this section exists to stop mislabelling. An unregistered slug
+// resolves to SQL: what every provider was before the descriptor existed.
+func datasourceQueryLanguage(slug string) string {
+	if lang := gowarehouse.NonSQLLanguageOf(slug); lang != "" {
+		return lang + " — not SQL, which this datasource rejects"
+	}
+	if meta, ok := gowarehouse.GetProviderMeta(slug); ok {
+		return meta.Language()
+	}
+	return "SQL"
+}
+
+// writeSQLRouting states the routing contract for a run whose datasources are
+// all SQL — every multi-warehouse project that exists today. The text is
+// unchanged and must stay that way: it is true for these runs, and a golden
+// test holds it to the byte.
+func writeSQLRouting(b *strings.Builder) {
+	b.WriteString("This project has multiple SQL datasources. Each SQL statement runs against exactly ONE datasource: set `datasource_id` on every `query_data` and `lookup_schema` action to the datasource that owns the tables you use (omitting it targets the primary). `search_tables` spans ALL datasources and tags each result with its `datasource`.\n")
+	b.WriteString("\nA single `query_data` statement may reference ONLY tables that live in its `datasource_id`. There is NO cross-engine federation and NO cross-datasource join. To correlate data across datasources, HOP across steps with bounded value-passing:\n")
+	b.WriteString("  1. Query datasource A for a BOUNDED set of key values (top-N ids / keys / an aggregate).\n")
+	b.WriteString("  2. In the next step, query datasource B with those values inlined as literal filters (e.g. `WHERE id IN (1,2,3)`).\n")
+	writeHopExample(b)
+}
+
+// writeMixedLanguageRouting states the same contract for a run carrying a
+// datasource that is not queried in SQL.
+//
+// Three things change, and only these three. The opening no longer calls
+// every datasource SQL. `lookup_schema` is scoped to the datasources that
+// have tables, because a metric name is close enough to a table name that
+// looking one up is the natural next move and it fails every time. And the
+// hop's second step is stated as a filter written in the target's own
+// language rather than as a `WHERE ... IN` clause.
+//
+// The worked example stays SQL-to-SQL, and says so. Every non-SQL source
+// today is one that cannot anchor, so it is never a project's only datasource
+// and such a run always has a SQL side for the example to be live for. It is
+// labelled rather than assumed because that is what keeps it honest if that
+// stops being true: an example marked SQL-to-SQL, next to a rule stated in
+// terms of each datasource's own language, teaches the rule either way.
+// Writing a second example in some specific non-SQL request format would
+// teach a syntax this package has no provider for and no way to keep true.
+func writeMixedLanguageRouting(b *strings.Builder) {
+	b.WriteString("This project has multiple datasources and they are NOT all queried in the same language — each one's language is named below, and a query written in the wrong one is rejected. Each query runs against exactly ONE datasource: set `datasource_id` on every `query_data` and `lookup_schema` action to the datasource you mean (omitting it targets the primary). `lookup_schema` applies only to a datasource that has tables. `search_tables` spans ALL datasources and tags each result with its `datasource`.\n")
+	b.WriteString("\nA single `query_data` request may reference ONLY what lives in its `datasource_id`. There is NO cross-engine federation and NO cross-datasource join. To correlate data across datasources, HOP across steps with bounded value-passing:\n")
+	b.WriteString("  1. Query datasource A for a BOUNDED set of key values (top-N ids / keys / an aggregate).\n")
+	b.WriteString("  2. In the next step, query datasource B for those values, inlined as literal filters written in B's OWN query language — `WHERE id IN (1,2,3)` where that language is SQL, the equivalent restriction in its own request format where it is not.\n")
+	b.WriteString("  (The worked example below hops between two SQL datasources. The rule is the same whatever the two languages are; only the filter's syntax changes.)\n")
+	writeHopExample(b)
+}
+
+// writeHopExample shows the hop as one wrong statement and the right two
+// steps. Shared by both contracts so they cannot drift apart on the part
+// neither of them disputes.
+func writeHopExample(b *strings.Builder) {
+	b.WriteString("  WRONG (fails — invoice_line is not in the Oracle datasource):\n")
+	b.WriteString("    {\"datasource_id\":\"wh_oracle\",\"query\":\"SELECT g.name, SUM(il.unit_price) FROM CHINOOK.TRACK t JOIN public.invoice_line il ON ... JOIN CHINOOK.GENRE g ...\"}\n")
+	b.WriteString("  RIGHT (two steps): step 1 `{\"datasource_id\":\"default\",\"query\":\"SELECT track_id, SUM(unit_price*quantity) AS rev FROM public.invoice_line GROUP BY track_id ORDER BY rev DESC LIMIT 20\"}`; step 2 `{\"datasource_id\":\"wh_oracle\",\"query\":\"SELECT t.track_id, g.name FROM CHINOOK.TRACK t JOIN CHINOOK.GENRE g ON t.genre_id=g.genre_id WHERE t.track_id IN (<the 20 ids from step 1>)\"}`.\n")
+}
+
+// writeDatasourceHeadline renders one datasource's opening line.
+//
+// On an all-SQL run this is the line it has always been: id, label, provider,
+// table count. On a mixed run every datasource also names the language its
+// queries are written in — including the SQL ones, since "the other one is
+// different" is not something a model can act on — and a datasource that has
+// no tables says so rather than reporting "0 tables", a count that reads as
+// an empty or broken warehouse when the truth is that it has none to count.
+//
+// The no-tables line is read off the run as well as the registry: a cube that
+// somehow arrived carrying tables gets the ordinary line, because whatever
+// its shape says, the model can see them.
+func writeDatasourceHeadline(b *strings.Builder, d datasourceDescriptor, named bool) {
+	if named && d.tableCount == 0 && providerIsCube(d.provider) {
+		fmt.Fprintf(b, "\n- **`%s`**%s — %s, NO TABLES: a metric/dimension cube. `lookup_schema` does not apply to it; `search_tables` lists its metrics and dimensions.\n",
+			d.id, labelSuffix(d.label), d.provider)
+	} else {
+		fmt.Fprintf(b, "\n- **`%s`**%s — %s, %d tables\n", d.id, labelSuffix(d.label), d.provider, d.tableCount)
+	}
+	if named {
+		fmt.Fprintf(b, "  - Query language: %s\n", datasourceQueryLanguage(d.provider))
+	}
 }
 
 // datasourceFocusAreas lists the enabled analysis-area names from a

--- a/services/agent/internal/discovery/orchestrator_multiwarehouse.go
+++ b/services/agent/internal/discovery/orchestrator_multiwarehouse.go
@@ -216,8 +216,8 @@ func (o *Orchestrator) buildGroupedCatalog(dc *datasourceContext, keywords []str
 }
 
 // buildDatasourcesPromptSection renders the routing contract the model
-// follows on a multi-warehouse run: one datasource per statement, hop
-// across datasources between steps, never join across them, plus each
+// follows on a multi-warehouse run: one datasource per query, hop across
+// datasources between steps, never join across them, plus each
 // datasource's routing card + its own domain-pack focus areas so the agent
 // applies the right playbook when it explores that datasource.
 //

--- a/services/agent/internal/discovery/orchestrator_multiwarehouse.go
+++ b/services/agent/internal/discovery/orchestrator_multiwarehouse.go
@@ -316,12 +316,28 @@ func writeSQLRouting(b *strings.Builder) {
 // writeMixedLanguageRouting states the same contract for a run carrying a
 // datasource that is not queried in SQL.
 //
-// Three things change, and only these three. The opening no longer calls
-// every datasource SQL. `lookup_schema` is scoped to the datasources that
-// have tables, because a metric name is close enough to a table name that
-// looking one up is the natural next move and it fails every time. And the
-// hop's second step is stated as a filter written in the target's own
-// language rather than as a `WHERE ... IN` clause.
+// Four things change, and only these four. The opening no longer calls every
+// datasource SQL. `lookup_schema` is scoped to the datasources that have
+// tables, because a metric name is close enough to a table name that looking
+// one up is the natural next move and it fails every time. The hop's second
+// step is stated as a filter written in the target's own language rather than
+// as a `WHERE ... IN` clause. And the section claims precedence over the
+// query examples above it.
+//
+// That last one is the smallest fix to a contradiction this section does not
+// own. What precedes it is the PROJECT's exploration prompt — its primary
+// datasource's domain pack, since a source that cannot anchor is never the
+// primary — and that pack teaches one action contract, with worked examples,
+// for whatever language it was written for. A non-primary datasource's own
+// pack contributes only its analysis-area names to a run; its prompts are
+// never rendered. So on a mixed run the model reads a full action contract in
+// one language and then a list of datasources that do not all speak it.
+//
+// Stating which one wins is what this section can honestly do from where it
+// sits, and it is stated in terms of precedence rather than of SQL so it stays
+// true whichever language the project's pack was written in. Rewriting or
+// suppressing that pack's action contract per datasource is a larger change
+// to how a run assembles its prompt, and it is tracked separately.
 //
 // The worked example stays SQL-to-SQL, and says so. Every non-SQL source
 // today is one that cannot anchor, so it is never a project's only datasource
@@ -333,6 +349,7 @@ func writeSQLRouting(b *strings.Builder) {
 // teach a syntax this package has no provider for and no way to keep true.
 func writeMixedLanguageRouting(b *strings.Builder) {
 	b.WriteString("This project has multiple datasources and they are NOT all queried in the same language — each one's language is named below, and a query written in the wrong one is rejected. Each query runs against exactly ONE datasource: set `datasource_id` on every `query_data` and `lookup_schema` action to the datasource you mean (omitting it targets the primary). `lookup_schema` applies only to a datasource that has tables. `search_tables` spans ALL datasources and tags each result with its `datasource`.\n")
+	b.WriteString("Where the query examples earlier in this prompt disagree with a datasource's language named here, THIS section wins: the action and its `datasource_id` are unchanged, but the `query` field carries whatever that datasource accepts.\n")
 	b.WriteString("\nA single `query_data` request may reference ONLY what lives in its `datasource_id`. There is NO cross-engine federation and NO cross-datasource join. To correlate data across datasources, HOP across steps with bounded value-passing:\n")
 	b.WriteString("  1. Query datasource A for a BOUNDED set of key values (top-N ids / keys / an aggregate).\n")
 	b.WriteString("  2. In the next step, query datasource B for those values, inlined as literal filters written in B's OWN query language — `WHERE id IN (1,2,3)` where that language is SQL, the equivalent restriction in its own request format where it is not.\n")

--- a/services/agent/internal/discovery/testdata/datasources_prompt_all_sql.golden
+++ b/services/agent/internal/discovery/testdata/datasources_prompt_all_sql.golden
@@ -1,0 +1,24 @@
+
+
+## Datasources (multi-warehouse)
+
+This project has multiple SQL datasources. Each SQL statement runs against exactly ONE datasource: set `datasource_id` on every `query_data` and `lookup_schema` action to the datasource that owns the tables you use (omitting it targets the primary). `search_tables` spans ALL datasources and tags each result with its `datasource`.
+
+A single `query_data` statement may reference ONLY tables that live in its `datasource_id`. There is NO cross-engine federation and NO cross-datasource join. To correlate data across datasources, HOP across steps with bounded value-passing:
+  1. Query datasource A for a BOUNDED set of key values (top-N ids / keys / an aggregate).
+  2. In the next step, query datasource B with those values inlined as literal filters (e.g. `WHERE id IN (1,2,3)`).
+  WRONG (fails — invoice_line is not in the Oracle datasource):
+    {"datasource_id":"wh_oracle","query":"SELECT g.name, SUM(il.unit_price) FROM CHINOOK.TRACK t JOIN public.invoice_line il ON ... JOIN CHINOOK.GENRE g ..."}
+  RIGHT (two steps): step 1 `{"datasource_id":"default","query":"SELECT track_id, SUM(unit_price*quantity) AS rev FROM public.invoice_line GROUP BY track_id ORDER BY rev DESC LIMIT 20"}`; step 2 `{"datasource_id":"wh_oracle","query":"SELECT t.track_id, g.name FROM CHINOOK.TRACK t JOIN CHINOOK.GENRE g ON t.genre_id=g.genre_id WHERE t.track_id IN (<the 20 ids from step 1>)"}`.
+
+Available datasources:
+
+- **`default`** (Sales PG) — postgres, 4 tables
+  - orders and invoices
+  - Subject areas: sales, billing
+  - Key entities: invoice, customer
+  - Key metrics: revenue, arpu
+
+- **`wh_oracle`** (Catalog) — oracle, 7 tables
+  - music catalog
+  - Focus areas (this datasource's domain pack): Genre Performance


### PR DESCRIPTION
## What

The multi-datasource routing contract stops telling the model that every datasource on the run is SQL.

`buildDatasourcesPromptSection` opened with *"This project has multiple SQL datasources. Each SQL statement runs against exactly ONE datasource…"* and then taught the hop rule with two SQL statements — a cross-datasource `JOIN` as the wrong way, a `WHERE id IN (…)` two-step as the right way. A source with no SQL is **only ever** present on a multi-datasource run, since one that cannot anchor may not run discovery on its own, so this is precisely the text a model reads when such a source is connected. Told the thing it is about to query is SQL, it writes SQL: a rejected query, a step spent against a source metered per request, and a repair loop entered for a reason the run created itself.

## How

The contract is split on the **query language**, resolved from the registry by provider slug:

- **All-SQL run** — renders byte for byte as it did. That is every multi-warehouse project that exists today, and the sentence is true for them.
- **A run carrying a non-SQL datasource** — gets a contract that says "multiple datasources", names each datasource's language, scopes `lookup_schema` to the datasources that have tables, states the hop's second step as *a filter written in B's own query language* rather than as a `WHERE … IN` clause, and claims precedence over the query examples above it.

Per datasource, on a mixed run:

```
- **`default`** (Sales PG) — postgres, 4 tables
  - Query language: PostgreSQL
- **`wh_analytics`** (Web Analytics) — ga4, NO TABLES: a metric/dimension cube. `lookup_schema` does not apply to it; `search_tables` lists its metrics and dimensions.
  - Query language: GA4 Report Request (JSON) — not SQL, which this datasource rejects
```

Every datasource is named, SQL ones included — *"one of these is different"* is not something a model can act on. And a source with no tables says so rather than reporting `0 tables`, a count that reads as an empty or broken warehouse and invites the one action that cannot work against it.

Four decisions worth the reviewer's attention:

- **Split on the language, not the shape.** A record system with tables and its own query API is entity-shaped; shape says nothing unusual about it, and calling it SQL is just as wrong as it is for a cube. `NonSQLLanguageOf` is also the answer that survives middleware — a wrapper that does not re-expose the query seam erases a live provider's declaration, and a registration cannot be wrapped.
- **`ProviderMeta.Language()` is not consulted first.** It falls back to `"SQL"` for a source that declares a shape and no language — exactly the source this section exists to stop mislabelling.
- **The worked example stays SQL-to-SQL, and says so.** Writing a second one in some specific non-SQL request format would teach a syntax this package has no provider for and no way to keep true. The rule above it is stated in terms of the values passed between steps, so it holds either way.
- **The section claims precedence over what precedes it.** What precedes it is the *project's* exploration prompt — its primary datasource's domain pack — which teaches one action contract with worked examples in one language, and a non-primary datasource's own pack contributes only its analysis-area names to a run. So on a mixed run the model reads a full action contract in one language and then a list of datasources that do not all speak it. This section previously reinforced that framing; it now says which one wins and what actually differs (the action and its `datasource_id` are unchanged; only the `query` field's content does). Stated as precedence rather than as "SQL loses", so it stays true whichever language the project's pack was written in.

## Verification

- `go test ./...` in `services/agent` — green; `golangci-lint run ./internal/discovery/...` — 0 issues. CI green.
- **Byte-identity for every existing project is proven by the diff, not asserted.** The first commit captures the section as it rendered *before* any edit into `testdata/datasources_prompt_all_sql.golden`; no later commit touches that file. The golden is a fixture, not an output — there is no `-update` flag, because regenerating it is the one way to lose the evidence.
- **12 mutants, 12 killed.** A mutation pass over the new code left two survivors, both fixed by new tests in `257d4bc`: dropping the shape check from the no-tables line (a table-shaped datasource whose cached schemas came back empty would be described as a metric/dimension cube), and deleting the sentence that scopes `lookup_schema` (the cube's own line said it, so every test still passed while the contract paragraph no longer did). Both were gaps in the tests, not in the code.
- Tests cover: the switch itself (one non-SQL datasource rewrites the contract, nothing else does); every language named on a mixed run; a cube not reporting `0 tables`; a cube that *does* arrive carrying tables keeping the ordinary line, because the model can see them; a table-shaped source with zero tables not being called a cube; the hop rule surviving two languages; the precedence claim; and the language resolver, including a cube that declares its language nowhere — the case `ProviderMeta.Language()` answers `"SQL"` for.

## Not done here

**#391** — a mixed run still renders the primary's action contract, worked SQL examples and all, to every datasource. The precedence sentence above is the most a section appended at the end can honestly do; actually gating or rewriting that contract per datasource changes how a run assembles its prompt, has three viable designs and no obviously right one, and is filed rather than guessed at. Raised as a P2 in Codex round 2.

`ask_serve.go:254` resolves `capability.QueryLanguage = meta.Language()`, which has the same fallback this PR avoids: a cube declaring neither a query language nor a display dialect would reach the ask prompt as `"SQL"`, and `writeCubeCatalogLine` would render *"Query language: SQL (not SQL)"*. Not reachable with any provider that exists — GA4 declares both — and a different prompt on a different path.

The file header's `docs/design/multi-warehouse.md` reference points at a document that is not in this repo. Pre-existing, left alone. No public doc describes this prompt, so nothing under `docs/` went stale.

Closes #387

— Co-coded with Jale 🤖
