### PR TITLE
fix(dashboard): exclude test files from production build tsconfig (unblocks v0.26.1)

### DIFF
--- a/ui/dashboard/tsconfig.json
+++ b/ui/dashboard/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/__tests__/**"]
 }


### PR DESCRIPTION
next build type-checked `*.test.ts(x)` files (which import vitest, a devDep absent in overlay builds), breaking the cloud-enterprise-tenant dashboard image (`Cannot find module 'vitest'`). Excludes test files from the build type-check — they run under vitest's own config, unaffected. **Verified:** exclude covers the 3 failing test files; real source still type-checked. Part of the v0.26.1 release fix.