### PR TITLE
fix(agent): default DISCOVERY_REFLECTION_ENABLED to on

### DIFF
--- a/services/agent/internal/discovery/orchestrator.go
+++ b/services/agent/internal/discovery/orchestrator.go
@@ -550,7 +550,7 @@ type DiscoveryOptions struct {
 	// ReflectionEnabled is the resolved per-project toggle for the end-of-run
 	// reflection / Discovery Ledger phase (project.EffectiveReflectionEnabled(),
 	// default-on). The deployment-availability flag (DISCOVERY_REFLECTION_ENABLED,
-	// default off) is the other gate — both must be on.
+	// also default-on) is the other gate — both must be on.
 	ReflectionEnabled bool
 }
 

--- a/services/agent/internal/discovery/reflection.go
+++ b/services/agent/internal/discovery/reflection.go
@@ -26,10 +26,14 @@ var reflectionPromptTemplate string
 // Env knobs for the reflection / consolidation phase (Rule 2 — all parametric).
 const (
 	// discoveryReflectionEnabledEnv is the deployment-availability gate (Layer
-	// A). Default off: the ledger loop only earns its keep where the enterprise
-	// RAG + evolution workflow can consume it, so the enterprise agent Helm
-	// overlay turns it on. Independent of the per-project Settings toggle
-	// (Layer B, default on).
+	// A). Default ON: the phase is already fully protected by the gates that
+	// actually matter — the ledger/finding repos are only wired by the
+	// enterprise agent plugins (nil elsewhere, so the phase returns early) and
+	// the sources license entitlement is checked below. Layer A therefore added
+	// no real protection while silently costing every deployment that forgot to
+	// set it an empty Discovery Ledger, with no error to point at. Set it to
+	// "false" to opt out explicitly. Independent of the per-project Settings
+	// toggle (Layer B, default on).
 	discoveryReflectionEnabledEnv    = "DISCOVERY_REFLECTION_ENABLED"
 	discoveryReflectionTimeoutEnv    = "DISCOVERY_REFLECTION_TIMEOUT"
 	discoveryReflectionMaxOutputEnv  = "DISCOVERY_REFLECTION_MAX_OUTPUT"
@@ -104,7 +108,7 @@ func (o *Orchestrator) RunPhaseReflection(ctx context.Context, result *models.Di
 	if !o.reflectionEnabled {
 		return // Layer B: per-project Settings toggle is off.
 	}
-	if !goconfig.GetEnvAsBool(discoveryReflectionEnabledEnv, false) {
+	if !goconfig.GetEnvAsBool(discoveryReflectionEnabledEnv, true) {
 		return // Layer A: feature not available on this deployment.
 	}
 	if o.aiClient == nil || o.ledgerRepo == nil || o.findingRepo == nil || result == nil {

--- a/services/agent/internal/discovery/reflection_test.go
+++ b/services/agent/internal/discovery/reflection_test.go
@@ -293,6 +293,29 @@ func TestRunPhaseReflection_EnvOff_NoWork(t *testing.T) {
 	}
 }
 
+// TestRunPhaseReflection_EnvUnset_DefaultsOn pins Layer A's default. An unset
+// DISCOVERY_REFLECTION_ENABLED must behave as enabled: the phase is already
+// protected by the enterprise-only ledger/finding repos and the sources
+// entitlement, so defaulting Layer A off only produced silently-empty ledgers
+// on deployments that never set it.
+func TestRunPhaseReflection_EnvUnset_DefaultsOn(t *testing.T) {
+	t.Setenv("DISCOVERY_REFLECTION_ENABLED", "") // empty => default branch
+
+	client, _ := stubClient(t, `{"coverage_summary":"x"}`, nil)
+	fr := &fakeFindingRepo{}
+	o := &Orchestrator{
+		reflectionEnabled: true, projectID: "proj-1", runID: "run-1", datasets: []string{"ds"},
+		llmInputWindow: 200000, llmOutputCap: 4000, aiClient: client,
+		ledgerRepo: &fakeLedgerRepo{}, findingRepo: fr,
+	}
+	o.RunPhaseReflection(context.Background(), &models.DiscoveryResult{ID: "d1",
+		Insights: []models.Insight{{Name: "x", AnalysisArea: "a"}}})
+
+	if len(fr.upserted) == 0 {
+		t.Fatal("unset deployment flag must default ON and consolidate findings, upserted=0")
+	}
+}
+
 func TestRunPhaseReflection_LicenseGate_NoWork(t *testing.T) {
 	t.Setenv("DISCOVERY_REFLECTION_ENABLED", "true")
 	policy.RegisterChecker(denyChecker{policy.NewNoopChecker()})

--- a/services/api/models/project.go
+++ b/services/api/models/project.go
@@ -115,8 +115,8 @@ type Project struct {
 	// Discovery Ledger phase (the agent consolidates each run into a persistent,
 	// compounding ledger so the next run builds on it). Nil means "use the
 	// deployment default" (true) — default-on, users opt out in Settings. The
-	// deployment-availability flag DISCOVERY_REFLECTION_ENABLED (default off) is
-	// the other gate. Keep in sync with the agent's models.Project copy.
+	// deployment-availability flag DISCOVERY_REFLECTION_ENABLED (also default-on)
+	// is the other gate. Keep in sync with the agent's models.Project copy.
 	ReflectionEnabled *bool `bson:"reflection_enabled,omitempty" json:"reflection_enabled,omitempty"`
 
 	// SmartOverflowEnabled is the per-project toggle for the analysis picker's


### PR DESCRIPTION
## Problem

Layer A of the reflection / Discovery Ledger gate defaulted to **off**:

```go
if !goconfig.GetEnvAsBool(discoveryReflectionEnabledEnv, false) {
    return // Layer A: feature not available on this deployment.
}
```

The stated rationale was that only enterprise deployments can consume the ledger, so the enterprise agent Helm overlay would turn it on. But the phase is already protected by the two gates that actually matter, both checked in the very next lines:

- `o.ledgerRepo` / `o.findingRepo` are wired **only** by the enterprise agent plugins and are nil everywhere else → the phase returns early
- the sources license entitlement is verified explicitly via `policy.GetChecker().FeatureEnabled(..., policy.FeatureSources)`

So Layer A added no protection that wasn't already there. What it *did* do is give any deployment that never set the env a permanently empty Discovery Ledger — with no error, no log, and nothing for an operator to point at. The failure mode is indistinguishable from a broken feature.

That is not hypothetical: it's how a real deployment ended up with an empty ledger while `SOURCES_ENABLED` was on and the entitlement was granted. The self-hosted chart sets the flag; other deployment paths silently didn't.

## Change

- Flip Layer A's default to **on**. `DISCOVERY_REFLECTION_ENABLED=false` still opts out explicitly.
- The per-project Settings toggle (Layer B, `EffectiveReflectionEnabled`, default-on) is unchanged, so users can still opt out per project.
- Correct two `default off` comments that had drifted onto `DiscoveryOptions.ReflectionEnabled` and the api's `models.Project.ReflectionEnabled`.
- Add `TestRunPhaseReflection_EnvUnset_DefaultsOn` pinning the new default, so this can't silently regress.

## Testing

```
go test ./internal/discovery/ -count=1     ok  (12.3s)
go vet ./internal/discovery/ ./internal/models/    clean
services/api: go build ./... + go test ./models/   ok
```

The existing gate tests set the env explicitly (`"true"` / `"false"`), so they were unaffected; `TestRunPhaseReflection_EnvOff_NoWork` still covers the explicit opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PDGPb3ae8nV1EeTMqEYCx