### PR TITLE
fix(runner): forward cloud policy + governance env to agent Jobs (enterprise-tenant#39)

### DIFF
--- a/services/api/internal/runner/env.go
+++ b/services/api/internal/runner/env.go
@@ -105,6 +105,30 @@ var agentForwardedEnvKeys = []string{
 	"DISCOVERY_LEDGER_MAX_FINDINGS",
 	"DISCOVERY_LEDGER_DEDUP_MINSCORE",
 	"DISCOVERY_LEDGER_TREND_DELTA",
+	// Cloud policy-checker identity. On cloud tenants the agent runs the
+	// cloud-enterprise agent image, whose policy.Checker is
+	// decisionbox-cloud-tenant/policy-plugin (registered only when
+	// POLICY_PROVIDER=cloud) and forwards entitlement checks to the control
+	// plane. Its config loader requires all three of CONTROL_PLANE_URL /
+	// DEPLOYMENT_ID / CONTROL_PLANE_INTERNAL_TOKEN. Without forwarding, the
+	// agent falls back to the allow-all Noop checker and plan caps go
+	// unenforced agent-side. The api pod already holds all four (POLICY_PROVIDER
+	// + CONTROL_PLANE_URL as literals, the latter two via envFrom the
+	// per-release cloud-auth / cloud-policy secrets), so this forwards them the
+	// same way the inference-credential secrets above are. Absent on self-hosted
+	// (POLICY_PROVIDER unset) ⇒ nothing forwarded, behavior unchanged.
+	// See decisionbox-cloud-enterprise-tenant#39.
+	"POLICY_PROVIDER",
+	"CONTROL_PLANE_URL",
+	"DEPLOYMENT_ID",
+	"CONTROL_PLANE_INTERNAL_TOKEN",
+	// GOVERNANCE_ENABLED gates the enterprise governance plugin's init() in the
+	// agent process (governance/register.go): without it the warehouse provider
+	// is never wrapped, so agent queries stay ungoverned regardless of the
+	// policy checker's FeatureGovernance entitlement. Forwarding the flag set on
+	// the api deployment is required for governance to apply to agent queries;
+	// the checker forwarding above is necessary but not sufficient on its own.
+	"GOVERNANCE_ENABLED",
 }
 
 // dockerAgentExtraEnvKeys are forwarded only by the Docker runner. The

--- a/services/api/internal/runner/env_test.go
+++ b/services/api/internal/runner/env_test.go
@@ -46,3 +46,58 @@ func TestForwardedEnv_SourcesEnabled(t *testing.T) {
 		t.Errorf("SOURCES_ENABLED not forwarded: %q", found["SOURCES_ENABLED"])
 	}
 }
+
+// TestForwardedEnv_CloudPolicyIdentity pins that the cloud policy-checker
+// identity + the governance init gate reach agent Jobs. On cloud tenants the
+// agent runs the cloud-enterprise agent image, whose policy.Checker is the
+// cloud policy-plugin (POLICY_PROVIDER=cloud) and needs CONTROL_PLANE_URL /
+// DEPLOYMENT_ID / CONTROL_PLANE_INTERNAL_TOKEN, and whose governance plugin
+// needs GOVERNANCE_ENABLED to wrap the warehouse provider. Without forwarding,
+// every agent-side entitlement was denied by the onprem license checker and
+// governance never engaged (decisionbox-cloud-enterprise-tenant#39).
+func TestForwardedEnv_CloudPolicyIdentity(t *testing.T) {
+	t.Setenv("POLICY_PROVIDER", "cloud")
+	t.Setenv("CONTROL_PLANE_URL", "https://cloud.decisionbox.io")
+	t.Setenv("DEPLOYMENT_ID", "deadbeefdeadbeefdeadbeef")
+	t.Setenv("CONTROL_PLANE_INTERNAL_TOKEN", "internal.jwt.token")
+	t.Setenv("GOVERNANCE_ENABLED", "true")
+
+	found := map[string]string{}
+	for _, kv := range collectForwardedEnv(agentForwardedEnvKeys) {
+		found[kv.Key] = kv.Value
+	}
+
+	for k, want := range map[string]string{
+		"POLICY_PROVIDER":              "cloud",
+		"CONTROL_PLANE_URL":            "https://cloud.decisionbox.io",
+		"DEPLOYMENT_ID":                "deadbeefdeadbeefdeadbeef",
+		"CONTROL_PLANE_INTERNAL_TOKEN": "internal.jwt.token",
+		"GOVERNANCE_ENABLED":           "true",
+	} {
+		if found[k] != want {
+			t.Errorf("%s not forwarded: got %q, want %q", k, found[k], want)
+		}
+	}
+}
+
+// TestForwardedEnv_CloudPolicyAbsentOnSelfHosted pins that the cloud identity
+// vars are NOT forwarded when unset — self-hosted deployments (no
+// POLICY_PROVIDER) must see none of them so the agent uses the OSS Noop
+// checker and its behavior is unchanged.
+func TestForwardedEnv_CloudPolicyAbsentOnSelfHosted(t *testing.T) {
+	// Explicitly clear so a polluted CI env can't mask a regression.
+	for _, k := range []string{
+		"POLICY_PROVIDER", "CONTROL_PLANE_URL", "DEPLOYMENT_ID",
+		"CONTROL_PLANE_INTERNAL_TOKEN", "GOVERNANCE_ENABLED",
+	} {
+		t.Setenv(k, "")
+	}
+
+	for _, kv := range collectForwardedEnv(agentForwardedEnvKeys) {
+		switch kv.Key {
+		case "POLICY_PROVIDER", "CONTROL_PLANE_URL", "DEPLOYMENT_ID",
+			"CONTROL_PLANE_INTERNAL_TOKEN", "GOVERNANCE_ENABLED":
+			t.Errorf("%s must not be forwarded when unset, got %q", kv.Key, kv.Value)
+		}
+	}
+}


### PR DESCRIPTION
## What

The K8s/Docker agent runner (`services/api/internal/runner/env.go`) forwards a curated env allowlist to spawned agent Jobs. It was missing the **cloud policy-checker identity** and the **governance init gate**, so on cloud tenants the agent could not enforce plan entitlements agent-side.

Adds to `agentForwardedEnvKeys`:

| var | why it's needed in the agent Job |
|---|---|
| `POLICY_PROVIDER` | activates `decisionbox-cloud-tenant/policy-plugin`'s control-plane checker (registers only when `=cloud`) |
| `CONTROL_PLANE_URL` / `DEPLOYMENT_ID` / `CONTROL_PLANE_INTERNAL_TOKEN` | required by the plugin's `LoadConfigFromEnv` (or it exits) |
| `GOVERNANCE_ENABLED` | the enterprise governance plugin's `init()` wraps the warehouse provider only when this is set — the checker entitlement alone is not enough |

## Why

Paired with the new cloud agent image ([decisionbox-cloud-enterprise-tenant#39](https://github.com/decisionbox-io/decisionbox-cloud-enterprise-tenant/issues/39)). That image swaps the onprem `license` checker for the cloud one, but the cloud checker can only reach the control plane if these vars are in the Job env. Without this change the agent falls back to the allow-all Noop checker (caps unenforced) and governance never engages.

## How it's forwarded

Via the existing literal-forwarding mechanism — the same path `SECRET_ENCRYPTION_KEY`, `LLM_API_KEY`, `EMBEDDING_API_KEY` already use (the runner has no secretRef plumbing, and these ride alongside those). The api pod already holds all five in its own env (the two secret-backed ones via `envFrom` the per-release cloud-auth/cloud-policy secrets). On self-hosted (`POLICY_PROVIDER` unset) none are forwarded, so behavior there is unchanged.

## Tests

`services/api/internal/runner/env_test.go`: two new tests — `TestForwardedEnv_CloudPolicyIdentity` (all five forwarded when set) and `TestForwardedEnv_CloudPolicyAbsentOnSelfHosted` (none forwarded when unset). `go build`, `go vet`, and `go test ./internal/runner/ -run TestForwardedEnv` all pass.

Closes part of decisionbox-cloud-enterprise-tenant#39 (the platform task item).

— Co-coded with Jale 🤖