### PR TITLE
feat(dashboard): expose a warehouse provider's shape on ProviderMeta

### DIFF
--- a/ui/dashboard/src/lib/api.ts
+++ b/ui/dashboard/src/lib/api.ts
@@ -650,6 +650,18 @@ export interface ProviderMeta {
   description: string;
   /** Short SQL dialect label (warehouse providers only), e.g. "BigQuery Standard SQL", "T-SQL". */
   dialect?: string;
+  /**
+   * How a warehouse provider organises what can be queried: "entities" for
+   * tables of rows, "cube" for metrics broken down by dimensions. Absent
+   * means "entities" — what every provider was before the capability
+   * descriptor existed, so a provider that does not declare one keeps
+   * working unchanged.
+   *
+   * Read it rather than inferring the same fact from the config fields: a
+   * source with no tables has no dataset to name, but "declares no dataset
+   * field" is a proxy that is true today and need not stay true.
+   */
+  shape?: string;
   config_fields: ConfigField[];
   auth_methods?: AuthMethod[];
   models?: ModelInfo[];


### PR DESCRIPTION
## What

`ProviderMeta` gains `shape?: string`.

`GET /api/v1/providers/warehouse` has returned the capability descriptor's shape since the descriptor existed — `"shape": "cube"` for GA4, absent for every table-shaped provider. The TypeScript type never described it, so any consumer wanting the fact had to infer it from something else.

## Why now

The consumer is the enterprise Data Sources form, which refuses to submit without a dataset. A cube has no tables and so no dataset to name — it is selectable in the dropdown and then permanently unsavable, while the server stopped requiring one per shape via `warehouse.RequiresDataset`.

The form needs to read the same declaration the server reads. The nearest proxy available without this field is "does the provider declare a `dataset` config field", and that is already wrong: `redshift` declares its dataset field `required: false` while the server still requires one, so a rule keyed on it would stop asking and produce a 400 instead of a disabled button.

## Scope

Type-only, additive, optional. Nothing in this repo reads it yet and no behaviour changes here. The doc comment states the default explicitly — absent means `entities`, which is what every provider was before the descriptor existed, so a provider that never declares one keeps working.

Consumed by decisionbox-enterprise#286.

— Co-coded with Jale 🤖
