### PR TITLE
feat(warehouse): three-legged auth, a provider-keyed app registration, and a credential a datasource can name

### DIFF
--- a/libs/go-common/connectors/registry.go
+++ b/libs/go-common/connectors/registry.go
@@ -18,9 +18,21 @@ type Factory func(cfg Config) (Connector, error)
 // ProviderMeta describes a connector for UI rendering (the instance-admin
 // app-registration form).
 type ProviderMeta struct {
-	ID           string        `json:"id"`
-	Name         string        `json:"name"`
-	Description  string        `json:"description"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+
+	// OAuthProvider identifies whose app registration this connector
+	// authenticates with — "google", say. Declared rather than assumed from the
+	// connector kind, because the registration is shared: a deployment that has
+	// registered a Google client for one feature must not be asked to register
+	// a second one here. Empty for a connector that needs no OAuth app.
+	OAuthProvider string `json:"oauth_provider,omitempty"`
+
+	// ConfigFields are the connector's OWN instance-level fields — what it
+	// needs beyond the shared OAuth registration. The Google Picker's api_key
+	// and app_id are the example: Drive needs them, and a consumer of the same
+	// Google client that never opens a picker does not.
 	ConfigFields []ConfigField `json:"config_fields"`
 }
 

--- a/libs/go-common/oauthreg/oauthreg.go
+++ b/libs/go-common/oauthreg/oauthreg.go
@@ -1,0 +1,79 @@
+// Package oauthreg names the deployment's own OAuth app registration: the
+// client_id, client_secret and redirect_uri an operator registers once with a
+// provider, so that no DecisionBox-owned application ever holds a customer's
+// data grant.
+//
+// # Why this is not part of either registry
+//
+// Two unrelated registries have consumers that authenticate against the same
+// provider — a data source in the warehouse registry, an external-storage
+// connector in the connectors one. Both need the same three fields, and a
+// customer who has registered a Google client should not have to register a
+// second one because the feature that needs it lives in a different registry.
+//
+// So the registration is keyed by the OAuth provider ("google"), not by the
+// consumer, and the key scheme lives in a package neither registry owns. Which
+// provider a consumer belongs to is declared in its own registry metadata; this
+// package only knows how the resulting key is spelled.
+package oauthreg
+
+import "strings"
+
+// Registration fields. A three-legged flow needs exactly these three: who is
+// asking (client_id), proof it is really them (client_secret), and the origin
+// the authorization code was issued against (redirect_uri).
+const (
+	FieldClientID     = "client_id"
+	FieldClientSecret = "client_secret"
+	FieldRedirectURI  = "redirect_uri"
+)
+
+// Fields is the full registration, in the order a form should render it.
+var Fields = []string{FieldClientID, FieldClientSecret, FieldRedirectURI}
+
+// keyPrefix namespaces the app registration away from per-project credentials.
+// The registration is instance-scoped — one OAuth client per deployment per
+// provider, shared by every consumer and every project.
+const keyPrefix = "oauth-app"
+
+// Key returns the secret-provider key holding one field of a provider's
+// instance-scoped OAuth app registration — e.g. oauth-app-google-client-id.
+//
+// Lowercase alphanumerics and hyphens only. Cloud secret backends compose their
+// provider-side secret name straight from this key and restrict that name's
+// charset: GCP allows [A-Za-z0-9_-], Azure Key Vault only [A-Za-z0-9-]. Azure is
+// the strictest, so its alphabet is the one used here.
+//
+// The substitution is lossy — two ids differing only in their separators produce
+// the same key. That is safe here and would not be for arbitrary input: both
+// arguments come from a closed set of compile-time constants (this package's
+// three fields, and the provider ids declared in registry metadata), so a
+// collision is a thing a reviewer can see rather than a thing a customer can
+// cause.
+func Key(provider, field string) string {
+	return keyPrefix + "-" + safe(provider) + "-" + safe(field)
+}
+
+// ConfigKey returns the provider-config key an app-registration field is passed
+// to a factory under.
+//
+// It is namespaced away from a provider's own config fields deliberately:
+// "client_id" is a plausible name for something a provider asks the operator
+// for, and a collision would silently overwrite one with the other.
+func ConfigKey(field string) string {
+	return "oauth_app_" + field
+}
+
+// safe maps a key fragment onto [a-z0-9-].
+func safe(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('-')
+	}
+	return b.String()
+}

--- a/libs/go-common/oauthreg/oauthreg.go
+++ b/libs/go-common/oauthreg/oauthreg.go
@@ -31,6 +31,16 @@ const (
 // Fields is the full registration, in the order a form should render it.
 var Fields = []string{FieldClientID, FieldClientSecret, FieldRedirectURI}
 
+// ProviderGoogle is the OAuth provider behind every Google API a consumer here
+// authenticates against.
+//
+// It is a constant rather than a literal in each registry entry because the
+// whole point of the shared registration is that these consumers name the SAME
+// provider: a typo in one of them would silently split one registration into
+// two, and the symptom would be a customer who registered their client watching
+// half their features report themselves unconfigured.
+const ProviderGoogle = "google"
+
 // keyPrefix namespaces the app registration away from per-project credentials.
 // The registration is instance-scoped — one OAuth client per deployment per
 // provider, shared by every consumer and every project.

--- a/libs/go-common/oauthreg/oauthreg_test.go
+++ b/libs/go-common/oauthreg/oauthreg_test.go
@@ -1,0 +1,71 @@
+package oauthreg
+
+import "testing"
+
+func TestKey_IsReadableAndSecretStoreSafe(t *testing.T) {
+	for _, tc := range []struct{ provider, field, want string }{
+		{"google", FieldClientID, "oauth-app-google-client-id"},
+		{"google", FieldClientSecret, "oauth-app-google-client-secret"},
+		{"google", FieldRedirectURI, "oauth-app-google-redirect-uri"},
+	} {
+		if got := Key(tc.provider, tc.field); got != tc.want {
+			t.Errorf("Key(%q, %q) = %q, want %q", tc.provider, tc.field, got, tc.want)
+		}
+	}
+}
+
+// Azure Key Vault is the strictest backend in play and accepts only
+// [A-Za-z0-9-]. A key it rejects fails to store at all, so this is the
+// constraint the substitution exists for.
+func TestKey_StaysInTheStrictestAlphabet(t *testing.T) {
+	for _, provider := range []string{"google", "sales_force", "Weird.Provider", "a b"} {
+		for _, field := range Fields {
+			key := Key(provider, field)
+			for _, r := range key {
+				if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+					continue
+				}
+				t.Fatalf("Key(%q, %q) = %q contains %q, which Azure Key Vault rejects", provider, field, key, r)
+			}
+		}
+	}
+}
+
+// Two providers must not share a key, or one deployment's registration would
+// silently overwrite the other's.
+func TestKey_DistinctProvidersDoNotCollide(t *testing.T) {
+	seen := map[string]string{}
+	for _, provider := range []string{"google", "salesforce", "hubspot"} {
+		key := Key(provider, FieldClientSecret)
+		if other, dup := seen[key]; dup {
+			t.Fatalf("providers %q and %q share the key %q", other, provider, key)
+		}
+		seen[key] = provider
+	}
+}
+
+// The config namespace is what lets applyOAuthAppRegistration clear everything
+// it owns by prefix without touching a provider's own fields.
+func TestConfigKey_IsPrefixed(t *testing.T) {
+	if got := ConfigKey(FieldClientID); got != "oauth_app_client_id" {
+		t.Fatalf("ConfigKey = %q, want oauth_app_client_id", got)
+	}
+	prefix := ConfigKey("")
+	for _, f := range Fields {
+		if len(ConfigKey(f)) <= len(prefix) || ConfigKey(f)[:len(prefix)] != prefix {
+			t.Fatalf("ConfigKey(%q) is not under the %q namespace", f, prefix)
+		}
+	}
+}
+
+func TestFields_IsTheWholeRegistration(t *testing.T) {
+	want := map[string]bool{FieldClientID: true, FieldClientSecret: true, FieldRedirectURI: true}
+	if len(Fields) != len(want) {
+		t.Fatalf("Fields = %v, want exactly the three registration fields", Fields)
+	}
+	for _, f := range Fields {
+		if !want[f] {
+			t.Errorf("unexpected field %q", f)
+		}
+	}
+}

--- a/libs/go-common/warehouse/authflow.go
+++ b/libs/go-common/warehouse/authflow.go
@@ -35,6 +35,19 @@ type AuthorizationCode struct {
 	AuthURL  string `json:"auth_url"`
 	TokenURL string `json:"token_url"`
 
+	// RevokeURL ends a grant at the provider (RFC 7009).
+	//
+	// It is needed because forgetting a refresh token is not the same as
+	// ending the authorization it belongs to. A datasource that is
+	// re-authorized, removed, or switched to another method discards the only
+	// copy of its token — and without this the grant stays live in the
+	// provider's account, listed to a user who has every reason to think
+	// disconnecting ended it.
+	//
+	// Optional: a provider that publishes no revocation endpoint simply cannot
+	// be told, and the alternative is to hold a credential nobody wants.
+	RevokeURL string `json:"revoke_url,omitempty"`
+
 	// Scopes are requested at consent and required of the result. Providers
 	// with granular consent let a user approve some and withhold others, and
 	// the resulting token is valid but cannot do the job — so this list is

--- a/libs/go-common/warehouse/authflow.go
+++ b/libs/go-common/warehouse/authflow.go
@@ -43,12 +43,18 @@ type AuthorizationCode struct {
 }
 
 // AuthMethodByID returns the provider's declared auth method with the given
-// id. An empty id resolves to the provider's first declared method, which is
-// how a datasource saved before it had a choice of methods still resolves to
-// the one it was configured under.
+// id.
+//
+// An empty id resolves to the provider's method only when it declares exactly
+// one: a datasource saved while a provider offered a single method never
+// stored a choice, and there is only one thing it can have been. With two or
+// more, an empty id is genuinely ambiguous and resolves to nothing — guessing
+// the first would answer for a datasource whose provider knows better, and a
+// provider that later gains a second method would silently reclassify every
+// datasource already connected under the original one.
 func (m ProviderMeta) AuthMethodByID(id string) (AuthMethod, bool) {
 	if id == "" {
-		if len(m.AuthMethods) == 0 {
+		if len(m.AuthMethods) != 1 {
 			return AuthMethod{}, false
 		}
 		return m.AuthMethods[0], true

--- a/libs/go-common/warehouse/authflow.go
+++ b/libs/go-common/warehouse/authflow.go
@@ -1,7 +1,5 @@
 package warehouse
 
-import "encoding/hex"
-
 // Auth-method flows. Flow names how a method obtains its credential, which is
 // what decides whether the UI can render a form for it at all.
 const (
@@ -32,6 +30,13 @@ const (
 // caller can build a consent URL without constructing a provider — which it
 // could not do anyway, since the credential is what the flow is for.
 type AuthorizationCode struct {
+	// Provider identifies whose OAuth app registration this method
+	// authenticates with — "google", say. It is declared rather than derived
+	// from the datasource slug because one registration serves several
+	// consumers: a deployment that has registered a Google client for one
+	// feature must not be asked to register a second for another.
+	Provider string `json:"provider"`
+
 	AuthURL  string `json:"auth_url"`
 	TokenURL string `json:"token_url"`
 
@@ -78,47 +83,4 @@ func (m ProviderMeta) AuthMethodByID(id string) (AuthMethod, bool) {
 		}
 	}
 	return AuthMethod{}, false
-}
-
-// OAuth app-registration fields. The deployment registers its own OAuth client
-// with the provider — its own client_id, client_secret and redirect_uri — so
-// no DecisionBox-owned application ever holds a customer's data grant, and an
-// app of the provider's "internal" type needs no vendor verification.
-const (
-	OAuthFieldClientID     = "client_id"
-	OAuthFieldClientSecret = "client_secret"
-	OAuthFieldRedirectURI  = "redirect_uri"
-)
-
-// OAuthAppFields is the full registration, in the order a form should render
-// it.
-var OAuthAppFields = []string{OAuthFieldClientID, OAuthFieldClientSecret, OAuthFieldRedirectURI}
-
-// oauthAppKeyPrefix namespaces the app registration away from per-project
-// warehouse credentials. The registration is instance-scoped — one OAuth
-// client per deployment per provider, shared by every project that connects
-// that kind of source.
-const oauthAppKeyPrefix = "warehouse-oauth-app"
-
-// OAuthAppKey returns the secret-provider key holding one field of a
-// provider's instance-scoped OAuth app registration.
-//
-// The provider slug is hex-encoded for the same reason CredentialsKey encodes
-// a warehouse id: cloud secret backends compose this key straight into the
-// provider-side secret name and restrict that name's charset — GCP allows
-// [A-Za-z0-9_-], Azure Key Vault only [A-Za-z0-9-]. Hex plus a hyphen
-// delimiter is accepted everywhere, is deterministic, and cannot collide
-// across distinct slugs the way a lossy character substitution can.
-func OAuthAppKey(provider, field string) string {
-	return oauthAppKeyPrefix + "-" + hex.EncodeToString([]byte(provider)) + "-" + hex.EncodeToString([]byte(field))
-}
-
-// OAuthAppConfigKey returns the ProviderConfig key an app-registration field
-// is passed to a provider factory under.
-//
-// It is namespaced away from the provider's own config fields deliberately:
-// "client_id" is a plausible name for something a provider asks the operator
-// for, and a collision would silently overwrite one with the other.
-func OAuthAppConfigKey(field string) string {
-	return "oauth_app_" + field
 }

--- a/libs/go-common/warehouse/authflow.go
+++ b/libs/go-common/warehouse/authflow.go
@@ -1,0 +1,105 @@
+package warehouse
+
+import "encoding/hex"
+
+// Auth-method flows. Flow names how a method obtains its credential, which is
+// what decides whether the UI can render a form for it at all.
+const (
+	// FlowStaticConfig is a credential the operator types in — a password, a
+	// service-account key, a role ARN. It is the zero value, so every auth
+	// method declared before flows existed keeps its meaning.
+	FlowStaticConfig = ""
+
+	// FlowAuthorizationCode is three-legged OAuth: the user is sent to the
+	// provider's consent screen, the provider hands back a code, and the code
+	// is exchanged for a durable refresh token stored as the datasource's
+	// credential. There is no field to type; the credential is the outcome of
+	// a conversation with the provider.
+	//
+	// This exists because a downloadable credential is not always obtainable.
+	// constraints/iam.disableServiceAccountKeyCreation — a CIS Google Cloud
+	// Benchmark control that regulated organisations enforce org-wide — makes
+	// a service-account key impossible to create, and for those deployments a
+	// user-delegated grant is the only way to connect at all.
+	FlowAuthorizationCode = "authorization_code"
+)
+
+// AuthorizationCode carries what a three-legged auth method needs that a
+// static one does not: where to send the user, where to redeem the code, and
+// what the resulting grant must cover.
+//
+// It is declared at registration, alongside the rest of ProviderMeta, so a
+// caller can build a consent URL without constructing a provider — which it
+// could not do anyway, since the credential is what the flow is for.
+type AuthorizationCode struct {
+	AuthURL  string `json:"auth_url"`
+	TokenURL string `json:"token_url"`
+
+	// Scopes are requested at consent and required of the result. Providers
+	// with granular consent let a user approve some and withhold others, and
+	// the resulting token is valid but cannot do the job — so this list is
+	// what the exchange checks the grant against, not merely what it asks for.
+	Scopes []string `json:"scopes"`
+}
+
+// AuthMethodByID returns the provider's declared auth method with the given
+// id. An empty id resolves to the provider's first declared method, which is
+// how a datasource saved before it had a choice of methods still resolves to
+// the one it was configured under.
+func (m ProviderMeta) AuthMethodByID(id string) (AuthMethod, bool) {
+	if id == "" {
+		if len(m.AuthMethods) == 0 {
+			return AuthMethod{}, false
+		}
+		return m.AuthMethods[0], true
+	}
+	for _, a := range m.AuthMethods {
+		if a.ID == id {
+			return a, true
+		}
+	}
+	return AuthMethod{}, false
+}
+
+// OAuth app-registration fields. The deployment registers its own OAuth client
+// with the provider — its own client_id, client_secret and redirect_uri — so
+// no DecisionBox-owned application ever holds a customer's data grant, and an
+// app of the provider's "internal" type needs no vendor verification.
+const (
+	OAuthFieldClientID     = "client_id"
+	OAuthFieldClientSecret = "client_secret"
+	OAuthFieldRedirectURI  = "redirect_uri"
+)
+
+// OAuthAppFields is the full registration, in the order a form should render
+// it.
+var OAuthAppFields = []string{OAuthFieldClientID, OAuthFieldClientSecret, OAuthFieldRedirectURI}
+
+// oauthAppKeyPrefix namespaces the app registration away from per-project
+// warehouse credentials. The registration is instance-scoped — one OAuth
+// client per deployment per provider, shared by every project that connects
+// that kind of source.
+const oauthAppKeyPrefix = "warehouse-oauth-app"
+
+// OAuthAppKey returns the secret-provider key holding one field of a
+// provider's instance-scoped OAuth app registration.
+//
+// The provider slug is hex-encoded for the same reason CredentialsKey encodes
+// a warehouse id: cloud secret backends compose this key straight into the
+// provider-side secret name and restrict that name's charset — GCP allows
+// [A-Za-z0-9_-], Azure Key Vault only [A-Za-z0-9-]. Hex plus a hyphen
+// delimiter is accepted everywhere, is deterministic, and cannot collide
+// across distinct slugs the way a lossy character substitution can.
+func OAuthAppKey(provider, field string) string {
+	return oauthAppKeyPrefix + "-" + hex.EncodeToString([]byte(provider)) + "-" + hex.EncodeToString([]byte(field))
+}
+
+// OAuthAppConfigKey returns the ProviderConfig key an app-registration field
+// is passed to a provider factory under.
+//
+// It is namespaced away from the provider's own config fields deliberately:
+// "client_id" is a plausible name for something a provider asks the operator
+// for, and a collision would silently overwrite one with the other.
+func OAuthAppConfigKey(field string) string {
+	return "oauth_app_" + field
+}

--- a/libs/go-common/warehouse/authflow.go
+++ b/libs/go-common/warehouse/authflow.go
@@ -58,6 +58,27 @@ type AuthorizationCode struct {
 	// the resulting token is valid but cannot do the job — so this list is
 	// what the exchange checks the grant against, not merely what it asks for.
 	Scopes []string `json:"scopes"`
+
+	// IdentityScopes are requested at consent so the resulting connection can
+	// be labelled with the account behind it, and are NOT required of the
+	// result.
+	//
+	// They are separate from Scopes because they buy a label, not a
+	// capability: withholding one leaves a grant that does everything the
+	// datasource needs, and refusing it over a missing display name would be
+	// absurd. Keeping them out of Scopes is what makes that true — the
+	// exchange checks that list and no other.
+	IdentityScopes []string `json:"identity_scopes,omitempty"`
+
+	// UserInfoURL reports who authorized the grant, so two connections to the
+	// same source can be told apart.
+	//
+	// It is declared here for the same reason RevokeURL is: it is a fact the
+	// provider publishes alongside its endpoints, not deployment
+	// configuration. Optional — a provider with no such endpoint, or a
+	// consent that withheld IdentityScopes, yields an unlabelled connection
+	// rather than a failed one.
+	UserInfoURL string `json:"user_info_url,omitempty"`
 }
 
 // AuthMethodByID returns the provider's declared auth method with the given

--- a/libs/go-common/warehouse/authflow_test.go
+++ b/libs/go-common/warehouse/authflow_test.go
@@ -1,0 +1,148 @@
+package warehouse
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Every auth method that existed before flows did declares none, so the zero
+// value has to keep meaning "a form the operator fills in". A default that
+// read as anything else would reclassify every provider in the registry.
+func TestFlow_TheZeroValueIsTheOldBehaviour(t *testing.T) {
+	var m AuthMethod
+	if m.Flow != FlowStaticConfig {
+		t.Errorf("an undeclared flow = %q, want the static-config flow", m.Flow)
+	}
+}
+
+// The wire shape is a contract with the dashboard, which renders the connect
+// form from it. A provider that declares no flow must serialise exactly as it
+// did before the field existed, or every existing provider's payload changes
+// shape for a capability none of them use.
+func TestAuthMethod_AStaticMethodSerialisesUnchanged(t *testing.T) {
+	b, err := json.Marshal(AuthMethod{
+		ID: "sa_key", Name: "Service Account Key", Description: "help",
+		Fields: []ConfigField{{Key: "credentials_json", Type: "credential"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, absent := range []string{"flow", "authorization"} {
+		if strings.Contains(string(b), `"`+absent+`"`) {
+			t.Errorf("a static method emitted %q: %s", absent, b)
+		}
+	}
+}
+
+func TestAuthMethod_AThreeLeggedMethodCarriesItsEndpoints(t *testing.T) {
+	b, err := json.Marshal(AuthMethod{
+		ID: "oauth_user", Name: "Sign in", Flow: FlowAuthorizationCode,
+		Authorization: &AuthorizationCode{
+			AuthURL:  "https://accounts.example/o/oauth2/auth",
+			TokenURL: "https://oauth2.example/token",
+			Scopes:   []string{"scope.readonly"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back AuthMethod
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Flow != FlowAuthorizationCode || back.Authorization == nil {
+		t.Fatalf("round trip lost the flow: %+v", back)
+	}
+	if back.Authorization.AuthURL == "" || back.Authorization.TokenURL == "" || len(back.Authorization.Scopes) != 1 {
+		t.Errorf("round trip lost the endpoints: %+v", back.Authorization)
+	}
+}
+
+// --- resolving the selected method ---
+
+func metaWithMethods(ids ...string) ProviderMeta {
+	m := ProviderMeta{}
+	for _, id := range ids {
+		m.AuthMethods = append(m.AuthMethods, AuthMethod{ID: id})
+	}
+	return m
+}
+
+func TestAuthMethodByID(t *testing.T) {
+	meta := metaWithMethods("oauth_user", "sa_key")
+
+	if got, ok := meta.AuthMethodByID("sa_key"); !ok || got.ID != "sa_key" {
+		t.Errorf("by id = %+v,%v", got, ok)
+	}
+	// A datasource configured before the provider offered a choice stores no
+	// method. Resolving that to nothing would leave it unable to authenticate
+	// at all, so it resolves to the provider's first — the one it was
+	// configured under.
+	if got, ok := meta.AuthMethodByID(""); !ok || got.ID != "oauth_user" {
+		t.Errorf("an unset method = %+v,%v, want the first declared", got, ok)
+	}
+	if _, ok := meta.AuthMethodByID("nonexistent"); ok {
+		t.Error("an unknown method id resolved to something")
+	}
+	if _, ok := metaWithMethods().AuthMethodByID(""); ok {
+		t.Error("a provider declaring no auth methods resolved one")
+	}
+}
+
+// --- the app-registration secret keys ---
+
+// Cloud secret backends compose this key into the backing secret's name and
+// restrict its charset; Azure Key Vault is the strictest at [A-Za-z0-9-]. A
+// key outside that alphabet fails to store, and it fails at connect time on
+// one deployment and not another.
+func TestOAuthAppKey_StaysInsideTheStrictestBackendsAlphabet(t *testing.T) {
+	for _, provider := range []string{"ga4", "salesforce", "some_provider", "odd:slug/v2"} {
+		for _, field := range OAuthAppFields {
+			key := OAuthAppKey(provider, field)
+			for _, r := range key {
+				if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+					continue
+				}
+				t.Fatalf("key %q for (%q,%q) contains %q, which Azure Key Vault rejects", key, provider, field, r)
+			}
+		}
+	}
+}
+
+// The registration is instance-scoped and per provider, so two providers must
+// never share a slot — connecting Salesforce would otherwise overwrite the
+// OAuth client GA4 connections were issued against and break all of them.
+func TestOAuthAppKey_IsDistinctPerProviderAndField(t *testing.T) {
+	seen := map[string]string{}
+	for _, provider := range []string{"ga4", "salesforce", "ga-4", "ga_4"} {
+		for _, field := range OAuthAppFields {
+			key := OAuthAppKey(provider, field)
+			if prev, clash := seen[key]; clash {
+				t.Fatalf("%s/%s collides with %s on key %q", provider, field, prev, key)
+			}
+			seen[key] = provider + "/" + field
+		}
+	}
+}
+
+// The key is stored data: changing it orphans every registration already
+// saved, and the symptom is a working deployment reporting its OAuth app as
+// unconfigured after an upgrade.
+func TestOAuthAppKey_IsStable(t *testing.T) {
+	if got, want := OAuthAppKey("ga4", OAuthFieldClientID), "warehouse-oauth-app-676134-636c69656e745f6964"; got != want {
+		t.Errorf("OAuthAppKey = %q, want %q", got, want)
+	}
+}
+
+// The registration is passed to a provider factory through the same flat map
+// as its own config fields, where "client_id" is a plausible name for
+// something a provider asks for itself. The namespace is what stops one
+// silently overwriting the other.
+func TestOAuthAppConfigKey_DoesNotCollideWithAProvidersOwnFields(t *testing.T) {
+	for _, f := range OAuthAppFields {
+		if got := OAuthAppConfigKey(f); got == f {
+			t.Errorf("OAuthAppConfigKey(%q) = %q — un-namespaced", f, got)
+		}
+	}
+}

--- a/libs/go-common/warehouse/authflow_test.go
+++ b/libs/go-common/warehouse/authflow_test.go
@@ -71,6 +71,50 @@ func TestAuthMethod_AThreeLeggedMethodCarriesItsEndpoints(t *testing.T) {
 	}
 }
 
+// The identity fields are what let a connection be labelled with the account
+// behind it, and the dashboard joins the scopes into the consent request. A
+// method that declares neither must emit neither: the dashboard would append
+// "undefined" to the scope string it asks Google for, and the consent would
+// fail on a scope nobody declared.
+func TestAuthorizationCode_IdentityIsOptionalAndRoundTrips(t *testing.T) {
+	bare, err := json.Marshal(AuthorizationCode{
+		Provider: "example", AuthURL: "https://a", TokenURL: "https://t",
+		Scopes: []string{"scope.readonly"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, absent := range []string{"identity_scopes", "user_info_url"} {
+		if strings.Contains(string(bare), `"`+absent+`"`) {
+			t.Errorf("a method with no identity capability emitted %q: %s", absent, bare)
+		}
+	}
+
+	b, err := json.Marshal(AuthorizationCode{
+		Provider: "example", AuthURL: "https://a", TokenURL: "https://t",
+		Scopes:         []string{"scope.readonly"},
+		IdentityScopes: []string{"openid", "https://example/userinfo.email"},
+		UserInfoURL:    "https://example/userinfo",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back AuthorizationCode
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.IdentityScopes) != 2 || back.UserInfoURL != "https://example/userinfo" {
+		t.Errorf("round trip lost the identity capability: %+v", back)
+	}
+	// Requested, never required — the exchange checks Scopes and no other
+	// list, so a withheld identity scope costs a label and not the grant.
+	for _, s := range back.Scopes {
+		if s == "openid" {
+			t.Error("an identity scope leaked into Scopes, which the exchange requires")
+		}
+	}
+}
+
 // --- resolving the selected method ---
 
 func metaWithMethods(ids ...string) ProviderMeta {

--- a/libs/go-common/warehouse/authflow_test.go
+++ b/libs/go-common/warehouse/authflow_test.go
@@ -28,7 +28,7 @@ func TestAuthMethod_AStaticMethodSerialisesUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	for _, absent := range []string{"flow", "authorization"} {
+	for _, absent := range []string{"flow", "authorization", "revoke_url"} {
 		if strings.Contains(string(b), `"`+absent+`"`) {
 			t.Errorf("a static method emitted %q: %s", absent, b)
 		}
@@ -39,9 +39,10 @@ func TestAuthMethod_AThreeLeggedMethodCarriesItsEndpoints(t *testing.T) {
 	b, err := json.Marshal(AuthMethod{
 		ID: "oauth_user", Name: "Sign in", Flow: FlowAuthorizationCode,
 		Authorization: &AuthorizationCode{
-			AuthURL:  "https://accounts.example/o/oauth2/auth",
-			TokenURL: "https://oauth2.example/token",
-			Scopes:   []string{"scope.readonly"},
+			AuthURL:   "https://accounts.example/o/oauth2/auth",
+			TokenURL:  "https://oauth2.example/token",
+			RevokeURL: "https://oauth2.example/revoke",
+			Scopes:    []string{"scope.readonly"},
 		},
 	})
 	if err != nil {
@@ -56,6 +57,11 @@ func TestAuthMethod_AThreeLeggedMethodCarriesItsEndpoints(t *testing.T) {
 	}
 	if back.Authorization.AuthURL == "" || back.Authorization.TokenURL == "" || len(back.Authorization.Scopes) != 1 {
 		t.Errorf("round trip lost the endpoints: %+v", back.Authorization)
+	}
+	// Losing this one is silent: everything still works, and a grant outlives
+	// the connection that held it.
+	if back.Authorization.RevokeURL != "https://oauth2.example/revoke" {
+		t.Errorf("round trip lost the revocation endpoint: %+v", back.Authorization)
 	}
 }
 

--- a/libs/go-common/warehouse/authflow_test.go
+++ b/libs/go-common/warehouse/authflow_test.go
@@ -75,18 +75,26 @@ func TestAuthMethodByID(t *testing.T) {
 	if got, ok := meta.AuthMethodByID("sa_key"); !ok || got.ID != "sa_key" {
 		t.Errorf("by id = %+v,%v", got, ok)
 	}
-	// A datasource configured before the provider offered a choice stores no
-	// method. Resolving that to nothing would leave it unable to authenticate
-	// at all, so it resolves to the provider's first — the one it was
-	// configured under.
-	if got, ok := meta.AuthMethodByID(""); !ok || got.ID != "oauth_user" {
-		t.Errorf("an unset method = %+v,%v, want the first declared", got, ok)
-	}
 	if _, ok := meta.AuthMethodByID("nonexistent"); ok {
 		t.Error("an unknown method id resolved to something")
 	}
 	if _, ok := metaWithMethods().AuthMethodByID(""); ok {
 		t.Error("a provider declaring no auth methods resolved one")
+	}
+}
+
+// A datasource saved while its provider offered a single method never stored a
+// choice, and there is only one thing it can have been.
+func TestAuthMethodByID_AnUnsetIDResolvesOnlyWhenThereIsNoChoice(t *testing.T) {
+	if got, ok := metaWithMethods("sa_key").AuthMethodByID(""); !ok || got.ID != "sa_key" {
+		t.Errorf("an unset method on a single-method provider = %+v,%v, want the one method", got, ok)
+	}
+	// With two, an unset id is ambiguous. Answering "the first" would
+	// reclassify every datasource connected under the original method the day
+	// a provider gains a second — silently, and in whichever direction the new
+	// method happened to be declared.
+	if got, ok := metaWithMethods("oauth_user", "sa_key").AuthMethodByID(""); ok {
+		t.Errorf("an unset method resolved to %+v on a provider offering two", got)
 	}
 }
 

--- a/libs/go-common/warehouse/authflow_test.go
+++ b/libs/go-common/warehouse/authflow_test.go
@@ -39,6 +39,7 @@ func TestAuthMethod_AThreeLeggedMethodCarriesItsEndpoints(t *testing.T) {
 	b, err := json.Marshal(AuthMethod{
 		ID: "oauth_user", Name: "Sign in", Flow: FlowAuthorizationCode,
 		Authorization: &AuthorizationCode{
+			Provider:  "example",
 			AuthURL:   "https://accounts.example/o/oauth2/auth",
 			TokenURL:  "https://oauth2.example/token",
 			RevokeURL: "https://oauth2.example/revoke",
@@ -57,6 +58,11 @@ func TestAuthMethod_AThreeLeggedMethodCarriesItsEndpoints(t *testing.T) {
 	}
 	if back.Authorization.AuthURL == "" || back.Authorization.TokenURL == "" || len(back.Authorization.Scopes) != 1 {
 		t.Errorf("round trip lost the endpoints: %+v", back.Authorization)
+	}
+	// Without the provider there is no app registration to look up, so the
+	// method cannot authenticate at all.
+	if back.Authorization.Provider != "example" {
+		t.Errorf("round trip lost the OAuth provider: %+v", back.Authorization)
 	}
 	// Losing this one is silent: everything still works, and a grant outlives
 	// the connection that held it.
@@ -105,58 +111,3 @@ func TestAuthMethodByID_AnUnsetIDResolvesOnlyWhenThereIsNoChoice(t *testing.T) {
 }
 
 // --- the app-registration secret keys ---
-
-// Cloud secret backends compose this key into the backing secret's name and
-// restrict its charset; Azure Key Vault is the strictest at [A-Za-z0-9-]. A
-// key outside that alphabet fails to store, and it fails at connect time on
-// one deployment and not another.
-func TestOAuthAppKey_StaysInsideTheStrictestBackendsAlphabet(t *testing.T) {
-	for _, provider := range []string{"ga4", "salesforce", "some_provider", "odd:slug/v2"} {
-		for _, field := range OAuthAppFields {
-			key := OAuthAppKey(provider, field)
-			for _, r := range key {
-				if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
-					continue
-				}
-				t.Fatalf("key %q for (%q,%q) contains %q, which Azure Key Vault rejects", key, provider, field, r)
-			}
-		}
-	}
-}
-
-// The registration is instance-scoped and per provider, so two providers must
-// never share a slot — connecting Salesforce would otherwise overwrite the
-// OAuth client GA4 connections were issued against and break all of them.
-func TestOAuthAppKey_IsDistinctPerProviderAndField(t *testing.T) {
-	seen := map[string]string{}
-	for _, provider := range []string{"ga4", "salesforce", "ga-4", "ga_4"} {
-		for _, field := range OAuthAppFields {
-			key := OAuthAppKey(provider, field)
-			if prev, clash := seen[key]; clash {
-				t.Fatalf("%s/%s collides with %s on key %q", provider, field, prev, key)
-			}
-			seen[key] = provider + "/" + field
-		}
-	}
-}
-
-// The key is stored data: changing it orphans every registration already
-// saved, and the symptom is a working deployment reporting its OAuth app as
-// unconfigured after an upgrade.
-func TestOAuthAppKey_IsStable(t *testing.T) {
-	if got, want := OAuthAppKey("ga4", OAuthFieldClientID), "warehouse-oauth-app-676134-636c69656e745f6964"; got != want {
-		t.Errorf("OAuthAppKey = %q, want %q", got, want)
-	}
-}
-
-// The registration is passed to a provider factory through the same flat map
-// as its own config fields, where "client_id" is a plausible name for
-// something a provider asks for itself. The namespace is what stops one
-// silently overwriting the other.
-func TestOAuthAppConfigKey_DoesNotCollideWithAProvidersOwnFields(t *testing.T) {
-	for _, f := range OAuthAppFields {
-		if got := OAuthAppConfigKey(f); got == f {
-			t.Errorf("OAuthAppConfigKey(%q) = %q — un-namespaced", f, got)
-		}
-	}
-}

--- a/libs/go-common/warehouse/credentials.go
+++ b/libs/go-common/warehouse/credentials.go
@@ -1,6 +1,9 @@
 package warehouse
 
-import "encoding/hex"
+import (
+	"encoding/hex"
+	"regexp"
+)
 
 // LegacyCredentialsKey is the secret key under which every project's
 // warehouse credentials were stored before multi-warehouse. It remains
@@ -55,10 +58,20 @@ const CredentialRefKey = "credential_ref" //nolint:gosec // G101: the name of a 
 // Nothing else in a project's secrets lives under it.
 const sharedCredentialPrefix = "warehouse-shared-credential"
 
-// maxSharedCredentialID bounds the id so the composed key stays inside the
-// 127-character limit Azure Key Vault imposes on a secret name: the prefix and
-// separator are 28 characters and hex doubles the id.
+// maxSharedCredentialID bounds the id.
+//
+// The limit that bites is not this key's own length: Azure Key Vault composes
+// the provider-side secret name as "<namespace>-<projectID>-<key>" and caps THAT
+// at 127 characters, so a project id (24 hex characters for a Mongo ObjectID)
+// and a namespace are spent before this key starts. 48 leaves the composed name
+// at 113 for a typical deployment, with room for a longer namespace.
 const maxSharedCredentialID = 48
+
+// sharedCredentialIDChars is the alphabet an id may use: Azure Key Vault's own,
+// which is the strictest of the backends. An id outside it is refused rather
+// than folded — folding is lossy, and two connections whose ids differed only in
+// their separators would share a slot.
+var sharedCredentialIDChars = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
 
 // SharedCredentialKey returns the secret key holding a credential that several
 // datasources read, named by an opaque id. Reports false for an id no key can be
@@ -72,12 +85,13 @@ const maxSharedCredentialID = 48
 // to a host they chose. Composed into a namespace nothing else writes, the worst
 // a forged id can name is a shared credential that does not exist.
 //
-// Hex-encoded for the same reason CredentialsKey encodes a warehouse id: the
-// cloud backends compose this key straight into the provider-side secret name
-// and restrict its charset, and hex plus a hyphen is accepted by all of them.
+// The id is not encoded, unlike the warehouse id in CredentialsKey. Encoding
+// exists to make arbitrary input storable, and doubles the length doing it;
+// here an id that is not already storable is refused instead, which keeps the
+// composed Azure name inside its limit.
 func SharedCredentialKey(id string) (string, bool) {
-	if id == "" || len(id) > maxSharedCredentialID {
+	if id == "" || len(id) > maxSharedCredentialID || !sharedCredentialIDChars.MatchString(id) {
 		return "", false
 	}
-	return sharedCredentialPrefix + "-" + hex.EncodeToString([]byte(id)), true
+	return sharedCredentialPrefix + "-" + id, true
 }

--- a/libs/go-common/warehouse/credentials.go
+++ b/libs/go-common/warehouse/credentials.go
@@ -37,3 +37,35 @@ func CredentialsKey(warehouseID string) string {
 	}
 	return LegacyCredentialsKey + "-" + hex.EncodeToString([]byte(warehouseID))
 }
+
+// CredentialRefKey is the datasource-config key naming the secret slot a
+// credential lives in, when it is not the one derived from the datasource id.
+//
+// It exists because a credential can be shared. A grant obtained once and used
+// by several datasources cannot live under a key derived from any one of them,
+// and derivation is exactly what CredentialsKey does. When this is set the agent
+// reads it instead; when it is not — which is every datasource that does not
+// share one — nothing about the read changes.
+const CredentialRefKey = "credential_ref" //nolint:gosec // G101: the name of a config field, not a credential
+
+// ValidCredentialRef reports whether a ref could be a key this system wrote.
+//
+// It is a shape check rather than an authorization one, and deliberately so:
+// the read it feeds is already scoped to the datasource's own project, so a ref
+// can only ever name a secret that project already owns. What this stops is a
+// value that is not a key at all — the cloud secret backends compose their
+// secret's name straight from it, and one outside their alphabet fails in a way
+// nobody can diagnose. Azure Key Vault is the strictest at [A-Za-z0-9-] and
+// every key this system produces is lowercase, so that is the alphabet here.
+func ValidCredentialRef(ref string) bool {
+	if ref == "" || len(ref) > 127 {
+		return false
+	}
+	for _, r := range ref {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/libs/go-common/warehouse/credentials.go
+++ b/libs/go-common/warehouse/credentials.go
@@ -38,34 +38,46 @@ func CredentialsKey(warehouseID string) string {
 	return LegacyCredentialsKey + "-" + hex.EncodeToString([]byte(warehouseID))
 }
 
-// CredentialRefKey is the datasource-config key naming the secret slot a
-// credential lives in, when it is not the one derived from the datasource id.
+// CredentialRefKey is the datasource-config key naming the shared credential a
+// datasource reads.
 //
 // It exists because a credential can be shared. A grant obtained once and used
 // by several datasources cannot live under a key derived from any one of them,
 // and derivation is exactly what CredentialsKey does. When this is set the agent
-// reads it instead; when it is not — which is every datasource that does not
-// share one — nothing about the read changes.
+// reads the shared slot it names; when it is not — which is every datasource
+// that does not share one — nothing about the read changes.
+//
+// Its value is an opaque id, NOT a secret key. See SharedCredentialKey for why
+// that distinction is the whole of the access control here.
 const CredentialRefKey = "credential_ref" //nolint:gosec // G101: the name of a config field, not a credential
 
-// ValidCredentialRef reports whether a ref could be a key this system wrote.
+// sharedCredentialPrefix namespaces credentials that several datasources read.
+// Nothing else in a project's secrets lives under it.
+const sharedCredentialPrefix = "warehouse-shared-credential"
+
+// maxSharedCredentialID bounds the id so the composed key stays inside the
+// 127-character limit Azure Key Vault imposes on a secret name: the prefix and
+// separator are 28 characters and hex doubles the id.
+const maxSharedCredentialID = 48
+
+// SharedCredentialKey returns the secret key holding a credential that several
+// datasources read, named by an opaque id. Reports false for an id no key can be
+// formed from.
 //
-// It is a shape check rather than an authorization one, and deliberately so:
-// the read it feeds is already scoped to the datasource's own project, so a ref
-// can only ever name a secret that project already owns. What this stops is a
-// value that is not a key at all — the cloud secret backends compose their
-// secret's name straight from it, and one outside their alphabet fails in a way
-// nobody can diagnose. Azure Key Vault is the strictest at [A-Za-z0-9-] and
-// every key this system produces is lowercase, so that is the alphabet here.
-func ValidCredentialRef(ref string) bool {
-	if ref == "" || len(ref) > 127 {
-		return false
+// The id is composed INTO a key rather than being one, and that is the whole of
+// the access control. A datasource's config is writable by anyone who can edit
+// the project, so a ref that was a raw key would let a member point a warehouse
+// provider at any other secret the project holds — its LLM or embedding
+// credential among them — and have the agent hand it over as credentials_json
+// to a host they chose. Composed into a namespace nothing else writes, the worst
+// a forged id can name is a shared credential that does not exist.
+//
+// Hex-encoded for the same reason CredentialsKey encodes a warehouse id: the
+// cloud backends compose this key straight into the provider-side secret name
+// and restrict its charset, and hex plus a hyphen is accepted by all of them.
+func SharedCredentialKey(id string) (string, bool) {
+	if id == "" || len(id) > maxSharedCredentialID {
+		return "", false
 	}
-	for _, r := range ref {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
-			continue
-		}
-		return false
-	}
-	return true
+	return sharedCredentialPrefix + "-" + hex.EncodeToString([]byte(id)), true
 }

--- a/libs/go-common/warehouse/credentials.go
+++ b/libs/go-common/warehouse/credentials.go
@@ -1,8 +1,8 @@
 package warehouse
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
-	"regexp"
 )
 
 // LegacyCredentialsKey is the secret key under which every project's
@@ -58,40 +58,40 @@ const CredentialRefKey = "credential_ref" //nolint:gosec // G101: the name of a 
 // Nothing else in a project's secrets lives under it.
 const sharedCredentialPrefix = "warehouse-shared-credential"
 
-// maxSharedCredentialID bounds the id.
+// SharedCredentialKey returns the secret key holding a credential obtained FOR
+// one consumer, named by an opaque id. Reports false when either half is empty.
 //
-// The limit that bites is not this key's own length: Azure Key Vault composes
-// the provider-side secret name as "<namespace>-<projectID>-<key>" and caps THAT
-// at 127 characters, so a project id (24 hex characters for a Mongo ObjectID)
-// and a namespace are spent before this key starts. 48 leaves the composed name
-// at 113 for a typical deployment, with room for a longer namespace.
-const maxSharedCredentialID = 48
-
-// sharedCredentialIDChars is the alphabet an id may use: Azure Key Vault's own,
-// which is the strictest of the backends. An id outside it is refused rather
-// than folded — folding is lossy, and two connections whose ids differed only in
-// their separators would share a slot.
-var sharedCredentialIDChars = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
-
-// SharedCredentialKey returns the secret key holding a credential that several
-// datasources read, named by an opaque id. Reports false for an id no key can be
-// formed from.
+// # Why the consumer is part of the key
 //
-// The id is composed INTO a key rather than being one, and that is the whole of
-// the access control. A datasource's config is writable by anyone who can edit
-// the project, so a ref that was a raw key would let a member point a warehouse
-// provider at any other secret the project holds — its LLM or embedding
-// credential among them — and have the agent hand it over as credentials_json
-// to a host they chose. Composed into a namespace nothing else writes, the worst
-// a forged id can name is a shared credential that does not exist.
+// A datasource's config is writable by anyone who can edit the project, and a
+// reference in it is just a string. Without the consumer, a member could point
+// ANY datasource at a credential obtained for another — and some providers make
+// that an exfiltration rather than a failure. The Postgres provider reads
+// credentials_json as the password and host from config, so a datasource naming
+// an analytics connection's slot and an attacker's host would send that
+// connection's Google refresh token straight to it.
 //
-// The id is not encoded, unlike the warehouse id in CredentialsKey. Encoding
-// exists to make arbitrary input storable, and doubles the length doing it;
-// here an id that is not already storable is refused instead, which keeps the
-// composed Azure name inside its limit.
-func SharedCredentialKey(id string) (string, bool) {
-	if id == "" || len(id) > maxSharedCredentialID || !sharedCredentialIDChars.MatchString(id) {
+// Composing the consumer in means a datasource can only ever address a
+// credential obtained for its own provider. Several datasources of that provider
+// still share one, which is the point; nothing else can reach it. Found in
+// review — the earlier version namespaced the key away from other FEATURES'
+// secrets and stopped there, which left this open.
+//
+// # Why it is hashed
+//
+// The parts are joined with a separator that cannot appear in a secret name, so
+// a readable key would have to encode them, and the composed Azure Key Vault
+// name — "<namespace>-<projectID>-<key>", capped at 127 characters — has no room
+// for that. A hash is fixed-width and unambiguous: the domain separator means no
+// pair of (consumer, id) values can be rearranged into another pair's key, which
+// a hyphen-joined key could be when one provider slug is a prefix of another.
+//
+// The cost is that a secret's name no longer says which connection it belongs
+// to. That is worth one exfiltration path.
+func SharedCredentialKey(consumer, id string) (string, bool) {
+	if consumer == "" || id == "" {
 		return "", false
 	}
-	return sharedCredentialPrefix + "-" + id, true
+	sum := sha256.Sum256([]byte(consumer + "\x00" + id))
+	return sharedCredentialPrefix + "-" + hex.EncodeToString(sum[:16]), true
 }

--- a/libs/go-common/warehouse/credentials_test.go
+++ b/libs/go-common/warehouse/credentials_test.go
@@ -3,6 +3,7 @@ package warehouse
 import (
 	"context"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -52,5 +53,42 @@ func TestWarehouseIDContext(t *testing.T) {
 	ctx = WithProjectID(ctx, "p1")
 	if WarehouseIDFromContext(ctx) != "wh_a" || ProjectIDFromContext(ctx) != "p1" {
 		t.Errorf("project and warehouse ids must not clobber each other")
+	}
+}
+
+// The alphabet is the strictest backend's (Azure Key Vault). A ref outside it
+// cannot name a key this system wrote, and reading it would fail at the cloud
+// provider rather than here.
+func TestValidCredentialRef(t *testing.T) {
+	valid := []string{
+		LegacyCredentialsKey,
+		CredentialsKey("wh_1"),
+		"connector-refresh-token-6f3a1b2c",
+		"a",
+	}
+	for _, ref := range valid {
+		if !ValidCredentialRef(ref) {
+			t.Errorf("ValidCredentialRef(%q) = false, want true", ref)
+		}
+	}
+
+	invalid := []string{
+		"", "   ", "../other", "Has-Capitals", "under_score", "with:colon",
+		"with/slash", "with.dot", strings.Repeat("a", 128),
+	}
+	for _, ref := range invalid {
+		if ValidCredentialRef(ref) {
+			t.Errorf("ValidCredentialRef(%q) = true, want false", ref)
+		}
+	}
+}
+
+// Every key this system produces has to pass its own check, or a datasource
+// pointed at a real slot would be refused.
+func TestValidCredentialRef_AcceptsEveryKeyCredentialsKeyProduces(t *testing.T) {
+	for _, id := range []string{"", DefaultWarehouseID, "wh_1", "wh_b", "Odd.ID:v2"} {
+		if key := CredentialsKey(id); !ValidCredentialRef(key) {
+			t.Errorf("CredentialsKey(%q) = %q, which ValidCredentialRef rejects", id, key)
+		}
 	}
 }

--- a/libs/go-common/warehouse/credentials_test.go
+++ b/libs/go-common/warehouse/credentials_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+// cloudSafeKey is the alphabet the strictest backend in play (Azure Key Vault)
+// accepts for a secret name. A key outside it fails to store at all.
+var cloudSafeKey = regexp.MustCompile(`^[a-zA-Z0-9-]{1,127}$`)
+
 func TestCredentialsKey(t *testing.T) {
 	// Unset / "default" resolve to the unmigrated primary key.
 	for _, id := range []string{"", DefaultWarehouseID} {
@@ -56,39 +60,84 @@ func TestWarehouseIDContext(t *testing.T) {
 	}
 }
 
-// The alphabet is the strictest backend's (Azure Key Vault). A ref outside it
-// cannot name a key this system wrote, and reading it would fail at the cloud
-// provider rather than here.
-func TestValidCredentialRef(t *testing.T) {
-	valid := []string{
+// The id is composed INTO a key rather than being one. That is what stops a
+// datasource config — writable by anyone who can edit the project — from naming
+// another secret the project holds.
+func TestSharedCredentialKey_CannotNameAnotherProjectSecret(t *testing.T) {
+	for _, id := range []string{
 		LegacyCredentialsKey,
 		CredentialsKey("wh_1"),
-		"connector-refresh-token-6f3a1b2c",
-		"a",
-	}
-	for _, ref := range valid {
-		if !ValidCredentialRef(ref) {
-			t.Errorf("ValidCredentialRef(%q) = false, want true", ref)
+		"llm-credentials",
+		"embedding-credentials",
+		"slack-bot-token",
+	} {
+		key, ok := SharedCredentialKey(id)
+		if !ok {
+			continue
 		}
-	}
-
-	invalid := []string{
-		"", "   ", "../other", "Has-Capitals", "under_score", "with:colon",
-		"with/slash", "with.dot", strings.Repeat("a", 128),
-	}
-	for _, ref := range invalid {
-		if ValidCredentialRef(ref) {
-			t.Errorf("ValidCredentialRef(%q) = true, want false", ref)
+		if key == id {
+			t.Errorf("SharedCredentialKey(%q) returned the id itself", id)
+		}
+		if !strings.HasPrefix(key, sharedCredentialPrefix+"-") {
+			t.Errorf("SharedCredentialKey(%q) = %q, which is outside the shared namespace", id, key)
 		}
 	}
 }
 
-// Every key this system produces has to pass its own check, or a datasource
-// pointed at a real slot would be refused.
-func TestValidCredentialRef_AcceptsEveryKeyCredentialsKeyProduces(t *testing.T) {
-	for _, id := range []string{"", DefaultWarehouseID, "wh_1", "wh_b", "Odd.ID:v2"} {
-		if key := CredentialsKey(id); !ValidCredentialRef(key) {
-			t.Errorf("CredentialsKey(%q) = %q, which ValidCredentialRef rejects", id, key)
+// The namespace must not overlap the derived per-datasource keys either, or a
+// shared credential could shadow one datasource's own.
+func TestSharedCredentialKey_DoesNotCollideWithADerivedKey(t *testing.T) {
+	derived := map[string]bool{}
+	for _, id := range []string{"", DefaultWarehouseID, "wh_1", "wh_2", "wh_b"} {
+		derived[CredentialsKey(id)] = true
+	}
+	for _, id := range []string{"conn-1", "wh_1", DefaultWarehouseID, "a"} {
+		key, ok := SharedCredentialKey(id)
+		if !ok {
+			t.Fatalf("SharedCredentialKey(%q) was refused", id)
+		}
+		if derived[key] {
+			t.Errorf("SharedCredentialKey(%q) = %q, which is a derived per-datasource key", id, key)
+		}
+	}
+}
+
+// Distinct ids must not share a slot, or one connection's grant would answer for
+// another's.
+func TestSharedCredentialKey_IsDistinctPerID(t *testing.T) {
+	seen := map[string]string{}
+	for _, id := range []string{"conn-1", "conn-2", "conn_1", "CONN-1"} {
+		key, ok := SharedCredentialKey(id)
+		if !ok {
+			t.Fatalf("SharedCredentialKey(%q) was refused", id)
+		}
+		if prev, clash := seen[key]; clash {
+			t.Fatalf("%q collides with %q on key %q", id, prev, key)
+		}
+		seen[key] = id
+	}
+}
+
+// The composed key has to be storable by every backend, whatever the id was.
+func TestSharedCredentialKey_StaysInTheStrictestAlphabet(t *testing.T) {
+	for _, id := range []string{"conn-1", "Odd.ID:v2", "with/slash", "../other", "a b"} {
+		key, ok := SharedCredentialKey(id)
+		if !ok {
+			continue
+		}
+		if !cloudSafeKey.MatchString(key) {
+			t.Errorf("SharedCredentialKey(%q) = %q, which a cloud backend would reject", id, key)
+		}
+	}
+}
+
+// An id no key can be formed from is refused rather than silently producing one:
+// an empty id would otherwise name the namespace's own root, and an over-long
+// one a key Azure rejects at write time, where nobody can see it.
+func TestSharedCredentialKey_RefusesWhatItCannotName(t *testing.T) {
+	for _, id := range []string{"", strings.Repeat("a", maxSharedCredentialID+1)} {
+		if _, ok := SharedCredentialKey(id); ok {
+			t.Errorf("SharedCredentialKey(%q) was accepted", id)
 		}
 	}
 }

--- a/libs/go-common/warehouse/credentials_test.go
+++ b/libs/go-common/warehouse/credentials_test.go
@@ -91,7 +91,7 @@ func TestSharedCredentialKey_DoesNotCollideWithADerivedKey(t *testing.T) {
 	for _, id := range []string{"", DefaultWarehouseID, "wh_1", "wh_2", "wh_b"} {
 		derived[CredentialsKey(id)] = true
 	}
-	for _, id := range []string{"conn-1", "wh_1", DefaultWarehouseID, "a"} {
+	for _, id := range []string{"conn-1", "wh1", DefaultWarehouseID, "a"} {
 		key, ok := SharedCredentialKey(id)
 		if !ok {
 			t.Fatalf("SharedCredentialKey(%q) was refused", id)
@@ -106,7 +106,7 @@ func TestSharedCredentialKey_DoesNotCollideWithADerivedKey(t *testing.T) {
 // another's.
 func TestSharedCredentialKey_IsDistinctPerID(t *testing.T) {
 	seen := map[string]string{}
-	for _, id := range []string{"conn-1", "conn-2", "conn_1", "CONN-1"} {
+	for _, id := range []string{"conn-1", "conn-2", "conn1", "CONN-1"} {
 		key, ok := SharedCredentialKey(id)
 		if !ok {
 			t.Fatalf("SharedCredentialKey(%q) was refused", id)
@@ -120,7 +120,7 @@ func TestSharedCredentialKey_IsDistinctPerID(t *testing.T) {
 
 // The composed key has to be storable by every backend, whatever the id was.
 func TestSharedCredentialKey_StaysInTheStrictestAlphabet(t *testing.T) {
-	for _, id := range []string{"conn-1", "Odd.ID:v2", "with/slash", "../other", "a b"} {
+	for _, id := range []string{"conn-1", "Odd.ID:v2", "with/slash", "../other", "a b", "CONN-1"} {
 		key, ok := SharedCredentialKey(id)
 		if !ok {
 			continue
@@ -131,13 +131,33 @@ func TestSharedCredentialKey_StaysInTheStrictestAlphabet(t *testing.T) {
 	}
 }
 
-// An id no key can be formed from is refused rather than silently producing one:
-// an empty id would otherwise name the namespace's own root, and an over-long
-// one a key Azure rejects at write time, where nobody can see it.
+// An id no key can be formed from is refused rather than silently producing one.
+// An empty id would name the namespace's own root; an over-long one, or one
+// outside the alphabet, a name Azure Key Vault rejects at write time, where
+// nobody can see it.
 func TestSharedCredentialKey_RefusesWhatItCannotName(t *testing.T) {
-	for _, id := range []string{"", strings.Repeat("a", maxSharedCredentialID+1)} {
+	for _, id := range []string{
+		"", "   ", strings.Repeat("a", maxSharedCredentialID+1),
+		"under_score", "with:colon", "with/slash", "with.dot", "../other",
+	} {
 		if _, ok := SharedCredentialKey(id); ok {
 			t.Errorf("SharedCredentialKey(%q) was accepted", id)
 		}
+	}
+}
+
+// The limit Azure enforces is on the name it composes, not on this key alone.
+// A connection id is a UUID, and the composed name for a typical deployment has
+// to stay inside 127 characters or the credential cannot be stored at all.
+func TestSharedCredentialKey_FitsAzuresComposedSecretName(t *testing.T) {
+	const uuid = "2f1c0b1e-9a2d-4c3b-8f7e-6d5a4b3c2d1e"
+	key, ok := SharedCredentialKey(uuid)
+	if !ok {
+		t.Fatal("a UUID id was refused")
+	}
+	// namespace + "-" + a 24-character Mongo ObjectID + "-" + key.
+	composed := len("decisionbox") + 1 + 24 + 1 + len(key)
+	if composed > 127 {
+		t.Fatalf("composed Azure secret name is %d characters, over the 127 limit", composed)
 	}
 }

--- a/libs/go-common/warehouse/credentials_test.go
+++ b/libs/go-common/warehouse/credentials_test.go
@@ -60,9 +60,46 @@ func TestWarehouseIDContext(t *testing.T) {
 	}
 }
 
-// The id is composed INTO a key rather than being one. That is what stops a
-// datasource config — writable by anyone who can edit the project — from naming
-// another secret the project holds.
+// A credential obtained for one consumer must not be addressable by another.
+// Some providers make that an exfiltration rather than a failure: Postgres reads
+// credentials_json as its password and host from config, so a datasource naming
+// an analytics connection's slot and an attacker's host would send that
+// connection's refresh token to it.
+func TestSharedCredentialKey_BindsTheCredentialToItsConsumer(t *testing.T) {
+	const id = "2f1c0b1e-9a2d-4c3b-8f7e-6d5a4b3c2d1e"
+	forGA4, ok := SharedCredentialKey("ga4", id)
+	if !ok {
+		t.Fatal("SharedCredentialKey refused a plain consumer and id")
+	}
+	forPostgres, ok := SharedCredentialKey("postgres", id)
+	if !ok {
+		t.Fatal("SharedCredentialKey refused a plain consumer and id")
+	}
+	if forGA4 == forPostgres {
+		t.Fatal("two providers share a slot for the same id")
+	}
+
+	// And several datasources of the SAME provider do share one — that is the
+	// whole point of a shared credential.
+	again, _ := SharedCredentialKey("ga4", id)
+	if again != forGA4 {
+		t.Fatal("the same consumer and id produced two different slots")
+	}
+}
+
+// The parts are joined with a separator that cannot appear in a key, so no pair
+// of values can be rearranged into another pair's slot — which a hyphen-joined
+// key could be when one provider slug is a prefix of another.
+func TestSharedCredentialKey_PartsCannotBeRearranged(t *testing.T) {
+	a, _ := SharedCredentialKey("ga4", "beta-conn-1")
+	b, _ := SharedCredentialKey("ga4-beta", "conn-1")
+	if a == b {
+		t.Fatal("a crafted id reached another provider's slot")
+	}
+}
+
+// The key must not be the id, or a datasource config — writable by anyone who
+// can edit the project — could name another secret the project holds.
 func TestSharedCredentialKey_CannotNameAnotherProjectSecret(t *testing.T) {
 	for _, id := range []string{
 		LegacyCredentialsKey,
@@ -71,9 +108,9 @@ func TestSharedCredentialKey_CannotNameAnotherProjectSecret(t *testing.T) {
 		"embedding-credentials",
 		"slack-bot-token",
 	} {
-		key, ok := SharedCredentialKey(id)
+		key, ok := SharedCredentialKey("ga4", id)
 		if !ok {
-			continue
+			t.Fatalf("SharedCredentialKey refused %q", id)
 		}
 		if key == id {
 			t.Errorf("SharedCredentialKey(%q) returned the id itself", id)
@@ -91,8 +128,8 @@ func TestSharedCredentialKey_DoesNotCollideWithADerivedKey(t *testing.T) {
 	for _, id := range []string{"", DefaultWarehouseID, "wh_1", "wh_2", "wh_b"} {
 		derived[CredentialsKey(id)] = true
 	}
-	for _, id := range []string{"conn-1", "wh1", DefaultWarehouseID, "a"} {
-		key, ok := SharedCredentialKey(id)
+	for _, id := range []string{"conn-1", "wh_1", DefaultWarehouseID, "a"} {
+		key, ok := SharedCredentialKey("ga4", id)
 		if !ok {
 			t.Fatalf("SharedCredentialKey(%q) was refused", id)
 		}
@@ -103,11 +140,12 @@ func TestSharedCredentialKey_DoesNotCollideWithADerivedKey(t *testing.T) {
 }
 
 // Distinct ids must not share a slot, or one connection's grant would answer for
-// another's.
+// another's — including ids that differ only in case, which Azure Key Vault
+// would otherwise fold together.
 func TestSharedCredentialKey_IsDistinctPerID(t *testing.T) {
 	seen := map[string]string{}
-	for _, id := range []string{"conn-1", "conn-2", "conn1", "CONN-1"} {
-		key, ok := SharedCredentialKey(id)
+	for _, id := range []string{"conn-1", "conn-2", "conn_1", "CONN-1"} {
+		key, ok := SharedCredentialKey("ga4", id)
 		if !ok {
 			t.Fatalf("SharedCredentialKey(%q) was refused", id)
 		}
@@ -118,46 +156,32 @@ func TestSharedCredentialKey_IsDistinctPerID(t *testing.T) {
 	}
 }
 
-// The composed key has to be storable by every backend, whatever the id was.
-func TestSharedCredentialKey_StaysInTheStrictestAlphabet(t *testing.T) {
-	for _, id := range []string{"conn-1", "Odd.ID:v2", "with/slash", "../other", "a b", "CONN-1"} {
-		key, ok := SharedCredentialKey(id)
+// The key has to be storable by every backend whatever the inputs were, and it
+// is fixed-width — so the name Azure Key Vault composes around it fits, for any
+// id and any provider slug.
+func TestSharedCredentialKey_IsAlwaysStorable(t *testing.T) {
+	for _, id := range []string{"conn-1", "Odd.ID:v2", "with/slash", "../other", "a b", strings.Repeat("x", 500)} {
+		key, ok := SharedCredentialKey("a-very-long-datasource-provider-slug", id)
 		if !ok {
-			continue
+			t.Fatalf("SharedCredentialKey(%q) was refused", id)
 		}
 		if !cloudSafeKey.MatchString(key) {
 			t.Errorf("SharedCredentialKey(%q) = %q, which a cloud backend would reject", id, key)
 		}
-	}
-}
-
-// An id no key can be formed from is refused rather than silently producing one.
-// An empty id would name the namespace's own root; an over-long one, or one
-// outside the alphabet, a name Azure Key Vault rejects at write time, where
-// nobody can see it.
-func TestSharedCredentialKey_RefusesWhatItCannotName(t *testing.T) {
-	for _, id := range []string{
-		"", "   ", strings.Repeat("a", maxSharedCredentialID+1),
-		"under_score", "with:colon", "with/slash", "with.dot", "../other",
-	} {
-		if _, ok := SharedCredentialKey(id); ok {
-			t.Errorf("SharedCredentialKey(%q) was accepted", id)
+		// namespace + "-" + a 24-character Mongo ObjectID + "-" + key.
+		if composed := len("decisionbox") + 1 + 24 + 1 + len(key); composed > 127 {
+			t.Errorf("composed Azure secret name is %d characters, over the 127 limit", composed)
 		}
 	}
 }
 
-// The limit Azure enforces is on the name it composes, not on this key alone.
-// A connection id is a UUID, and the composed name for a typical deployment has
-// to stay inside 127 characters or the credential cannot be stored at all.
-func TestSharedCredentialKey_FitsAzuresComposedSecretName(t *testing.T) {
-	const uuid = "2f1c0b1e-9a2d-4c3b-8f7e-6d5a4b3c2d1e"
-	key, ok := SharedCredentialKey(uuid)
-	if !ok {
-		t.Fatal("a UUID id was refused")
+// Half a name is not a name: an empty consumer or id would put every caller that
+// omitted one in the same slot.
+func TestSharedCredentialKey_RefusesHalfAName(t *testing.T) {
+	if _, ok := SharedCredentialKey("", "conn-1"); ok {
+		t.Error("an empty consumer was accepted")
 	}
-	// namespace + "-" + a 24-character Mongo ObjectID + "-" + key.
-	composed := len("decisionbox") + 1 + 24 + 1 + len(key)
-	if composed > 127 {
-		t.Fatalf("composed Azure secret name is %d characters, over the 127 limit", composed)
+	if _, ok := SharedCredentialKey("ga4", ""); ok {
+		t.Error("an empty id was accepted")
 	}
 }

--- a/libs/go-common/warehouse/middleware.go
+++ b/libs/go-common/warehouse/middleware.go
@@ -14,8 +14,8 @@ type namedMiddleware struct {
 }
 
 var (
-	middlewareMu sync.RWMutex
-	middlewares  []namedMiddleware
+	middlewareMu    sync.RWMutex
+	middlewares     []namedMiddleware
 	middlewareNames = make(map[string]bool)
 )
 

--- a/libs/go-common/warehouse/registry.go
+++ b/libs/go-common/warehouse/registry.go
@@ -74,18 +74,18 @@ type AuthMethod struct {
 // ConfigField describes a single configuration field for a provider.
 // The UI renders a form dynamically from these fields.
 type ConfigField struct {
-	Key         string `json:"key"`          // config key: "project_id", "dataset"
-	Label       string `json:"label"`        // display label: "GCP Project ID"
-	Description string `json:"description"`  // help text
+	Key         string `json:"key"`         // config key: "project_id", "dataset"
+	Label       string `json:"label"`       // display label: "GCP Project ID"
+	Description string `json:"description"` // help text
 	Required    bool   `json:"required"`
-	Type        string `json:"type"`         // "string", "number", "boolean", "credential" (stored as secret, not in project config)
-	Default     string `json:"default"`      // default value
-	Placeholder string `json:"placeholder"`  // placeholder text
+	Type        string `json:"type"`        // "string", "number", "boolean", "credential" (stored as secret, not in project config)
+	Default     string `json:"default"`     // default value
+	Placeholder string `json:"placeholder"` // placeholder text
 }
 
 var (
-	providersMu sync.RWMutex
-	providers   = make(map[string]ProviderFactory)
+	providersMu  sync.RWMutex
+	providers    = make(map[string]ProviderFactory)
 	providerMeta = make(map[string]ProviderMeta)
 )
 

--- a/libs/go-common/warehouse/registry.go
+++ b/libs/go-common/warehouse/registry.go
@@ -55,6 +55,20 @@ type AuthMethod struct {
 	Name        string        `json:"name"`        // display name: "Application Default Credentials"
 	Description string        `json:"description"` // help text
 	Fields      []ConfigField `json:"fields"`      // fields specific to this auth method
+
+	// Flow names how the credential is obtained. Empty (FlowStaticConfig) is
+	// the only shape that existed before, and stays the default: the fields
+	// above are a form, and what the operator types is the credential.
+	//
+	// A method that declares FlowAuthorizationCode has no form to render —
+	// its credential is the durable refresh token a consent produces — so a
+	// UI must branch on this rather than on Fields being empty.
+	Flow string `json:"flow,omitempty"`
+
+	// Authorization carries the consent and token endpoints and the scopes
+	// the grant must cover. Set when Flow is FlowAuthorizationCode; nil
+	// otherwise.
+	Authorization *AuthorizationCode `json:"authorization,omitempty"`
 }
 
 // ConfigField describes a single configuration field for a provider.

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -291,6 +291,47 @@ func warehouseIDOrDefault(wh models.WarehouseConfig) string {
 	return wh.ID
 }
 
+// applyOAuthAppRegistration adds the deployment's own OAuth client to a
+// datasource's provider config when the datasource authenticates with a
+// three-legged (user-delegated) method.
+//
+// The stored credential for such a datasource is a refresh token, which is
+// worthless on its own: minting an access token from it requires the client
+// that issued it. That client is registered once per deployment per provider
+// — instance-scoped, not on the project document — so it is read here rather
+// than travelling with the datasource.
+//
+// A registration field that is simply unset is left out, so the provider
+// reports its own "not configured" rather than a secret-store detail. A
+// secret store that cannot be READ is a different thing and is returned as an
+// error: it has not told us the field is empty, and reporting it as empty
+// would send an operator to re-enter an app registration that is already
+// there.
+func applyOAuthAppRegistration(ctx context.Context, secretProvider gosecrets.Provider, providerSlug string, cfg gowarehouse.ProviderConfig) error {
+	meta, ok := gowarehouse.GetProviderMeta(providerSlug)
+	if !ok {
+		return nil // unregistered; NewProvider reports it with the name in hand
+	}
+	method, ok := meta.AuthMethodByID(cfg["auth_method"])
+	if !ok || method.Flow != gowarehouse.FlowAuthorizationCode {
+		return nil
+	}
+
+	for _, field := range gowarehouse.OAuthAppFields {
+		v, err := secretProvider.Get(ctx, "", gowarehouse.OAuthAppKey(providerSlug, field))
+		switch {
+		case errors.Is(err, gosecrets.ErrNotFound):
+			continue
+		case err != nil:
+			return fmt.Errorf("read the %s OAuth app registration (%s): %w", providerSlug, field, err)
+		}
+		if v != "" {
+			cfg[gowarehouse.OAuthAppConfigKey(field)] = v
+		}
+	}
+	return nil
+}
+
 func initWarehouseProvider(ctx context.Context, project *models.Project, warehouseID string, secretProvider gosecrets.Provider, projectID string) (gowarehouse.Provider, error) {
 	wh, ok := project.WarehouseByID(warehouseID)
 	if !ok || wh.Provider == "" {
@@ -324,6 +365,10 @@ func initWarehouseProvider(ctx context.Context, project *models.Project, warehou
 		applog.Info("Warehouse credentials loaded from secret provider")
 	} else if err != nil && !errors.Is(err, gosecrets.ErrNotFound) {
 		applog.WithError(err).Warn("Failed to read warehouse credentials from secret provider")
+	}
+
+	if err := applyOAuthAppRegistration(ctx, secretProvider, wh.Provider, whCfg); err != nil {
+		return nil, err
 	}
 
 	provider, err := gowarehouse.NewProvider(wh.Provider, whCfg)

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -395,10 +395,11 @@ func initWarehouseProvider(ctx context.Context, project *models.Project, warehou
 	// found, which is no more a provider's business than the key it replaces.
 	credentialKey := gowarehouse.CredentialsKey(wh.ID)
 	if ref := strings.TrimSpace(whCfg[gowarehouse.CredentialRefKey]); ref != "" {
-		if !gowarehouse.ValidCredentialRef(ref) {
-			return nil, fmt.Errorf("data source %q names a credential reference that is not a usable secret key", wh.ID)
+		shared, ok := gowarehouse.SharedCredentialKey(ref)
+		if !ok {
+			return nil, fmt.Errorf("data source %q names a shared credential that cannot exist", wh.ID)
 		}
-		credentialKey = ref
+		credentialKey = shared
 	}
 	delete(whCfg, gowarehouse.CredentialRefKey)
 

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -344,6 +344,14 @@ func applyOAuthAppRegistration(ctx context.Context, secretProvider gosecrets.Pro
 		return fmt.Errorf("datasource provider %q declares a three-legged auth method (%q) with no OAuth provider", providerSlug, method.ID)
 	}
 
+	// Record the method this resolved to. A datasource saved while its provider
+	// offered exactly one method stored no choice, and AuthMethodByID reads that
+	// as the one it can only have been — but a factory switches on the config's
+	// own auth_method, so leaving it empty would have this function and the
+	// provider disagree about how the datasource authenticates. It is written
+	// only on the branch that has established the answer.
+	cfg["auth_method"] = method.ID
+
 	oauthProvider := method.Authorization.Provider
 	for _, field := range oauthreg.Fields {
 		v, err := secretProvider.Get(ctx, "", oauthreg.Key(oauthProvider, field))

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -387,7 +387,22 @@ func initWarehouseProvider(ctx context.Context, project *models.Project, warehou
 		whCfg[k] = v
 	}
 
-	whCreds, err := secretProvider.Get(ctx, projectID, gowarehouse.CredentialsKey(wh.ID))
+	// Which slot the credential lives in. Derived from the datasource id unless
+	// the datasource names one — which is how a credential obtained once can be
+	// used by several datasources, since a derived key belongs to exactly one.
+	//
+	// The ref is not passed on to the provider: it says where the credential was
+	// found, which is no more a provider's business than the key it replaces.
+	credentialKey := gowarehouse.CredentialsKey(wh.ID)
+	if ref := strings.TrimSpace(whCfg[gowarehouse.CredentialRefKey]); ref != "" {
+		if !gowarehouse.ValidCredentialRef(ref) {
+			return nil, fmt.Errorf("data source %q names a credential reference that is not a usable secret key", wh.ID)
+		}
+		credentialKey = ref
+	}
+	delete(whCfg, gowarehouse.CredentialRefKey)
+
+	whCreds, err := secretProvider.Get(ctx, projectID, credentialKey)
 	if err == nil && whCreds != "" {
 		whCfg["credentials_json"] = whCreds
 		applog.Info("Warehouse credentials loaded from secret provider")

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -396,7 +396,11 @@ func initWarehouseProvider(ctx context.Context, project *models.Project, warehou
 	credentialKey := gowarehouse.CredentialsKey(wh.ID)
 	sharedRef := strings.TrimSpace(whCfg[gowarehouse.CredentialRefKey])
 	if sharedRef != "" {
-		shared, ok := gowarehouse.SharedCredentialKey(sharedRef)
+		// Composed with THIS datasource's provider, so a reference can only ever
+		// address a credential obtained for it. A datasource naming another
+		// provider's slot gets a key that does not exist, which is refused below
+		// rather than handed a credential it was not issued.
+		shared, ok := gowarehouse.SharedCredentialKey(wh.Provider, sharedRef)
 		if !ok {
 			return nil, fmt.Errorf("data source %q names a shared credential that cannot exist", wh.ID)
 		}

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -20,6 +20,7 @@ import (
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
 	gomongo "github.com/decisionbox-io/decisionbox/libs/go-common/mongodb"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/notify"
+	"github.com/decisionbox-io/decisionbox/libs/go-common/oauthreg"
 	gosecrets "github.com/decisionbox-io/decisionbox/libs/go-common/secrets"
 	gosources "github.com/decisionbox-io/decisionbox/libs/go-common/sources"
 	"github.com/decisionbox-io/decisionbox/libs/go-common/telemetry"
@@ -297,9 +298,14 @@ func warehouseIDOrDefault(wh models.WarehouseConfig) string {
 //
 // The stored credential for such a datasource is a refresh token, which is
 // worthless on its own: minting an access token from it requires the client
-// that issued it. That client is registered once per deployment per provider
-// — instance-scoped, not on the project document — so it is read here rather
-// than travelling with the datasource.
+// that issued it. That client is registered once per deployment per OAuth
+// provider — instance-scoped, not on the project document — so it is read here
+// rather than travelling with the datasource.
+//
+// Keyed by the OAuth provider the method declares, not by the datasource slug:
+// one registration serves every consumer of that provider, so a customer who
+// has registered a Google client once does not register another for the next
+// feature that needs one.
 //
 // A registration field that is simply unset is left out, so the provider
 // reports its own "not configured" rather than a secret-store detail. A
@@ -316,7 +322,7 @@ func applyOAuthAppRegistration(ctx context.Context, secretProvider gosecrets.Pro
 	// registration behind a stale per-project one, which is the failure this
 	// separation exists to make impossible.
 	for k := range cfg {
-		if strings.HasPrefix(k, gowarehouse.OAuthAppConfigKey("")) {
+		if strings.HasPrefix(k, oauthreg.ConfigKey("")) {
 			delete(cfg, k)
 		}
 	}
@@ -330,16 +336,25 @@ func applyOAuthAppRegistration(ctx context.Context, secretProvider gosecrets.Pro
 		return nil
 	}
 
-	for _, field := range gowarehouse.OAuthAppFields {
-		v, err := secretProvider.Get(ctx, "", gowarehouse.OAuthAppKey(providerSlug, field))
+	// A three-legged method that names no OAuth provider can never authenticate:
+	// there is no registration to look up and therefore no client to mint a token
+	// with. That is a registry declaration error, and saying so beats letting the
+	// provider report a generic "not configured" for something no operator can fix.
+	if method.Authorization == nil || method.Authorization.Provider == "" {
+		return fmt.Errorf("datasource provider %q declares a three-legged auth method (%q) with no OAuth provider", providerSlug, method.ID)
+	}
+
+	oauthProvider := method.Authorization.Provider
+	for _, field := range oauthreg.Fields {
+		v, err := secretProvider.Get(ctx, "", oauthreg.Key(oauthProvider, field))
 		switch {
 		case errors.Is(err, gosecrets.ErrNotFound):
 			continue
 		case err != nil:
-			return fmt.Errorf("read the %s OAuth app registration (%s): %w", providerSlug, field, err)
+			return fmt.Errorf("read the %s OAuth app registration (%s): %w", oauthProvider, field, err)
 		}
 		if v != "" {
-			cfg[gowarehouse.OAuthAppConfigKey(field)] = v
+			cfg[oauthreg.ConfigKey(field)] = v
 		}
 	}
 	return nil

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -394,8 +394,9 @@ func initWarehouseProvider(ctx context.Context, project *models.Project, warehou
 	// The ref is not passed on to the provider: it says where the credential was
 	// found, which is no more a provider's business than the key it replaces.
 	credentialKey := gowarehouse.CredentialsKey(wh.ID)
-	if ref := strings.TrimSpace(whCfg[gowarehouse.CredentialRefKey]); ref != "" {
-		shared, ok := gowarehouse.SharedCredentialKey(ref)
+	sharedRef := strings.TrimSpace(whCfg[gowarehouse.CredentialRefKey])
+	if sharedRef != "" {
+		shared, ok := gowarehouse.SharedCredentialKey(sharedRef)
 		if !ok {
 			return nil, fmt.Errorf("data source %q names a shared credential that cannot exist", wh.ID)
 		}
@@ -404,10 +405,24 @@ func initWarehouseProvider(ctx context.Context, project *models.Project, warehou
 	delete(whCfg, gowarehouse.CredentialRefKey)
 
 	whCreds, err := secretProvider.Get(ctx, projectID, credentialKey)
-	if err == nil && whCreds != "" {
+	switch {
+	case err == nil && whCreds != "":
 		whCfg["credentials_json"] = whCreds
 		applog.Info("Warehouse credentials loaded from secret provider")
-	} else if err != nil && !errors.Is(err, gosecrets.ErrNotFound) {
+
+	case sharedRef != "":
+		// A datasource that NAMES a credential and does not get one is a
+		// different thing from one that has none. Falling through would build the
+		// provider with an empty credential, and some of them read that as "use
+		// the ambient identity" — a BigQuery source would run as the agent's own
+		// service account, against a project the customer chose. Refuse instead,
+		// whether the slot is empty, absent, or unreadable.
+		if err == nil {
+			return nil, fmt.Errorf("data source %q reads a shared credential that is stored but empty", wh.ID)
+		}
+		return nil, fmt.Errorf("data source %q reads a shared credential that is not available: %w", wh.ID, err)
+
+	case err != nil && !errors.Is(err, gosecrets.ErrNotFound):
 		applog.WithError(err).Warn("Failed to read warehouse credentials from secret provider")
 	}
 

--- a/services/agent/agentserver/agentserver.go
+++ b/services/agent/agentserver/agentserver.go
@@ -308,6 +308,19 @@ func warehouseIDOrDefault(wh models.WarehouseConfig) string {
 // would send an operator to re-enter an app registration that is already
 // there.
 func applyOAuthAppRegistration(ctx context.Context, secretProvider gosecrets.Provider, providerSlug string, cfg gowarehouse.ProviderConfig) error {
+	// The namespace belongs to the deployment, so nothing a project document
+	// carries in it survives to a provider — whether it was written before the
+	// datasource routes reserved the namespace, or by something else that
+	// writes project documents. Cleared first and unconditionally: a value left
+	// standing because its secret happened to be unset would hide a missing app
+	// registration behind a stale per-project one, which is the failure this
+	// separation exists to make impossible.
+	for k := range cfg {
+		if strings.HasPrefix(k, gowarehouse.OAuthAppConfigKey("")) {
+			delete(cfg, k)
+		}
+	}
+
 	meta, ok := gowarehouse.GetProviderMeta(providerSlug)
 	if !ok {
 		return nil // unregistered; NewProvider reports it with the name in hand

--- a/services/agent/agentserver/credential_ref_test.go
+++ b/services/agent/agentserver/credential_ref_test.go
@@ -81,3 +81,88 @@ func TestInitWarehouseProvider_NoStoredCredentialIsNotAnError(t *testing.T) {
 		t.Fatalf("credentials_json = %q, want it absent", cfg["credentials_json"])
 	}
 }
+
+// The point of the ref: a credential obtained once, under a key that belongs to
+// no single datasource, read by whichever datasource names it.
+func TestInitWarehouseProvider_ReadsTheNamedCredentialWhenSet(t *testing.T) {
+	secrets := &fakeSecretProvider{store: map[string]string{
+		"p1/connector-refresh-token-abc":           "the-shared-grant",
+		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
+	}}
+
+	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}, secrets)
+	if cfg["credentials_json"] != "the-shared-grant" {
+		t.Fatalf("credentials_json = %q, want the credential the ref names", cfg["credentials_json"])
+	}
+}
+
+// Two datasources naming the same slot both authenticate with it — which is the
+// whole reason the ref exists, and what a derived key cannot do.
+func TestInitWarehouseProvider_TwoDatasourcesCanShareOneCredential(t *testing.T) {
+	secrets := &fakeSecretProvider{store: map[string]string{
+		"p1/connector-refresh-token-abc": "the-shared-grant",
+	}}
+	project := &models.Project{
+		ID: "p1",
+		Warehouses: []models.WarehouseConfig{
+			{ID: "wh_1", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}},
+			{ID: "wh_2", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}},
+		},
+	}
+	for _, id := range []string{"wh_1", "wh_2"} {
+		capturedMu.Lock()
+		captured = nil
+		capturedMu.Unlock()
+		_, _ = initWarehouseProvider(context.Background(), project, id, secrets, "p1") //nolint:errcheck // the stub factory returns nil
+		capturedMu.Lock()
+		got := captured["credentials_json"]
+		capturedMu.Unlock()
+		if got != "the-shared-grant" {
+			t.Errorf("%s got credentials_json = %q, want the shared grant", id, got)
+		}
+	}
+}
+
+// An empty ref is not a ref. It has to fall back rather than read a secret named
+// "", which would silently leave the datasource with no credential at all.
+func TestInitWarehouseProvider_AnEmptyRefFallsBackToTheDerivedKey(t *testing.T) {
+	secrets := &fakeSecretProvider{store: map[string]string{
+		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
+	}}
+	for _, ref := range []string{"", "   "} {
+		cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: ref}, secrets)
+		if cfg["credentials_json"] != "the-derived-credential" {
+			t.Errorf("ref %q: credentials_json = %q, want the derived one", ref, cfg["credentials_json"])
+		}
+	}
+}
+
+// The ref names where a credential was found, which is no more a provider's
+// business than the derived key it replaces. Leaving it in the config would also
+// let a provider treat it as one of its own fields.
+func TestInitWarehouseProvider_TheRefIsNotPassedToTheProvider(t *testing.T) {
+	secrets := &fakeSecretProvider{store: map[string]string{"p1/connector-refresh-token-abc": "grant"}}
+	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}, secrets)
+	if v, present := cfg[gowarehouse.CredentialRefKey]; present {
+		t.Fatalf("the provider was handed %s = %q", gowarehouse.CredentialRefKey, v)
+	}
+}
+
+// A ref outside the secret backends' alphabet cannot name a key this system
+// wrote, and reading it would fail at the cloud provider in a way nobody can
+// diagnose. Refusing beats falling back to the derived key, which would look
+// like a working connection authenticating as something else.
+func TestInitWarehouseProvider_AnUnusableRefIsRefused(t *testing.T) {
+	secrets := &fakeSecretProvider{store: map[string]string{
+		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
+	}}
+	for _, ref := range []string{"../other", "Has-Capitals", "under_score", "with:colon", "with/slash"} {
+		project := &models.Project{
+			ID:         "p1",
+			Warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: ref}}},
+		}
+		if _, err := initWarehouseProvider(context.Background(), project, "wh_1", secrets, "p1"); err == nil {
+			t.Errorf("ref %q was accepted", ref)
+		}
+	}
+}

--- a/services/agent/agentserver/credential_ref_test.go
+++ b/services/agent/agentserver/credential_ref_test.go
@@ -237,7 +237,7 @@ func TestInitWarehouseProvider_AnUnreadableStoreRefusesANamedCredential(t *testi
 
 // mustSharedKey is sharedKey outside a test's scope, for table keys.
 func mustSharedKey(id string) string {
-	key, ok := gowarehouse.SharedCredentialKey(id)
+	key, ok := gowarehouse.SharedCredentialKey("test-capture-source", id)
 	if !ok {
 		panic("SharedCredentialKey refused " + id)
 	}
@@ -263,13 +263,48 @@ func TestInitWarehouseProvider_AnUnusableRefIsRefused(t *testing.T) {
 	}
 }
 
-// sharedKey composes the slot an id names, so a test seeds exactly where the
-// agent will look.
+// sharedKey composes the slot an id names for the capture stub, so a test seeds
+// exactly where the agent will look.
 func sharedKey(t *testing.T, id string) string {
 	t.Helper()
-	key, ok := gowarehouse.SharedCredentialKey(id)
+	key, ok := gowarehouse.SharedCredentialKey("test-capture-source", id)
 	if !ok {
 		t.Fatalf("SharedCredentialKey(%q) was refused", id)
 	}
 	return key
+}
+
+// A credential obtained for one provider must not be readable by another. Some
+// providers make that an exfiltration rather than a failure: Postgres reads
+// credentials_json as its password and host from config, so a datasource naming
+// an analytics connection's slot and an attacker's host would send that
+// connection's refresh token to it.
+func TestInitWarehouseProvider_ARefCannotReachAnotherProvidersCredential(t *testing.T) {
+	otherProvidersSlot, ok := gowarehouse.SharedCredentialKey("some-other-source", "conn-1")
+	if !ok {
+		t.Fatal("SharedCredentialKey refused a plain consumer and id")
+	}
+	secrets := &fakeSecretProvider{store: map[string]string{
+		"p1/" + otherProvidersSlot: "the-other-connections-grant",
+	}}
+	project := &models.Project{
+		ID: "p1",
+		Warehouses: []models.WarehouseConfig{{
+			ID: "wh_1", Provider: "test-capture-source",
+			Config: map[string]string{gowarehouse.CredentialRefKey: "conn-1"},
+		}},
+	}
+	capturedMu.Lock()
+	captured = nil
+	capturedMu.Unlock()
+
+	if _, err := initWarehouseProvider(context.Background(), project, "wh_1", secrets, "p1"); err == nil {
+		t.Fatal("a data source reached a credential obtained for another provider")
+	}
+	capturedMu.Lock()
+	got := captured
+	capturedMu.Unlock()
+	if got != nil {
+		t.Fatalf("the provider was built with %v", got)
+	}
 }

--- a/services/agent/agentserver/credential_ref_test.go
+++ b/services/agent/agentserver/credential_ref_test.go
@@ -2,6 +2,7 @@ package agentserver
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -86,11 +87,11 @@ func TestInitWarehouseProvider_NoStoredCredentialIsNotAnError(t *testing.T) {
 // no single datasource, read by whichever datasource names it.
 func TestInitWarehouseProvider_ReadsTheNamedCredentialWhenSet(t *testing.T) {
 	secrets := &fakeSecretProvider{store: map[string]string{
-		"p1/connector-refresh-token-abc":           "the-shared-grant",
+		"p1/" + sharedKey(t, "abc"):                "the-shared-grant",
 		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
 	}}
 
-	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}, secrets)
+	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "abc"}, secrets)
 	if cfg["credentials_json"] != "the-shared-grant" {
 		t.Fatalf("credentials_json = %q, want the credential the ref names", cfg["credentials_json"])
 	}
@@ -100,13 +101,13 @@ func TestInitWarehouseProvider_ReadsTheNamedCredentialWhenSet(t *testing.T) {
 // whole reason the ref exists, and what a derived key cannot do.
 func TestInitWarehouseProvider_TwoDatasourcesCanShareOneCredential(t *testing.T) {
 	secrets := &fakeSecretProvider{store: map[string]string{
-		"p1/connector-refresh-token-abc": "the-shared-grant",
+		"p1/" + sharedKey(t, "abc"): "the-shared-grant",
 	}}
 	project := &models.Project{
 		ID: "p1",
 		Warehouses: []models.WarehouseConfig{
-			{ID: "wh_1", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}},
-			{ID: "wh_2", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}},
+			{ID: "wh_1", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: "abc"}},
+			{ID: "wh_2", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: "abc"}},
 		},
 	}
 	for _, id := range []string{"wh_1", "wh_2"} {
@@ -141,28 +142,60 @@ func TestInitWarehouseProvider_AnEmptyRefFallsBackToTheDerivedKey(t *testing.T) 
 // business than the derived key it replaces. Leaving it in the config would also
 // let a provider treat it as one of its own fields.
 func TestInitWarehouseProvider_TheRefIsNotPassedToTheProvider(t *testing.T) {
-	secrets := &fakeSecretProvider{store: map[string]string{"p1/connector-refresh-token-abc": "grant"}}
-	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "connector-refresh-token-abc"}, secrets)
+	secrets := &fakeSecretProvider{store: map[string]string{"p1/" + sharedKey(t, "abc"): "grant"}}
+	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "abc"}, secrets)
 	if v, present := cfg[gowarehouse.CredentialRefKey]; present {
 		t.Fatalf("the provider was handed %s = %q", gowarehouse.CredentialRefKey, v)
 	}
 }
 
-// A ref outside the secret backends' alphabet cannot name a key this system
-// wrote, and reading it would fail at the cloud provider in a way nobody can
-// diagnose. Refusing beats falling back to the derived key, which would look
-// like a working connection authenticating as something else.
+// The ref is an id composed INTO a key, not a key. That is what stops a
+// datasource config — writable by anyone who can edit the project — from naming
+// another secret the project holds, and the read must land in the shared
+// namespace whatever the id looks like.
+func TestInitWarehouseProvider_ARefCannotNameAnotherProjectSecret(t *testing.T) {
+	secrets := &fakeSecretProvider{store: map[string]string{
+		"p1/llm-credentials":                       "the-llm-secret",
+		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
+	}}
+
+	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "llm-credentials"}, secrets)
+	if got := cfg["credentials_json"]; got == "the-llm-secret" {
+		t.Fatal("a data source read another feature's credential by naming its key")
+	}
+	// And it does not silently fall back to the derived one either: the ref was
+	// honoured, it just named a slot that does not exist.
+	if got := cfg["credentials_json"]; got == "the-derived-credential" {
+		t.Fatal("a ref that named nothing fell back to the derived key")
+	}
+}
+
+// An id no key can be formed from is refused rather than falling back to the
+// derived key, which would look like a working connection authenticating as
+// something else.
 func TestInitWarehouseProvider_AnUnusableRefIsRefused(t *testing.T) {
 	secrets := &fakeSecretProvider{store: map[string]string{
 		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
 	}}
-	for _, ref := range []string{"../other", "Has-Capitals", "under_score", "with:colon", "with/slash"} {
-		project := &models.Project{
-			ID:         "p1",
-			Warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: "test-capture-source", Config: map[string]string{gowarehouse.CredentialRefKey: ref}}},
-		}
-		if _, err := initWarehouseProvider(context.Background(), project, "wh_1", secrets, "p1"); err == nil {
-			t.Errorf("ref %q was accepted", ref)
-		}
+	project := &models.Project{
+		ID: "p1",
+		Warehouses: []models.WarehouseConfig{{
+			ID: "wh_1", Provider: "test-capture-source",
+			Config: map[string]string{gowarehouse.CredentialRefKey: strings.Repeat("a", 200)},
+		}},
 	}
+	if _, err := initWarehouseProvider(context.Background(), project, "wh_1", secrets, "p1"); err == nil {
+		t.Error("an id no key can be formed from was accepted")
+	}
+}
+
+// sharedKey composes the slot an id names, so a test seeds exactly where the
+// agent will look.
+func sharedKey(t *testing.T, id string) string {
+	t.Helper()
+	key, ok := gowarehouse.SharedCredentialKey(id)
+	if !ok {
+		t.Fatalf("SharedCredentialKey(%q) was refused", id)
+	}
+	return key
 }

--- a/services/agent/agentserver/credential_ref_test.go
+++ b/services/agent/agentserver/credential_ref_test.go
@@ -1,0 +1,83 @@
+package agentserver
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+	"github.com/decisionbox-io/decisionbox/services/agent/internal/models"
+)
+
+// capturedConfig is the config the last construction of the capture stub saw.
+// initWarehouseProvider builds the provider for every discovery run, ask turn,
+// schema index and connection test in the product, so what it hands the factory
+// is the thing worth pinning.
+var (
+	capturedMu sync.Mutex
+	captured   gowarehouse.ProviderConfig
+)
+
+func init() {
+	gowarehouse.RegisterWithMeta("test-capture-source",
+		func(cfg gowarehouse.ProviderConfig) (gowarehouse.Provider, error) {
+			capturedMu.Lock()
+			captured = cfg
+			capturedMu.Unlock()
+			return nil, nil
+		},
+		gowarehouse.ProviderMeta{
+			Name:       "Capture test source",
+			Capability: gowarehouse.Capability{Shape: gowarehouse.ShapeCube},
+		})
+}
+
+// buildWith runs initWarehouseProvider over a one-datasource project and returns
+// the config the factory received. Construction itself returns a nil provider,
+// which surfaces as an error the caller ignores — the config is what is under
+// test.
+func buildWith(t *testing.T, cfg map[string]string, secrets *fakeSecretProvider) gowarehouse.ProviderConfig {
+	t.Helper()
+	capturedMu.Lock()
+	captured = nil
+	capturedMu.Unlock()
+
+	project := &models.Project{
+		ID:         "p1",
+		Warehouses: []models.WarehouseConfig{{ID: "wh_1", Provider: "test-capture-source", Config: cfg}},
+	}
+	_, _ = initWarehouseProvider(context.Background(), project, "wh_1", secrets, "p1") //nolint:errcheck // the stub factory returns nil; the config is the assertion
+
+	capturedMu.Lock()
+	defer capturedMu.Unlock()
+	return captured
+}
+
+// Characterization: with no credential_ref, the credential comes from the key
+// derived from the datasource id — which is every datasource that exists today.
+// This must not change.
+func TestInitWarehouseProvider_DerivesTheCredentialKeyFromTheDatasourceID(t *testing.T) {
+	secrets := &fakeSecretProvider{store: map[string]string{
+		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
+	}}
+
+	cfg := buildWith(t, nil, secrets)
+	if cfg == nil {
+		t.Fatal("the provider factory was never reached")
+	}
+	if cfg["credentials_json"] != "the-derived-credential" {
+		t.Fatalf("credentials_json = %q, want the value under the derived key", cfg["credentials_json"])
+	}
+}
+
+// A datasource with no stored credential still constructs: the provider reports
+// what it needs in its own words, which is a better message than anything here.
+func TestInitWarehouseProvider_NoStoredCredentialIsNotAnError(t *testing.T) {
+	cfg := buildWith(t, nil, &fakeSecretProvider{store: map[string]string{}})
+	if cfg == nil {
+		t.Fatal("the provider factory was never reached")
+	}
+	if _, present := cfg["credentials_json"]; present {
+		t.Fatalf("credentials_json = %q, want it absent", cfg["credentials_json"])
+	}
+}

--- a/services/agent/agentserver/credential_ref_test.go
+++ b/services/agent/agentserver/credential_ref_test.go
@@ -2,6 +2,7 @@ package agentserver
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -151,23 +152,96 @@ func TestInitWarehouseProvider_TheRefIsNotPassedToTheProvider(t *testing.T) {
 
 // The ref is an id composed INTO a key, not a key. That is what stops a
 // datasource config — writable by anyone who can edit the project — from naming
-// another secret the project holds, and the read must land in the shared
-// namespace whatever the id looks like.
+// another secret the project holds.
 func TestInitWarehouseProvider_ARefCannotNameAnotherProjectSecret(t *testing.T) {
 	secrets := &fakeSecretProvider{store: map[string]string{
 		"p1/llm-credentials":                       "the-llm-secret",
 		"p1/" + gowarehouse.CredentialsKey("wh_1"): "the-derived-credential",
 	}}
+	project := &models.Project{
+		ID: "p1",
+		Warehouses: []models.WarehouseConfig{{
+			ID: "wh_1", Provider: "test-capture-source",
+			Config: map[string]string{gowarehouse.CredentialRefKey: "llm-credentials"},
+		}},
+	}
 
-	cfg := buildWith(t, map[string]string{gowarehouse.CredentialRefKey: "llm-credentials"}, secrets)
-	if got := cfg["credentials_json"]; got == "the-llm-secret" {
-		t.Fatal("a data source read another feature's credential by naming its key")
+	capturedMu.Lock()
+	captured = nil
+	capturedMu.Unlock()
+
+	// The id names a slot inside the shared namespace, which is empty — so this
+	// is refused rather than reaching the provider at all.
+	_, err := initWarehouseProvider(context.Background(), project, "wh_1", secrets, "p1")
+	if err == nil {
+		t.Fatal("a data source naming another feature's credential key was accepted")
 	}
-	// And it does not silently fall back to the derived one either: the ref was
-	// honoured, it just named a slot that does not exist.
-	if got := cfg["credentials_json"]; got == "the-derived-credential" {
-		t.Fatal("a ref that named nothing fell back to the derived key")
+	capturedMu.Lock()
+	got := captured
+	capturedMu.Unlock()
+	if got != nil {
+		t.Fatalf("the provider was built anyway, with %v", got)
 	}
+}
+
+// A datasource that NAMES a credential and does not get one is not a datasource
+// without one. Some providers read an empty credential as "use the ambient
+// identity" — BigQuery falls back to application-default credentials — so a
+// typo'd or deleted ref would run as the agent's own service account against a
+// project the customer chose.
+func TestInitWarehouseProvider_AnUnresolvableRefRefusesRatherThanFallBack(t *testing.T) {
+	for name, store := range map[string]map[string]string{
+		"absent": {},
+		"empty":  {"p1/" + mustSharedKey("conn-1"): ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			project := &models.Project{
+				ID: "p1",
+				Warehouses: []models.WarehouseConfig{{
+					ID: "wh_1", Provider: "test-capture-source",
+					Config: map[string]string{gowarehouse.CredentialRefKey: "conn-1"},
+				}},
+			}
+			capturedMu.Lock()
+			captured = nil
+			capturedMu.Unlock()
+
+			if _, err := initWarehouseProvider(context.Background(), project, "wh_1", &fakeSecretProvider{store: store}, "p1"); err == nil {
+				t.Fatal("an unresolvable shared credential was accepted")
+			}
+			capturedMu.Lock()
+			got := captured
+			capturedMu.Unlock()
+			if got != nil {
+				t.Fatalf("the provider was built with no credential: %v", got)
+			}
+		})
+	}
+}
+
+// A secret store that cannot be read is not a store that said "no such
+// credential" either, and both end the same way for a datasource that named one.
+func TestInitWarehouseProvider_AnUnreadableStoreRefusesANamedCredential(t *testing.T) {
+	project := &models.Project{
+		ID: "p1",
+		Warehouses: []models.WarehouseConfig{{
+			ID: "wh_1", Provider: "test-capture-source",
+			Config: map[string]string{gowarehouse.CredentialRefKey: "conn-1"},
+		}},
+	}
+	secrets := &fakeSecretProvider{getErr: errors.New("secret store unavailable")}
+	if _, err := initWarehouseProvider(context.Background(), project, "wh_1", secrets, "p1"); err == nil {
+		t.Fatal("an unreadable store was accepted for a datasource that names a credential")
+	}
+}
+
+// mustSharedKey is sharedKey outside a test's scope, for table keys.
+func mustSharedKey(id string) string {
+	key, ok := gowarehouse.SharedCredentialKey(id)
+	if !ok {
+		panic("SharedCredentialKey refused " + id)
+	}
+	return key
 }
 
 // An id no key can be formed from is refused rather than falling back to the

--- a/services/agent/agentserver/oauth_app_registration_test.go
+++ b/services/agent/agentserver/oauth_app_registration_test.go
@@ -293,3 +293,39 @@ func TestApplyOAuthAppRegistration_AThreeLeggedMethodWithNoAuthorizationIsAnErro
 		t.Fatal("a three-legged method with no authorization block was accepted")
 	}
 }
+
+// A datasource saved while its provider offered exactly one method stored no
+// choice, and the method resolves to the one it can only have been. The provider
+// factory switches on the config's own auth_method, though, so leaving it empty
+// would have this function and the provider disagree about how the datasource
+// authenticates.
+func TestApplyOAuthAppRegistration_RecordsAnInferredMethod(t *testing.T) {
+	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
+	sp := appSecrets(t, oauthProvider, map[string]string{oauthreg.FieldClientID: "cid"})
+
+	cfg := gowarehouse.ProviderConfig{} // saved before the provider offered a choice
+	if err := applyOAuthAppRegistration(context.Background(), sp, slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if cfg["auth_method"] != "oauth_user" {
+		t.Errorf("auth_method = %q, want the method this resolved to", cfg["auth_method"])
+	}
+	if cfg[oauthreg.ConfigKey(oauthreg.FieldClientID)] != "cid" {
+		t.Error("the registration was not applied to the inferred method")
+	}
+}
+
+// A datasource whose method is a static one keeps it: nothing is inferred, and
+// nothing is rewritten.
+func TestApplyOAuthAppRegistration_LeavesARecordedMethodAlone(t *testing.T) {
+	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "sa_key"}, threeLegged("oauth_user"))
+	sp := appSecrets(t, oauthProvider, map[string]string{oauthreg.FieldClientID: "cid"})
+
+	cfg := gowarehouse.ProviderConfig{"auth_method": "sa_key"}
+	if err := applyOAuthAppRegistration(context.Background(), sp, slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if cfg["auth_method"] != "sa_key" {
+		t.Errorf("auth_method = %q, want it untouched", cfg["auth_method"])
+	}
+}

--- a/services/agent/agentserver/oauth_app_registration_test.go
+++ b/services/agent/agentserver/oauth_app_registration_test.go
@@ -1,0 +1,156 @@
+package agentserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
+)
+
+// registerAuthFlowProvider publishes a provider whose only purpose is to
+// declare an auth method of the given flow. The factory is never called —
+// applyOAuthAppRegistration reads metadata and nothing else.
+func registerAuthFlowProvider(t *testing.T, slug string, methods ...gowarehouse.AuthMethod) {
+	t.Helper()
+	gowarehouse.RegisterWithMeta(slug,
+		func(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) {
+			t.Fatal("the provider factory should not run here")
+			return nil, nil
+		},
+		gowarehouse.ProviderMeta{Name: slug, AuthMethods: methods},
+	)
+}
+
+func threeLegged(id string) gowarehouse.AuthMethod {
+	return gowarehouse.AuthMethod{
+		ID: id, Flow: gowarehouse.FlowAuthorizationCode,
+		Authorization: &gowarehouse.AuthorizationCode{
+			AuthURL: "https://accounts.example/auth", TokenURL: "https://oauth.example/token",
+			Scopes: []string{"example.readonly"},
+		},
+	}
+}
+
+func appSecrets(t *testing.T, slug string, fields map[string]string) *fakeSecretProvider {
+	t.Helper()
+	sp := &fakeSecretProvider{store: map[string]string{}}
+	for f, v := range fields {
+		sp.store["/"+gowarehouse.OAuthAppKey(slug, f)] = v
+	}
+	return sp
+}
+
+// The refresh token stored as the datasource's credential cannot mint an
+// access token without the client that issued it, and that client is
+// registered per deployment rather than per datasource — so it has to be
+// added here or the provider has half a credential.
+func TestApplyOAuthAppRegistration_AddsTheDeploymentsClient(t *testing.T) {
+	const slug = "test-oauth-provider"
+	registerAuthFlowProvider(t, slug, threeLegged("oauth_user"))
+	sp := appSecrets(t, slug, map[string]string{
+		gowarehouse.OAuthFieldClientID:     "cid",
+		gowarehouse.OAuthFieldClientSecret: "sec",
+		gowarehouse.OAuthFieldRedirectURI:  "https://dash.example",
+	})
+
+	cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
+	if err := applyOAuthAppRegistration(context.Background(), sp, slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	want := map[string]string{
+		gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientID):     "cid",
+		gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientSecret): "sec",
+		gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldRedirectURI):  "https://dash.example",
+	}
+	for k, v := range want {
+		if cfg[k] != v {
+			t.Errorf("cfg[%q] = %q, want %q", k, cfg[k], v)
+		}
+	}
+}
+
+// Every other datasource in a deployment authenticates with a key or a
+// password. Reading an OAuth registration for those would be a secret lookup
+// per provider construction that can only ever come back empty.
+func TestApplyOAuthAppRegistration_LeavesAStaticMethodAlone(t *testing.T) {
+	const slug = "test-static-provider"
+	registerAuthFlowProvider(t, slug, gowarehouse.AuthMethod{ID: "sa_key"})
+	sp := appSecrets(t, slug, map[string]string{gowarehouse.OAuthFieldClientID: "cid"})
+
+	cfg := gowarehouse.ProviderConfig{"auth_method": "sa_key"}
+	if err := applyOAuthAppRegistration(context.Background(), sp, slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(cfg) != 1 {
+		t.Errorf("a static method's config was added to: %v", cfg)
+	}
+}
+
+// A provider offering both methods must be read from what the datasource
+// selected, not from what the provider is capable of. Answering from the
+// provider would inject an OAuth client into a key-authenticated datasource
+// and, worse, skip it for an OAuth one on a provider whose first method is a
+// key.
+func TestApplyOAuthAppRegistration_ReadsTheSelectedMethodNotTheProvider(t *testing.T) {
+	const slug = "test-either-provider"
+	registerAuthFlowProvider(t, slug, gowarehouse.AuthMethod{ID: "sa_key"}, threeLegged("oauth_user"))
+	fields := map[string]string{gowarehouse.OAuthFieldClientID: "cid"}
+	clientIDKey := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientID)
+
+	onKey := gowarehouse.ProviderConfig{"auth_method": "sa_key"}
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, fields), slug, onKey); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, added := onKey[clientIDKey]; added {
+		t.Error("a key-authenticated datasource on a provider that also offers OAuth got an OAuth client")
+	}
+
+	onOAuth := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, fields), slug, onOAuth); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if onOAuth[clientIDKey] != "cid" {
+		t.Error("an OAuth datasource on a provider whose first method is a key got no OAuth client")
+	}
+}
+
+// An unset field means the operator has not registered the app. The provider
+// says so in its own words, naming what it needs; a secret-store detail
+// surfaced here would not.
+func TestApplyOAuthAppRegistration_AnUnregisteredAppIsNotAnError(t *testing.T) {
+	const slug = "test-unregistered-provider"
+	registerAuthFlowProvider(t, slug, threeLegged("oauth_user"))
+
+	cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, nil), slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(cfg) != 1 {
+		t.Errorf("nothing was registered, yet config gained entries: %v", cfg)
+	}
+}
+
+// A secret store that cannot be read has not said the field is empty. Treating
+// the two alike would report a configured deployment as unconfigured and send
+// an operator to re-enter credentials that are already stored.
+func TestApplyOAuthAppRegistration_AnUnreadableStoreIsAnError(t *testing.T) {
+	const slug = "test-broken-store-provider"
+	registerAuthFlowProvider(t, slug, threeLegged("oauth_user"))
+	sp := &fakeSecretProvider{getErr: errors.New("secret store unavailable")}
+
+	err := applyOAuthAppRegistration(context.Background(), sp, slug, gowarehouse.ProviderConfig{"auth_method": "oauth_user"})
+	if err == nil {
+		t.Fatal("an unreadable secret store was reported as an unregistered app")
+	}
+}
+
+// An unregistered slug is reported by NewProvider, which has the name and the
+// list of what is registered. Failing earlier here would replace that with a
+// worse message.
+func TestApplyOAuthAppRegistration_AnUnknownProviderIsLeftToNewProvider(t *testing.T) {
+	cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
+	if err := applyOAuthAppRegistration(context.Background(), &fakeSecretProvider{}, "nope-not-registered", cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+}

--- a/services/agent/agentserver/oauth_app_registration_test.go
+++ b/services/agent/agentserver/oauth_app_registration_test.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/decisionbox-io/decisionbox/libs/go-common/oauthreg"
 	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 )
 
@@ -36,21 +37,32 @@ func registerAuthFlowProvider(t *testing.T, methods ...gowarehouse.AuthMethod) s
 	return slug
 }
 
+// oauthProvider is the OAuth provider the stub methods authenticate against.
+// The registration is keyed by this, not by the datasource slug — which is the
+// whole point of the scheme, and what lets two datasource providers share one
+// registered client.
+const oauthProvider = "example-idp"
+
 func threeLegged(id string) gowarehouse.AuthMethod {
+	return threeLeggedFor(id, oauthProvider)
+}
+
+func threeLeggedFor(id, provider string) gowarehouse.AuthMethod {
 	return gowarehouse.AuthMethod{
 		ID: id, Flow: gowarehouse.FlowAuthorizationCode,
 		Authorization: &gowarehouse.AuthorizationCode{
-			AuthURL: "https://accounts.example/auth", TokenURL: "https://oauth.example/token",
+			Provider: provider,
+			AuthURL:  "https://accounts.example/auth", TokenURL: "https://oauth.example/token",
 			Scopes: []string{"example.readonly"},
 		},
 	}
 }
 
-func appSecrets(t *testing.T, slug string, fields map[string]string) *fakeSecretProvider {
+func appSecrets(t *testing.T, provider string, fields map[string]string) *fakeSecretProvider {
 	t.Helper()
 	sp := &fakeSecretProvider{store: map[string]string{}}
 	for f, v := range fields {
-		sp.store["/"+gowarehouse.OAuthAppKey(slug, f)] = v
+		sp.store["/"+oauthreg.Key(provider, f)] = v
 	}
 	return sp
 }
@@ -61,10 +73,10 @@ func appSecrets(t *testing.T, slug string, fields map[string]string) *fakeSecret
 // added here or the provider has half a credential.
 func TestApplyOAuthAppRegistration_AddsTheDeploymentsClient(t *testing.T) {
 	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
-	sp := appSecrets(t, slug, map[string]string{
-		gowarehouse.OAuthFieldClientID:     "cid",
-		gowarehouse.OAuthFieldClientSecret: "sec",
-		gowarehouse.OAuthFieldRedirectURI:  "https://dash.example",
+	sp := appSecrets(t, oauthProvider, map[string]string{
+		oauthreg.FieldClientID:     "cid",
+		oauthreg.FieldClientSecret: "sec",
+		oauthreg.FieldRedirectURI:  "https://dash.example",
 	})
 
 	cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
@@ -72,9 +84,9 @@ func TestApplyOAuthAppRegistration_AddsTheDeploymentsClient(t *testing.T) {
 		t.Fatalf("apply: %v", err)
 	}
 	want := map[string]string{
-		gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientID):     "cid",
-		gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientSecret): "sec",
-		gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldRedirectURI):  "https://dash.example",
+		oauthreg.ConfigKey(oauthreg.FieldClientID):     "cid",
+		oauthreg.ConfigKey(oauthreg.FieldClientSecret): "sec",
+		oauthreg.ConfigKey(oauthreg.FieldRedirectURI):  "https://dash.example",
 	}
 	for k, v := range want {
 		if cfg[k] != v {
@@ -88,7 +100,7 @@ func TestApplyOAuthAppRegistration_AddsTheDeploymentsClient(t *testing.T) {
 // per provider construction that can only ever come back empty.
 func TestApplyOAuthAppRegistration_LeavesAStaticMethodAlone(t *testing.T) {
 	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "sa_key"})
-	sp := appSecrets(t, slug, map[string]string{gowarehouse.OAuthFieldClientID: "cid"})
+	sp := appSecrets(t, oauthProvider, map[string]string{oauthreg.FieldClientID: "cid"})
 
 	cfg := gowarehouse.ProviderConfig{"auth_method": "sa_key"}
 	if err := applyOAuthAppRegistration(context.Background(), sp, slug, cfg); err != nil {
@@ -106,11 +118,11 @@ func TestApplyOAuthAppRegistration_LeavesAStaticMethodAlone(t *testing.T) {
 // key.
 func TestApplyOAuthAppRegistration_ReadsTheSelectedMethodNotTheProvider(t *testing.T) {
 	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "sa_key"}, threeLegged("oauth_user"))
-	fields := map[string]string{gowarehouse.OAuthFieldClientID: "cid"}
-	clientIDKey := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientID)
+	fields := map[string]string{oauthreg.FieldClientID: "cid"}
+	clientIDKey := oauthreg.ConfigKey(oauthreg.FieldClientID)
 
 	onKey := gowarehouse.ProviderConfig{"auth_method": "sa_key"}
-	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, fields), slug, onKey); err != nil {
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, oauthProvider, fields), slug, onKey); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	if _, added := onKey[clientIDKey]; added {
@@ -118,7 +130,7 @@ func TestApplyOAuthAppRegistration_ReadsTheSelectedMethodNotTheProvider(t *testi
 	}
 
 	onOAuth := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
-	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, fields), slug, onOAuth); err != nil {
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, oauthProvider, fields), slug, onOAuth); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	if onOAuth[clientIDKey] != "cid" {
@@ -133,7 +145,7 @@ func TestApplyOAuthAppRegistration_AnUnregisteredAppIsNotAnError(t *testing.T) {
 	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
 
 	cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
-	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, nil), slug, cfg); err != nil {
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, oauthProvider, nil), slug, cfg); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	if len(cfg) != 1 {
@@ -171,8 +183,8 @@ func TestApplyOAuthAppRegistration_AnUnknownProviderIsLeftToNewProvider(t *testi
 // per-project one and the separation would be worth nothing.
 func TestApplyOAuthAppRegistration_ProjectSuppliedClientFieldsNeverSurvive(t *testing.T) {
 	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
-	clientID := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientID)
-	clientSecret := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientSecret)
+	clientID := oauthreg.ConfigKey(oauthreg.FieldClientID)
+	clientSecret := oauthreg.ConfigKey(oauthreg.FieldClientSecret)
 
 	// Nothing registered: the project's own values must not stand in for it.
 	cfg := gowarehouse.ProviderConfig{
@@ -180,7 +192,7 @@ func TestApplyOAuthAppRegistration_ProjectSuppliedClientFieldsNeverSurvive(t *te
 		clientID:      "from-the-project-document",
 		clientSecret:  "and-a-secret-with-it",
 	}
-	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, nil), slug, cfg); err != nil {
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, oauthProvider, nil), slug, cfg); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	for _, k := range []string{clientID, clientSecret} {
@@ -191,7 +203,7 @@ func TestApplyOAuthAppRegistration_ProjectSuppliedClientFieldsNeverSurvive(t *te
 
 	// Registered: the deployment's value is what the provider sees.
 	cfg = gowarehouse.ProviderConfig{"auth_method": "oauth_user", clientID: "from-the-project-document"}
-	registered := appSecrets(t, slug, map[string]string{gowarehouse.OAuthFieldClientID: "the-deployments"})
+	registered := appSecrets(t, oauthProvider, map[string]string{oauthreg.FieldClientID: "the-deployments"})
 	if err := applyOAuthAppRegistration(context.Background(), registered, slug, cfg); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
@@ -206,13 +218,78 @@ func TestApplyOAuthAppRegistration_ProjectSuppliedClientFieldsNeverSurvive(t *te
 // worth not having.
 func TestApplyOAuthAppRegistration_TheNamespaceIsClearedForEveryMethod(t *testing.T) {
 	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "sa_key"})
-	clientSecret := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientSecret)
+	clientSecret := oauthreg.ConfigKey(oauthreg.FieldClientSecret)
 
 	cfg := gowarehouse.ProviderConfig{"auth_method": "sa_key", clientSecret: "from-the-project-document"}
-	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, nil), slug, cfg); err != nil {
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, oauthProvider, nil), slug, cfg); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	if _, present := cfg[clientSecret]; present {
 		t.Error("a project-supplied client secret survived on a key-authenticated datasource")
+	}
+}
+
+// The reason the registration is keyed by the OAuth provider rather than by the
+// datasource slug: a customer who registers one Google client uses it for every
+// datasource that authenticates against Google, and never registers a second.
+func TestApplyOAuthAppRegistration_TwoDatasourcesShareOneRegistration(t *testing.T) {
+	first := registerAuthFlowProvider(t, threeLeggedFor("oauth_user", "shared-idp"))
+	second := registerAuthFlowProvider(t, threeLeggedFor("oauth_user", "shared-idp"))
+	sp := appSecrets(t, "shared-idp", map[string]string{oauthreg.FieldClientID: "one-client"})
+	clientID := oauthreg.ConfigKey(oauthreg.FieldClientID)
+
+	for _, slug := range []string{first, second} {
+		cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
+		if err := applyOAuthAppRegistration(context.Background(), sp, slug, cfg); err != nil {
+			t.Fatalf("apply for %s: %v", slug, err)
+		}
+		if cfg[clientID] != "one-client" {
+			t.Errorf("%s read cfg[%q] = %q, want the one registered client", slug, clientID, cfg[clientID])
+		}
+	}
+}
+
+// A registration keyed by one provider must not answer for another, or
+// registering the second would overwrite the client the first one's grants were
+// issued against and break every connection made with it.
+func TestApplyOAuthAppRegistration_AnotherProvidersRegistrationDoesNotAnswer(t *testing.T) {
+	slug := registerAuthFlowProvider(t, threeLeggedFor("oauth_user", "idp-a"))
+	sp := appSecrets(t, "idp-b", map[string]string{oauthreg.FieldClientID: "b-client"})
+
+	cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
+	if err := applyOAuthAppRegistration(context.Background(), sp, slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if v, present := cfg[oauthreg.ConfigKey(oauthreg.FieldClientID)]; present {
+		t.Errorf("another provider's client %q was injected", v)
+	}
+}
+
+// A three-legged method that names no OAuth provider has no registration to
+// look up, so it can never mint a token. That is a declaration error in the
+// registry, and it is worth saying so rather than letting the provider report a
+// generic "not configured" that no operator can act on.
+func TestApplyOAuthAppRegistration_AThreeLeggedMethodWithNoProviderIsAnError(t *testing.T) {
+	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{
+		ID: "oauth_user", Flow: gowarehouse.FlowAuthorizationCode,
+		Authorization: &gowarehouse.AuthorizationCode{
+			AuthURL: "https://accounts.example/auth", TokenURL: "https://oauth.example/token",
+		},
+	})
+
+	err := applyOAuthAppRegistration(context.Background(), &fakeSecretProvider{store: map[string]string{}}, slug, gowarehouse.ProviderConfig{"auth_method": "oauth_user"})
+	if err == nil {
+		t.Fatal("a three-legged method with no OAuth provider was accepted")
+	}
+}
+
+// Same, for a method that declares the flow but carries no Authorization block
+// at all.
+func TestApplyOAuthAppRegistration_AThreeLeggedMethodWithNoAuthorizationIsAnError(t *testing.T) {
+	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "oauth_user", Flow: gowarehouse.FlowAuthorizationCode})
+
+	err := applyOAuthAppRegistration(context.Background(), &fakeSecretProvider{store: map[string]string{}}, slug, gowarehouse.ProviderConfig{"auth_method": "oauth_user"})
+	if err == nil {
+		t.Fatal("a three-legged method with no authorization block was accepted")
 	}
 }

--- a/services/agent/agentserver/oauth_app_registration_test.go
+++ b/services/agent/agentserver/oauth_app_registration_test.go
@@ -163,3 +163,56 @@ func TestApplyOAuthAppRegistration_AnUnknownProviderIsLeftToNewProvider(t *testi
 		t.Fatalf("apply: %v", err)
 	}
 }
+
+// The oauth_app_* namespace belongs to the deployment. A project document that
+// carries a value in it — written before the datasource routes reserved the
+// namespace, or by anything else that writes project documents — must not
+// reach a provider, or a missing app registration would hide behind a stale
+// per-project one and the separation would be worth nothing.
+func TestApplyOAuthAppRegistration_ProjectSuppliedClientFieldsNeverSurvive(t *testing.T) {
+	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
+	clientID := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientID)
+	clientSecret := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientSecret)
+
+	// Nothing registered: the project's own values must not stand in for it.
+	cfg := gowarehouse.ProviderConfig{
+		"auth_method": "oauth_user",
+		clientID:      "from-the-project-document",
+		clientSecret:  "and-a-secret-with-it",
+	}
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, nil), slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, k := range []string{clientID, clientSecret} {
+		if v, present := cfg[k]; present {
+			t.Errorf("cfg[%q] = %q survived from the project document", k, v)
+		}
+	}
+
+	// Registered: the deployment's value is what the provider sees.
+	cfg = gowarehouse.ProviderConfig{"auth_method": "oauth_user", clientID: "from-the-project-document"}
+	registered := appSecrets(t, slug, map[string]string{gowarehouse.OAuthFieldClientID: "the-deployments"})
+	if err := applyOAuthAppRegistration(context.Background(), registered, slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if cfg[clientID] != "the-deployments" {
+		t.Errorf("cfg[%q] = %q, want the deployment's registration", clientID, cfg[clientID])
+	}
+}
+
+// The namespace is cleared whatever the datasource authenticates with. A
+// key-authenticated source has no use for these fields, and leaving a
+// project-supplied value sitting in a namespace the platform owns is a state
+// worth not having.
+func TestApplyOAuthAppRegistration_TheNamespaceIsClearedForEveryMethod(t *testing.T) {
+	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "sa_key"})
+	clientSecret := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientSecret)
+
+	cfg := gowarehouse.ProviderConfig{"auth_method": "sa_key", clientSecret: "from-the-project-document"}
+	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, nil), slug, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, present := cfg[clientSecret]; present {
+		t.Error("a project-supplied client secret survived on a key-authenticated datasource")
+	}
+}

--- a/services/agent/agentserver/oauth_app_registration_test.go
+++ b/services/agent/agentserver/oauth_app_registration_test.go
@@ -3,16 +3,29 @@ package agentserver
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	gowarehouse "github.com/decisionbox-io/decisionbox/libs/go-common/warehouse"
 )
 
+// authFlowSlugSeq makes every registered stub distinct for the life of the
+// process.
+var authFlowSlugSeq atomic.Int64
+
 // registerAuthFlowProvider publishes a provider whose only purpose is to
-// declare an auth method of the given flow. The factory is never called —
-// applyOAuthAppRegistration reads metadata and nothing else.
-func registerAuthFlowProvider(t *testing.T, slug string, methods ...gowarehouse.AuthMethod) {
+// declare an auth method of the given flow, and returns its slug. The factory
+// is never called — applyOAuthAppRegistration reads metadata and nothing else.
+//
+// The slug is unique per registration because the registry is process-global
+// and panics on a duplicate: anything reused — including the test's own name,
+// which repeats under `go test -count=2` — turns a rerun into a panic with
+// nothing wrong in the code under test.
+func registerAuthFlowProvider(t *testing.T, methods ...gowarehouse.AuthMethod) string {
 	t.Helper()
+	slug := fmt.Sprintf("test-authflow-%d-%s", authFlowSlugSeq.Add(1), strings.ToLower(t.Name()))
 	gowarehouse.RegisterWithMeta(slug,
 		func(gowarehouse.ProviderConfig) (gowarehouse.Provider, error) {
 			t.Fatal("the provider factory should not run here")
@@ -20,6 +33,7 @@ func registerAuthFlowProvider(t *testing.T, slug string, methods ...gowarehouse.
 		},
 		gowarehouse.ProviderMeta{Name: slug, AuthMethods: methods},
 	)
+	return slug
 }
 
 func threeLegged(id string) gowarehouse.AuthMethod {
@@ -46,8 +60,7 @@ func appSecrets(t *testing.T, slug string, fields map[string]string) *fakeSecret
 // registered per deployment rather than per datasource — so it has to be
 // added here or the provider has half a credential.
 func TestApplyOAuthAppRegistration_AddsTheDeploymentsClient(t *testing.T) {
-	const slug = "test-oauth-provider"
-	registerAuthFlowProvider(t, slug, threeLegged("oauth_user"))
+	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
 	sp := appSecrets(t, slug, map[string]string{
 		gowarehouse.OAuthFieldClientID:     "cid",
 		gowarehouse.OAuthFieldClientSecret: "sec",
@@ -74,8 +87,7 @@ func TestApplyOAuthAppRegistration_AddsTheDeploymentsClient(t *testing.T) {
 // password. Reading an OAuth registration for those would be a secret lookup
 // per provider construction that can only ever come back empty.
 func TestApplyOAuthAppRegistration_LeavesAStaticMethodAlone(t *testing.T) {
-	const slug = "test-static-provider"
-	registerAuthFlowProvider(t, slug, gowarehouse.AuthMethod{ID: "sa_key"})
+	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "sa_key"})
 	sp := appSecrets(t, slug, map[string]string{gowarehouse.OAuthFieldClientID: "cid"})
 
 	cfg := gowarehouse.ProviderConfig{"auth_method": "sa_key"}
@@ -93,8 +105,7 @@ func TestApplyOAuthAppRegistration_LeavesAStaticMethodAlone(t *testing.T) {
 // and, worse, skip it for an OAuth one on a provider whose first method is a
 // key.
 func TestApplyOAuthAppRegistration_ReadsTheSelectedMethodNotTheProvider(t *testing.T) {
-	const slug = "test-either-provider"
-	registerAuthFlowProvider(t, slug, gowarehouse.AuthMethod{ID: "sa_key"}, threeLegged("oauth_user"))
+	slug := registerAuthFlowProvider(t, gowarehouse.AuthMethod{ID: "sa_key"}, threeLegged("oauth_user"))
 	fields := map[string]string{gowarehouse.OAuthFieldClientID: "cid"}
 	clientIDKey := gowarehouse.OAuthAppConfigKey(gowarehouse.OAuthFieldClientID)
 
@@ -119,8 +130,7 @@ func TestApplyOAuthAppRegistration_ReadsTheSelectedMethodNotTheProvider(t *testi
 // says so in its own words, naming what it needs; a secret-store detail
 // surfaced here would not.
 func TestApplyOAuthAppRegistration_AnUnregisteredAppIsNotAnError(t *testing.T) {
-	const slug = "test-unregistered-provider"
-	registerAuthFlowProvider(t, slug, threeLegged("oauth_user"))
+	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
 
 	cfg := gowarehouse.ProviderConfig{"auth_method": "oauth_user"}
 	if err := applyOAuthAppRegistration(context.Background(), appSecrets(t, slug, nil), slug, cfg); err != nil {
@@ -135,8 +145,7 @@ func TestApplyOAuthAppRegistration_AnUnregisteredAppIsNotAnError(t *testing.T) {
 // the two alike would report a configured deployment as unconfigured and send
 // an operator to re-enter credentials that are already stored.
 func TestApplyOAuthAppRegistration_AnUnreadableStoreIsAnError(t *testing.T) {
-	const slug = "test-broken-store-provider"
-	registerAuthFlowProvider(t, slug, threeLegged("oauth_user"))
+	slug := registerAuthFlowProvider(t, threeLegged("oauth_user"))
 	sp := &fakeSecretProvider{getErr: errors.New("secret store unavailable")}
 
 	err := applyOAuthAppRegistration(context.Background(), sp, slug, gowarehouse.ProviderConfig{"auth_method": "oauth_user"})

--- a/ui/dashboard/src/__tests__/WarehouseFormFields.test.tsx
+++ b/ui/dashboard/src/__tests__/WarehouseFormFields.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MantineProvider } from '@mantine/core';
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 import {
   WarehouseFormFields,
   WarehouseFormState,
@@ -106,16 +107,24 @@ function ControlledHarness({
   providers,
   initial,
   hasSavedCredential,
+  authorizationSlot,
 }: {
   providers: ProviderMeta[];
   initial: WarehouseFormState;
   hasSavedCredential?: boolean;
+  authorizationSlot?: ReactNode;
 }) {
   const [v, setV] = useState<WarehouseFormState>(initial);
   return (
     <MantineProvider>
       <div data-testid="state-dump">{JSON.stringify(v)}</div>
-      <WarehouseFormFields providers={providers} value={v} onChange={setV} hasSavedCredential={hasSavedCredential} />
+      <WarehouseFormFields
+        providers={providers}
+        value={v}
+        onChange={setV}
+        hasSavedCredential={hasSavedCredential}
+        authorizationSlot={authorizationSlot}
+      />
     </MantineProvider>
   );
 }
@@ -402,6 +411,36 @@ describe('three-legged auth methods', () => {
     );
     expect(screen.queryByLabelText(/Credentials JSON/)).not.toBeInTheDocument();
     expect(screen.getByText(/no credential to enter/i)).toBeInTheDocument();
+  });
+
+  // The notice is what a caller with nothing better to offer says. One that can
+  // collect the authorization on this form — an enterprise build with
+  // connections — passes its own affordance instead, and must not have both.
+  test('a caller\'s authorization slot replaces the explanation', () => {
+    render(
+      <ControlledHarness
+        providers={[consentMeta]}
+        initial={{ ...emptyWarehouseFormState(), provider: 'consent-source', authMethod: 'oauth_user' }}
+        authorizationSlot={<div>pick a connection</div>}
+      />,
+    );
+    expect(screen.getByText('pick a connection')).toBeInTheDocument();
+    expect(screen.queryByText(/no credential to enter/i)).not.toBeInTheDocument();
+  });
+
+  // The slot belongs to the three-legged branch, not to the form. A provider's
+  // static method still renders its own credential field, and the slot has no
+  // business appearing above it.
+  test('the slot is ignored by a method that has a credential to type', () => {
+    render(
+      <ControlledHarness
+        providers={[consentMeta]}
+        initial={{ ...emptyWarehouseFormState(), provider: 'consent-source', authMethod: 'sa_key' }}
+        authorizationSlot={<div>pick a connection</div>}
+      />,
+    );
+    expect(screen.queryByText('pick a connection')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Credentials JSON/)).toBeInTheDocument();
   });
 
   // The guard reads the selected method, not the provider. A provider offering

--- a/ui/dashboard/src/__tests__/WarehouseFormFields.test.tsx
+++ b/ui/dashboard/src/__tests__/WarehouseFormFields.test.tsx
@@ -72,6 +72,36 @@ const mssqlMeta: ProviderMeta = {
   ],
 };
 
+// A provider whose primary method is three-legged: no fields, because the
+// credential is the grant a consent screen produces. It also offers a static
+// method, so the two can be compared in the same form.
+const consentMeta: ProviderMeta = {
+  id: 'consent-source',
+  name: 'Consent Source',
+  description: 'A source authorized by signing in with the provider',
+  config_fields: [
+    { key: 'property_id', label: 'Property ID', required: true, type: 'string', placeholder: '', description: '', default: '', options: [] },
+  ],
+  auth_methods: [
+    {
+      id: 'oauth_user',
+      name: 'Sign in',
+      description: 'Authorize as a user',
+      fields: [],
+      flow: 'authorization_code',
+      authorization: { auth_url: 'https://accounts.example/auth', token_url: 'https://oauth.example/token', scopes: ['read'] },
+    },
+    {
+      id: 'sa_key',
+      name: 'Key',
+      description: 'A downloaded key',
+      fields: [
+        { key: 'credentials_json', label: 'Credentials JSON', required: true, type: 'credential', placeholder: '', description: '', default: '', options: [] },
+      ],
+    },
+  ],
+};
+
 function ControlledHarness({
   providers,
   initial,
@@ -355,5 +385,47 @@ describe('WarehouseFormFields — DynamicField textarea variant', () => {
     const ta = container.querySelector('textarea') as HTMLTextAreaElement;
     fireEvent.change(ta, { target: { value: 'host=db port=5432' } });
     expect(onChange).toHaveBeenCalledWith('host=db port=5432');
+  });
+});
+
+describe('three-legged auth methods', () => {
+  // The credential for a consent-based method does not exist until the user
+  // has signed in with the provider. A form rendered for it would be an empty
+  // box above a Save button, and saving would attach a data source that cannot
+  // authenticate — with nothing left blank to complain about.
+  test('renders an explanation instead of a credential field', () => {
+    render(
+      <ControlledHarness
+        providers={[consentMeta]}
+        initial={{ ...emptyWarehouseFormState(), provider: 'consent-source', authMethod: 'oauth_user' }}
+      />,
+    );
+    expect(screen.queryByLabelText(/Credentials JSON/)).not.toBeInTheDocument();
+    expect(screen.getByText(/no credential to enter/i)).toBeInTheDocument();
+  });
+
+  // The guard reads the selected method, not the provider. A provider offering
+  // both must still render the form for the one that has fields.
+  test('the provider\'s static method still renders its credential field', () => {
+    render(
+      <ControlledHarness
+        providers={[consentMeta]}
+        initial={{ ...emptyWarehouseFormState(), provider: 'consent-source', authMethod: 'sa_key' }}
+      />,
+    );
+    expect(screen.getByLabelText(/Credentials JSON/)).toBeInTheDocument();
+    expect(screen.queryByText(/no credential to enter/i)).not.toBeInTheDocument();
+  });
+
+  // Config fields belong to the provider, not to the auth method, so the
+  // source stays configurable while its authorization is a separate step.
+  test('provider config fields are unaffected', () => {
+    render(
+      <ControlledHarness
+        providers={[consentMeta]}
+        initial={{ ...emptyWarehouseFormState(), provider: 'consent-source', authMethod: 'oauth_user' }}
+      />,
+    );
+    expect(screen.getByLabelText(/Property ID/)).toBeInTheDocument();
   });
 });

--- a/ui/dashboard/src/__tests__/WarehouseFormFields.test.tsx
+++ b/ui/dashboard/src/__tests__/WarehouseFormFields.test.tsx
@@ -89,7 +89,7 @@ const consentMeta: ProviderMeta = {
       description: 'Authorize as a user',
       fields: [],
       flow: 'authorization_code',
-      authorization: { auth_url: 'https://accounts.example/auth', token_url: 'https://oauth.example/token', scopes: ['read'] },
+      authorization: { provider: 'example', auth_url: 'https://accounts.example/auth', token_url: 'https://oauth.example/token', scopes: ['read'] },
     },
     {
       id: 'sa_key',

--- a/ui/dashboard/src/components/projects/WarehouseFormFields.tsx
+++ b/ui/dashboard/src/components/projects/WarehouseFormFields.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { Alert, Group, Select, Stack, Text, TextInput, Textarea } from '@mantine/core';
 import { ConfigField, ProviderMeta } from '@/lib/api';
 
@@ -61,6 +62,11 @@ interface Props {
    *  Used by the settings/wizard variants where a credential may already
    *  be persisted. */
   hasSavedCredential?: boolean;
+  /** Rendered in place of the three-legged notice below, for a caller that
+   *  can offer the authorization here rather than after the save. The notice
+   *  is the honest answer only where nothing else is on offer, so a caller
+   *  that has something better passes it and this one steps aside. */
+  authorizationSlot?: ReactNode;
 }
 
 // WarehouseFormFields renders the warehouse provider selector and all
@@ -69,7 +75,7 @@ interface Props {
 // to `onChange` events. Used by:
 //   - projects/new/page.tsx       (Step 2 of the new-project wizard)
 //   - WarehouseConfigPanel.tsx    (settings tab + plugin-overlaid wizards)
-export function WarehouseFormFields({ providers, value, onChange, hasSavedCredential }: Props) {
+export function WarehouseFormFields({ providers, value, onChange, hasSavedCredential, authorizationSlot }: Props) {
   const selected = providers.find((p) => p.id === value.provider);
   const authMethods = selected?.auth_methods || [];
   const selectedAuth = authMethods.find((m) => m.id === value.authMethod);
@@ -80,7 +86,8 @@ export function WarehouseFormFields({ providers, value, onChange, hasSavedCreden
   // consent screen produces rather than anything a person can type. Rendering
   // the form for it would show an empty box and a Save button, and saving
   // would attach a data source that cannot authenticate — with no error, since
-  // nothing was left blank. Say so instead.
+  // nothing was left blank. Say so instead, or let the caller put its own
+  // authorization affordance there via authorizationSlot.
   const isAuthorizationCode = selectedAuth?.flow === 'authorization_code';
 
   const setProvider = (id: string) => {
@@ -133,14 +140,14 @@ export function WarehouseFormFields({ providers, value, onChange, hasSavedCreden
 
       {selectedAuth?.description && <Text size="xs" c="dimmed">{selectedAuth.description}</Text>}
 
-      {isAuthorizationCode && (
+      {isAuthorizationCode && (authorizationSlot ?? (
         <Alert color="blue" variant="light">
           <Text size="sm">
             This method has no credential to enter: you authorize {selected?.name || 'the provider'} by
             signing in with it, which is done from the data source itself once it has been saved.
           </Text>
         </Alert>
-      )}
+      ))}
 
       {!isAuthorizationCode && authConfigFields.map((field) => (
         <DynamicField

--- a/ui/dashboard/src/components/projects/WarehouseFormFields.tsx
+++ b/ui/dashboard/src/components/projects/WarehouseFormFields.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Group, Select, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import { Alert, Group, Select, Stack, Text, TextInput, Textarea } from '@mantine/core';
 import { ConfigField, ProviderMeta } from '@/lib/api';
 
 export interface WarehouseFormState {
@@ -76,6 +76,12 @@ export function WarehouseFormFields({ providers, value, onChange, hasSavedCreden
   const authFields = selectedAuth?.fields || [];
   const authCredField = authFields.find((f) => f.type === 'credential');
   const authConfigFields = authFields.filter((f) => f.type !== 'credential');
+  // A three-legged method has no fields, because its credential is the grant a
+  // consent screen produces rather than anything a person can type. Rendering
+  // the form for it would show an empty box and a Save button, and saving
+  // would attach a data source that cannot authenticate — with no error, since
+  // nothing was left blank. Say so instead.
+  const isAuthorizationCode = selectedAuth?.flow === 'authorization_code';
 
   const setProvider = (id: string) => {
     const prov = providers.find((p) => p.id === id);
@@ -127,7 +133,16 @@ export function WarehouseFormFields({ providers, value, onChange, hasSavedCreden
 
       {selectedAuth?.description && <Text size="xs" c="dimmed">{selectedAuth.description}</Text>}
 
-      {authConfigFields.map((field) => (
+      {isAuthorizationCode && (
+        <Alert color="blue" variant="light">
+          <Text size="sm">
+            This method has no credential to enter: you authorize {selected?.name || 'the provider'} by
+            signing in with it, which is done from the data source itself once it has been saved.
+          </Text>
+        </Alert>
+      )}
+
+      {!isAuthorizationCode && authConfigFields.map((field) => (
         <DynamicField
           key={field.key}
           field={field}
@@ -136,7 +151,7 @@ export function WarehouseFormFields({ providers, value, onChange, hasSavedCreden
         />
       ))}
 
-      {authCredField && (
+      {!isAuthorizationCode && authCredField && (
         <Textarea
           label={hasSavedCredential ? `Update ${authCredField.label}` : authCredField.label}
           required={authCredField.required && !hasSavedCredential}

--- a/ui/dashboard/src/lib/api.ts
+++ b/ui/dashboard/src/lib/api.ts
@@ -727,6 +727,13 @@ export interface AuthMethod {
 }
 
 export interface AuthorizationCode {
+  /**
+   * Whose OAuth app registration this method authenticates with — "google",
+   * say. Declared rather than derived from the provider slug because one
+   * registration serves several consumers: a customer who has registered a
+   * Google client for one feature is not asked to register another.
+   */
+  provider: string;
   auth_url: string;
   token_url: string;
   /** Where a grant is ended (RFC 7009). Absent when the provider publishes none. */

--- a/ui/dashboard/src/lib/api.ts
+++ b/ui/dashboard/src/lib/api.ts
@@ -729,6 +729,8 @@ export interface AuthMethod {
 export interface AuthorizationCode {
   auth_url: string;
   token_url: string;
+  /** Where a grant is ended (RFC 7009). Absent when the provider publishes none. */
+  revoke_url?: string;
   /** Scopes the consent must grant; a partial grant is refused at exchange. */
   scopes: string[];
 }

--- a/ui/dashboard/src/lib/api.ts
+++ b/ui/dashboard/src/lib/api.ts
@@ -740,6 +740,12 @@ export interface AuthorizationCode {
   revoke_url?: string;
   /** Scopes the consent must grant; a partial grant is refused at exchange. */
   scopes: string[];
+  /**
+   * Scopes asked for so the connection can be labelled with the account behind
+   * it. Requested alongside `scopes` but never required: withholding one costs
+   * a display name, not a capability.
+   */
+  identity_scopes?: string[];
 }
 
 export interface ConfigField {

--- a/ui/dashboard/src/lib/api.ts
+++ b/ui/dashboard/src/lib/api.ts
@@ -711,6 +711,26 @@ export interface AuthMethod {
   name: string;
   description: string;
   fields: ConfigField[];
+  /**
+   * How the credential is obtained. Absent means the fields above are a form
+   * and what the operator types into it is the credential — the only shape
+   * that existed before this field, and still the default.
+   *
+   * "authorization_code" is three-legged OAuth: there is no form, because the
+   * credential is the durable grant a consent screen produces. A form
+   * rendered from `fields` would show nothing and offer no way to connect, so
+   * a caller must branch on this rather than on `fields` being empty.
+   */
+  flow?: string;
+  /** Consent and token endpoints, present when flow is "authorization_code". */
+  authorization?: AuthorizationCode;
+}
+
+export interface AuthorizationCode {
+  auth_url: string;
+  token_url: string;
+  /** Scopes the consent must grant; a partial grant is refused at exchange. */
+  scopes: string[];
 }
 
 export interface ConfigField {


### PR DESCRIPTION
**Part of #252** (enterprise decisionbox-io/decisionbox-enterprise#252), platform half of enterprise **#292**. Targets `feat/non-sql-datasources`.

The community half of user-delegated OAuth for datasources: what the registry has to be able to say, and what the agent has to be able to read, so the enterprise side can hold a grant on a connection.

## What this adds

**A three-legged auth method.** `AuthMethod` could only describe a form to type into. It gains a `Flow`, and an `AuthorizationCode` block carrying where to send the user, where to redeem the code, where to end the grant, and the scopes the consent must cover — the last because providers with granular consent let a user approve some and withhold others, so it is what the exchange checks the grant *against*, not merely what it asks for.

**The OAuth app registration, keyed by provider.** The deployment's own client was stored under a key derived from the datasource slug, which quietly asserts that every consumer needs its own registration. It does not: a customer who registers one Google client should use it for every feature that authenticates against Google, and never register a second. So the key becomes the OAuth provider, which each consumer declares in its registry entry — both registries gain that declaration, and since neither owns the key scheme it moves to its own package (`libs/go-common/oauthreg`).

The keys are readable now (`oauth-app-google-client-id`) rather than hex. The hex existed to keep arbitrary slugs inside Azure Key Vault's alphabet; with both halves drawn from a closed set of compile-time constants, a lossy substitution is a collision a reviewer can see rather than one a customer can cause.

**A credential a datasource can name.** `initWarehouseProvider` derived the secret key from the datasource id, which cannot reach a credential that several datasources share. A datasource may now name its slot (`credential_ref`); when it does not — every datasource that exists today — nothing about the read changes.

**Loud failures where silence would mislead.** A three-legged method that names no OAuth provider can never authenticate, so it is a registry declaration error rather than a generic "not configured" from the provider. An unusable `credential_ref` is refused rather than falling back to the derived key, which would look like a working connection authenticating as something else.

**Where a grant's account is reported.** A three-legged method could say what a grant must *cover* but not who authorized it, so a connection made through one had nothing to be labelled with but its provider's name — two connections to the same source were indistinguishable. `AuthorizationCode` gains `UserInfoURL` and `IdentityScopes`, declared alongside `RevokeURL` because they are facts the provider publishes rather than deployment configuration.

`IdentityScopes` stay out of `Scopes` deliberately: the exchange requires everything in that list, and a withheld display name must not cost a working grant.

**An extension point on the connect form.** A three-legged method's notice says to authorize the data source *after* saving it, which is the honest answer only where nothing better is on offer. `WarehouseFormFields` gains an optional `authorizationSlot` that replaces the notice when a caller supplies one, so a build that can collect the authorization on the form itself is not forced to render its picker beneath a notice telling the customer to go elsewhere. Absent the prop, nothing changes.

## What is deliberately not here

- Anything Google-specific. The whole surface is declared by whichever provider adopts it.
- A consent URL builder. The code is obtained in the browser by Google Identity Services; a redirect leg ships with the provider that needs one (Salesforce).
- Credential storage or revocation. Both are enterprise-side, on the connection that holds the grant.

## Verification

- `libs/go-common` + `services/agent` + `services/api` unit suites, and the composed dashboard suite (737 tests).
- The credential-key change is pinned by a characterization test written **before** it, so "the derived path still works" is a test that was already passing rather than one written to agree with the new code.
- Mutation-checked: ignoring the ref, leaving it in the provider config, accepting an unusable one, and treating an empty one as set are all caught.
- `golangci-lint` clean on every touched package.

## Known limitation

Nothing reads `oauth-app-*` until the enterprise side writes it, so this merges as inert plumbing — which is the point: enterprise CI cannot compile its half until this lands on the bridge branch.

— Co-coded with Jale 🤖

