### PR TITLE
fix(agent): default DISCOVERY_QUESTIONS_ENABLED on; forward SOURCES_ENABLED to agent Jobs

### DIFF
--- a/services/agent/internal/discovery/questions.go
+++ b/services/agent/internal/discovery/questions.go
@@ -23,10 +23,14 @@ var questionsPromptTemplate string
 // Env knobs for the clarifying-questions phase (Rule 2 — all parametric).
 const (
 	// discoveryQuestionsEnabledEnv is the deployment-availability gate. Default
-	// off: the loop is only useful where the answers can be captured (enterprise
-	// + sources), so the enterprise agent Helm overlay turns it on. This is
-	// independent of the per-project Settings toggle (default on), which is the
-	// user-facing control — both must be on for questions to generate.
+	// ON: the phase is already protected by the gates that actually matter and
+	// are checked immediately after it — the per-project Settings toggle (Layer
+	// B, default on), a nil questionRepo on builds without it, and the sources
+	// entitlement below. Defaulting Layer A off added no real protection while
+	// silently costing every deployment that forgot to set it a permanently
+	// empty Questions page, with no error to point at. Set it to "false" to opt
+	// out explicitly. The per-project toggle remains the user-facing control —
+	// both must be on for questions to generate.
 	discoveryQuestionsEnabledEnv    = "DISCOVERY_QUESTIONS_ENABLED"
 	discoveryQuestionsMaxEnv        = "DISCOVERY_QUESTIONS_MAX"
 	discoveryQuestionsMaxOutputEnv  = "DISCOVERY_QUESTIONS_MAX_OUTPUT"
@@ -84,7 +88,7 @@ func (o *Orchestrator) RunPhaseQuestions(ctx context.Context, result *models.Dis
 	if !o.clarifyingQuestionsEnabled {
 		return // Layer B: per-project Settings toggle is off.
 	}
-	if !goconfig.GetEnvAsBool(discoveryQuestionsEnabledEnv, false) {
+	if !goconfig.GetEnvAsBool(discoveryQuestionsEnabledEnv, true) {
 		return // Layer A: feature not available on this deployment.
 	}
 	if o.aiClient == nil || o.questionRepo == nil || result == nil {

--- a/services/agent/internal/discovery/questions_test.go
+++ b/services/agent/internal/discovery/questions_test.go
@@ -344,6 +344,42 @@ func TestRunPhaseQuestions_ToggleOff_NoWork(t *testing.T) {
 	}
 }
 
+// TestRunPhaseQuestions_EnvUnset_DefaultsOn pins Layer A's default. An unset
+// DISCOVERY_QUESTIONS_ENABLED must behave as enabled: the phase is already
+// protected by the per-project toggle, a nil questionRepo, and the sources
+// entitlement, so defaulting Layer A off only produced silently-empty Questions
+// pages on deployments that never set it.
+func TestRunPhaseQuestions_EnvUnset_DefaultsOn(t *testing.T) {
+	t.Setenv("DISCOVERY_QUESTIONS_ENABLED", "") // empty => default branch
+	resp := `{"questions":[{"question":"Does code 4 mean closed?","rationale":"opaque enum","linked_target":{"type":"insight","id":"a"},"answer_type":"boolean"}]}`
+	client, _ := stubClient(t, resp, nil)
+	repo := &fakeQuestionRepo{}
+	o := newTestOrchestrator(client, repo)
+
+	o.RunPhaseQuestions(context.Background(), &models.DiscoveryResult{ID: "disc-1",
+		Insights: []models.Insight{insightWith("a", "opaque", valmodels.StatusUnverifiable, 0.9)}})
+
+	if len(repo.inserted) == 0 {
+		t.Fatal("unset deployment flag must default ON and insert questions, inserted=0")
+	}
+}
+
+// TestRunPhaseQuestions_EnvOff_NoWork covers the explicit opt-out, which is the
+// only way to disable the phase deployment-wide now that Layer A defaults on.
+func TestRunPhaseQuestions_EnvOff_NoWork(t *testing.T) {
+	t.Setenv("DISCOVERY_QUESTIONS_ENABLED", "false")
+	client, prov := stubClient(t, `{"questions":[]}`, nil)
+	repo := &fakeQuestionRepo{}
+	o := newTestOrchestrator(client, repo)
+
+	o.RunPhaseQuestions(context.Background(), &models.DiscoveryResult{ID: "d1",
+		Insights: []models.Insight{insightWith("a", "x", valmodels.StatusUnverifiable, 0.9)}})
+
+	if prov.calls != 0 || len(repo.inserted) != 0 {
+		t.Fatalf("deployment flag off must do no work: calls=%d inserted=%d", prov.calls, len(repo.inserted))
+	}
+}
+
 // denyChecker entitles nothing — mirrors an enterprise deployment whose license
 // lacks sources_enabled.
 type denyChecker struct{ policy.Checker }

--- a/services/api/internal/runner/env.go
+++ b/services/api/internal/runner/env.go
@@ -56,6 +56,12 @@ var agentForwardedEnvKeys = []string{
 	// agent side (not the API), so it has to be forwarded for container
 	// runs. Subprocess runs already inherit it from the API process env.
 	"DISCOVERY_MAX_DURATION",
+	// SOURCES_ENABLED gates the enterprise sources agent plugin. Without
+	// forwarding, the plugin still loads but hands back the community NoOp
+	// retriever, so discovery runs with no knowledge-source context at all
+	// while the API reports Knowledge Sources as enabled — a silent
+	// downgrade rather than a visible failure.
+	"SOURCES_ENABLED",
 	// VALIDATION_* knobs for the LLM-native verifier+refuter pipeline.
 	// All consumed by the agent via verifier.LoadConfigFromEnv during
 	// both full-discovery validation and manual --mode=validate-doc runs.

--- a/services/api/internal/runner/env_test.go
+++ b/services/api/internal/runner/env_test.go
@@ -29,3 +29,20 @@ func TestForwardedEnv_InferenceCredentials(t *testing.T) {
 		t.Error("BLURB_LLM_API_KEY should not be forwarded when unset")
 	}
 }
+
+// TestForwardedEnv_SourcesEnabled pins that SOURCES_ENABLED reaches agent
+// containers. Without it the enterprise sources plugin still loads but returns
+// the community NoOp retriever, so discovery runs with no knowledge-source
+// context while the API reports Knowledge Sources as enabled.
+func TestForwardedEnv_SourcesEnabled(t *testing.T) {
+	t.Setenv("SOURCES_ENABLED", "true")
+
+	found := map[string]string{}
+	for _, kv := range collectForwardedEnv(agentForwardedEnvKeys) {
+		found[kv.Key] = kv.Value
+	}
+
+	if found["SOURCES_ENABLED"] != "true" {
+		t.Errorf("SOURCES_ENABLED not forwarded: %q", found["SOURCES_ENABLED"])
+	}
+}


### PR DESCRIPTION
Closes #400.

Two independent Layer-A gaps. Both disable a feature **silently** — the phase returns early with no error and no log line, so it reads as a broken product feature rather than a missing env var.

## 1. `DISCOVERY_QUESTIONS_ENABLED` defaulted off

`services/agent/internal/discovery/questions.go` — same reasoning #399 already corrected for the reflection phase. The phase is protected by the gates checked immediately after Layer A:

- the per-project Settings toggle (Layer B, `EffectiveClarifyingQuestionsEnabled`, default-on)
- `o.questionRepo == nil` for builds without it
- the sources entitlement

So Layer A added no protection while costing any deployment that forgot the env var a permanently empty Questions page. Now defaults **on**; `DISCOVERY_QUESTIONS_ENABLED=false` still opts out explicitly, and the per-project toggle remains the user-facing control.

## 2. `SOURCES_ENABLED` was never forwarded to agent Jobs

`services/api/internal/runner/env.go` — `agentForwardedEnvKeys` carries the `DISCOVERY_QUESTIONS_*`, `DISCOVERY_REFLECTION_*`, `DISCOVERY_LEDGER_*` and `VALIDATION_*` families but not `SOURCES_ENABLED`.

The consequence isn't "plugin absent" — per the enterprise plugin's own comment, with the flag off it *"run[s] the hooks but return[s] the community NoOp retriever"*. So discovery ran with **no knowledge-source context at all** while the API reported Knowledge Sources as enabled. A silent downgrade, not a failure.

## Tests

- `TestRunPhaseQuestions_EnvUnset_DefaultsOn` — pins the new default (mirrors #399's reflection test)
- `TestRunPhaseQuestions_EnvOff_NoWork` — covers the explicit opt-out, which had **no** test before; it's now the only way to disable the phase deployment-wide
- `TestForwardedEnv_SourcesEnabled` — pins the forwarding

```
services/agent: go test ./internal/discovery/ -count=1   ok (10.3s)
services/api:   go test ./internal/runner/   -count=1   ok (12.0s)
go vet on both packages                                  clean
```

Existing gate tests set the env explicitly, so they were unaffected.

## Scope

This does not by itself make Questions work on every deployment — the phase also checks the sources entitlement, and resolving that correctly is a separate concern tracked outside this repo. This PR removes the two silent-plumbing blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PDGPb3ae8nV1EeTMqEYCx