### PR TITLE
fix(agent): budget reflection/questions output against the model cap, not a fixed default

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,7 +77,7 @@ Generation is off by default and, where it is enabled, respects a per-project **
 |----------|---------|-------------|
 | `DISCOVERY_QUESTIONS_ENABLED` | `false` | Master switch for question generation. Off by default. The agent runs as a separate container, so this is forwarded from the API process to spawned agent containers automatically. |
 | `DISCOVERY_QUESTIONS_MAX` | `5` | Hard cap on the number of questions generated per run (after dedup against already-asked / already-answered questions). |
-| `DISCOVERY_QUESTIONS_MAX_OUTPUT` | `2000` | Output-token budget for the single generation call, budgeted against the model's context window like the analysis/recommendation phases. |
+| `DISCOVERY_QUESTIONS_MAX_OUTPUT` | model's output cap | Optional ceiling on the single generation call. Unset, the phase uses the model's own output cap and budgets it against the context window, like the analysis/recommendation phases. Set it only to deliberately cap the spend — a value below what the response needs truncates it mid-JSON and the phase yields nothing. |
 | `DISCOVERY_QUESTIONS_CONFIDENCE_MAX_PCT` | `50` | An insight/recommendation with confidence below this percentage is treated as "uncertain" and eligible to raise a question. |
 | `DISCOVERY_QUESTIONS_PARSE_MAX_RETRIES` | `1` | How many times to re-prompt if the model's response can't be parsed as the questions envelope. |
 | `DISCOVERY_QUESTIONS_TIMEOUT` | `3m` | Dedicated wall-clock budget for the questions hop, independent of `DISCOVERY_MAX_DURATION`. Go duration format. |
@@ -93,7 +93,7 @@ Semantic dedup / trend detection and per-analysis-area retrieval of prior findin
 |----------|---------|-------------|
 | `DISCOVERY_REFLECTION_ENABLED` | `false` | Master switch for the reflection / Discovery Ledger hop. Off by default. Forwarded from the API process to spawned agent containers automatically. |
 | `DISCOVERY_REFLECTION_TIMEOUT` | `3m` | Dedicated wall-clock budget for the reflection hop, independent of `DISCOVERY_MAX_DURATION`. Go duration format. |
-| `DISCOVERY_REFLECTION_MAX_OUTPUT` | `3000` | Output-token budget for the single reflection call, budgeted against the model's context window. |
+| `DISCOVERY_REFLECTION_MAX_OUTPUT` | model's output cap | Optional ceiling on the single reflection call. Unset, the phase uses the model's own output cap and budgets it against the context window. Set it only to deliberately cap the spend — the reflection response re-judges every prior ledger finding, so it grows with the ledger, and a value below what it needs truncates it mid-JSON and yields no coverage, learnings or next-tasks. |
 | `DISCOVERY_REFLECTION_PARSE_MAX_RETRIES` | `1` | How many times to re-prompt if the model's reflection response can't be parsed. |
 | `DISCOVERY_LEDGER_MAX_FINDINGS` | `500` | Retention cap on ledger findings per project; least-valuable (resolved/refuted, oldest) are pruned first. |
 | `DISCOVERY_LEDGER_DEDUP_MINSCORE` | `0.85` | Cosine-similarity floor above which a new finding is treated as a semantic duplicate of a prior one (needs the embedding provider). |

--- a/services/agent/internal/discovery/analysis_budget.go
+++ b/services/agent/internal/discovery/analysis_budget.go
@@ -2,10 +2,14 @@ package discovery
 
 import (
 	"context"
+	"os"
+	"strconv"
+	"strings"
 	"unicode/utf8"
 
 	goconfig "github.com/decisionbox-io/decisionbox/libs/go-common/config"
 	gollm "github.com/decisionbox-io/decisionbox/libs/go-common/llm"
+	applog "github.com/decisionbox-io/decisionbox/services/agent/internal/log"
 )
 
 // Output-token budgeting for the analysis + recommendation phases.
@@ -67,6 +71,60 @@ const minPickerBudgetTokens = 4096
 // max_tokens is still recomputed against the measured input after the prompt is
 // assembled, so the actual generation is never smaller than the window allows.
 const analysisOutputReserveTokens = 16384
+
+// logOutputCapTruncation reports the one case that is otherwise invisible: a
+// structured-output response that failed to parse AND consumed its entire
+// max_tokens budget. That combination is almost always truncation mid-JSON
+// rather than a model that emitted malformed output, and the two need different
+// fixes — raise the cap vs. repair the prompt. Without this the phase just
+// degrades to a no-op with a generic "unusable response" error, which is how
+// issue #403 stayed hidden: the ledger still recorded its non-LLM outputs, so it
+// looked like the phase had run.
+func logOutputCapTruncation(phase, envKey string, attempt, maxTokens, tokensOut int) {
+	if maxTokens <= 0 || tokensOut < maxTokens {
+		return
+	}
+	applog.WithFields(applog.Fields{
+		"phase":      phase,
+		"attempt":    attempt,
+		"max_tokens": maxTokens,
+		"tokens_out": tokensOut,
+		"env":        envKey,
+	}).Warn("Response did not parse and used the entire output budget — it was almost certainly truncated. Raise " + envKey + ", or use a model with a larger output cap.")
+}
+
+// phaseOutputCap resolves the output ceiling for a bounded, structured-output
+// discovery phase (reflection, clarifying questions).
+//
+// Unset env → the model's own cap, which is exactly what the analysis and
+// recommendation paths pass (see orchestrator.go). Those two scale with
+// whatever model the deployment runs. The newer phases instead layered a small
+// fixed default on top, and since the budget takes the minimum, that default
+// became the binding constraint: on a project large enough to need more, the
+// response was truncated mid-JSON, failed to parse, and the phase degraded to
+// a no-op — silently, because its other outputs still persisted (issue #403).
+//
+// Set env → an explicit operator override: clamped to [clampMin, 32000] and
+// never above what the model itself allows.
+//
+// fallback applies only when the model cap is unknown (<= 0). The budgeter must
+// never be handed a zero cap: boundOutputCap would keep it at zero and collapse
+// max_tokens — and the floor with it — to nothing.
+func phaseOutputCap(envKey string, modelOutputCap, clampMin, fallback int) int {
+	if raw := strings.TrimSpace(os.Getenv(envKey)); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			capped := clampInt(v, clampMin, 32000)
+			if modelOutputCap > 0 && capped > modelOutputCap {
+				capped = modelOutputCap
+			}
+			return capped
+		}
+	}
+	if modelOutputCap > 0 {
+		return modelOutputCap
+	}
+	return fallback
+}
 
 // boundOutputCap clamps an output cap to the model window — output can never
 // exceed the context window, so a catalog/default cap larger than a

--- a/services/agent/internal/discovery/analysis_budget_test.go
+++ b/services/agent/internal/discovery/analysis_budget_test.go
@@ -127,3 +127,75 @@ func TestAnalysisMinOutputTokens_EnvOverride(t *testing.T) {
 		t.Fatalf("invalid env should fall back to %d, got %d", defaultAnalysisMinOutputTokens, got)
 	}
 }
+
+// --- phaseOutputCap (issue #403) ---
+
+// TestPhaseOutputCap_UnsetUsesModelCap is the fix: with no env override the
+// phase inherits the model's own cap, exactly like the analysis and
+// recommendation paths, instead of a small fixed default that silently
+// truncated the response.
+func TestPhaseOutputCap_UnsetUsesModelCap(t *testing.T) {
+	t.Setenv("DBX_TEST_PHASE_CAP", "")
+	if got := phaseOutputCap("DBX_TEST_PHASE_CAP", 64000, 512, 3000); got != 64000 {
+		t.Errorf("unset env must yield the model cap, got %d want 64000", got)
+	}
+}
+
+// TestPhaseOutputCap_EnvOverrides keeps the operator knob working.
+func TestPhaseOutputCap_EnvOverrides(t *testing.T) {
+	t.Setenv("DBX_TEST_PHASE_CAP", "9000")
+	if got := phaseOutputCap("DBX_TEST_PHASE_CAP", 64000, 512, 3000); got != 9000 {
+		t.Errorf("env override not honored, got %d want 9000", got)
+	}
+}
+
+// TestPhaseOutputCap_EnvNeverExceedsModel — a too-high override must not produce
+// a max_tokens the provider rejects.
+func TestPhaseOutputCap_EnvNeverExceedsModel(t *testing.T) {
+	t.Setenv("DBX_TEST_PHASE_CAP", "30000")
+	if got := phaseOutputCap("DBX_TEST_PHASE_CAP", 4096, 512, 3000); got != 4096 {
+		t.Errorf("override must be bounded by the model cap, got %d want 4096", got)
+	}
+}
+
+// TestPhaseOutputCap_UnknownModelUsesFallback guards the zero-cap trap:
+// boundOutputCap would keep a 0 cap at 0 and collapse max_tokens (and the
+// floor) to nothing, so an unknown model must fall back to the constant.
+func TestPhaseOutputCap_UnknownModelUsesFallback(t *testing.T) {
+	t.Setenv("DBX_TEST_PHASE_CAP", "")
+	if got := phaseOutputCap("DBX_TEST_PHASE_CAP", 0, 512, 3000); got != 3000 {
+		t.Errorf("unknown model cap must fall back, got %d want 3000", got)
+	}
+}
+
+// TestPhaseOutputCap_InvalidEnvFallsBackToModel — a garbage value must not be
+// treated as 0 and collapse the budget.
+func TestPhaseOutputCap_InvalidEnvFallsBackToModel(t *testing.T) {
+	for _, v := range []string{"abc", "0", "-5"} {
+		t.Setenv("DBX_TEST_PHASE_CAP", v)
+		if got := phaseOutputCap("DBX_TEST_PHASE_CAP", 64000, 512, 3000); got != 64000 {
+			t.Errorf("invalid env %q must fall through to the model cap, got %d", v, got)
+		}
+	}
+}
+
+// TestPhaseOutputCap_RegressionForIssue403 reproduces the production numbers:
+// a 15K-token prompt on a 200K window previously got max_tokens=3000 and
+// truncated. With the model cap it gets the analysis floor or better.
+func TestPhaseOutputCap_RegressionForIssue403(t *testing.T) {
+	t.Setenv("DBX_TEST_PHASE_CAP", "")
+	const window, prompt, modelCap = 200000, 15337, 64000
+
+	old := budgetedMaxOutputTokens(window, prompt, 3000, defaultAnalysisMinOutputTokens)
+	now := budgetedMaxOutputTokens(window, prompt, phaseOutputCap("DBX_TEST_PHASE_CAP", modelCap, 512, 3000), defaultAnalysisMinOutputTokens)
+
+	if old != 3000 {
+		t.Fatalf("precondition: old behaviour should cap at 3000, got %d", old)
+	}
+	if now <= old {
+		t.Errorf("model-cap budget %d must exceed the old fixed cap %d", now, old)
+	}
+	if now < defaultAnalysisMinOutputTokens {
+		t.Errorf("budget %d fell below the analysis floor %d", now, defaultAnalysisMinOutputTokens)
+	}
+}

--- a/services/agent/internal/discovery/questions.go
+++ b/services/agent/internal/discovery/questions.go
@@ -185,14 +185,11 @@ func (o *Orchestrator) generateQuestions(ctx context.Context, items []uncertaint
 	prompt = o.injectKnowledgeSources(ctx, prompt, "clarifying questions about "+strings.Join(o.datasets, ", "), knowledgeTopKRecommendations)
 
 	window, modelOutputCap := o.resolveModelBudget()
-	outputCap := clampInt(goconfig.GetEnvAsInt(discoveryQuestionsMaxOutputEnv, defaultDiscoveryQuestionsMaxOutput), 256, 32000)
-	// Never request more output than the model/operator allows — mirror the
-	// analysis/recommendation paths, which budget against resolveModelBudget's
-	// output cap. Without this, a high DISCOVERY_QUESTIONS_MAX_OUTPUT (or a model
-	// whose real cap is lower) could send a max_tokens the provider 4xx-rejects.
-	if modelOutputCap > 0 && outputCap > modelOutputCap {
-		outputCap = modelOutputCap
-	}
+	// Default to the model's own cap, mirroring the analysis/recommendation
+	// paths; DISCOVERY_QUESTIONS_MAX_OUTPUT stays available as an operator
+	// override and is never allowed above what the model itself accepts (a
+	// too-high max_tokens is 4xx-rejected by some providers). See issue #403.
+	outputCap := phaseOutputCap(discoveryQuestionsMaxOutputEnv, modelOutputCap, 256, defaultDiscoveryQuestionsMaxOutput)
 	maxTokens := budgetedMaxOutputTokens(window, approxTokens(ctx, prompt), outputCap, analysisMinOutputTokens())
 
 	format := questionsResponseFormat()
@@ -220,6 +217,7 @@ func (o *Orchestrator) generateQuestions(ctx context.Context, items []uncertaint
 		parsed, rawCount, perr := parseQuestions(chatResult.Content)
 		if perr != nil {
 			lastErr = perr
+			logOutputCapTruncation("Clarifying questions", discoveryQuestionsMaxOutputEnv, attempt, maxTokens, chatResult.TokensOut)
 			continue
 		}
 		final := postProcessQuestions(parsed, validTargets, existingKeys, maxN)

--- a/services/agent/internal/discovery/reflection_llm.go
+++ b/services/agent/internal/discovery/reflection_llm.go
@@ -79,8 +79,10 @@ func (o *Orchestrator) generateReflection(ctx context.Context, result *models.Di
 	window, modelOutputCap := o.resolveModelBudget()
 	// Default to the model's own cap, mirroring the analysis and recommendation
 	// paths; DISCOVERY_REFLECTION_MAX_OUTPUT stays available as an operator
-	// override. A fixed default here silently truncated the response on any
-	// project with a substantial ledger (issue #403).
+	// override. The response is bounded by the prompt caps
+	// (maxPriorFindingsInPrompt, maxLedgerTasksInPrompt, the 300-table catalog
+	// cap), so it does not grow without limit — a fixed default was simply
+	// below what an ordinary ledger needs, and truncated it mid-JSON (#403).
 	outputCap := phaseOutputCap(discoveryReflectionMaxOutputEnv, modelOutputCap, 512, defaultDiscoveryReflectionMaxOutput)
 	maxTokens := budgetedMaxOutputTokens(window, approxTokens(ctx, prompt), outputCap, analysisMinOutputTokens())
 

--- a/services/agent/internal/discovery/reflection_llm.go
+++ b/services/agent/internal/discovery/reflection_llm.go
@@ -77,10 +77,11 @@ func (o *Orchestrator) generateReflection(ctx context.Context, result *models.Di
 	prompt := o.buildReflectionPrompt(result, prior, tasks, pol)
 
 	window, modelOutputCap := o.resolveModelBudget()
-	outputCap := clampInt(goconfig.GetEnvAsInt(discoveryReflectionMaxOutputEnv, defaultDiscoveryReflectionMaxOutput), 512, 32000)
-	if modelOutputCap > 0 && outputCap > modelOutputCap {
-		outputCap = modelOutputCap
-	}
+	// Default to the model's own cap, mirroring the analysis and recommendation
+	// paths; DISCOVERY_REFLECTION_MAX_OUTPUT stays available as an operator
+	// override. A fixed default here silently truncated the response on any
+	// project with a substantial ledger (issue #403).
+	outputCap := phaseOutputCap(discoveryReflectionMaxOutputEnv, modelOutputCap, 512, defaultDiscoveryReflectionMaxOutput)
 	maxTokens := budgetedMaxOutputTokens(window, approxTokens(ctx, prompt), outputCap, analysisMinOutputTokens())
 
 	format := reflectionResponseFormat()
@@ -107,6 +108,7 @@ func (o *Orchestrator) generateReflection(ctx context.Context, result *models.Di
 		parsed, perr := parseReflection(chatResult.Content)
 		if perr != nil {
 			lastErr = perr
+			logOutputCapTruncation("Reflection", discoveryReflectionMaxOutputEnv, attempt, maxTokens, chatResult.TokensOut)
 			continue
 		}
 		return parsed, nil


### PR DESCRIPTION
Closes #403.

## The bug

#347/#348 made output budgeting dynamic. All four discovery LLM phases call the same `budgetedMaxOutputTokens(window, input, outputCap, floor)` — the difference is what each passes as `outputCap`:

| phase | outputCap source | binding limit |
|---|---|---|
| analysis (`orchestrator.go:1144`) | `resolveModelBudget()` → model cap | dynamic |
| recommendations (`orchestrator.go:1742`) | `resolveModelBudget()` → model cap | dynamic |
| clarifying questions (`questions.go:196`) | env, default **2000**, then min'd with model cap | fixed 2000 |
| reflection (`reflection_llm.go:84`) | env, default **3000**, then min'd with model cap | fixed 3000 |

The two phases that work take the model's cap directly. The two newer ones layer a small fixed default on top — and since the budget takes the minimum, that default wins and the dynamic sizing never applies.

The scale mismatch: `defaultAnalysisMinOutputTokens` is **8192** — the *floor* every one of these calls is guaranteed. Reflection was *capped* at 3000, well under half the floor for a comparable call. Nothing upstream imposed it: the same model returned **13,399** output tokens on an analysis call in the same minute, and `DefaultMaxOutputTokens` for an uncatalogued model is 64000.

## What it looked like in production

A project with 43 prior ledger findings. The reflection response is sized by the ledger — it re-judges every prior finding — so it hit `max_tokens` exactly, truncated mid-JSON, failed to parse, and after the single repair retry `generateReflection` returned nil.

Steps 3 and 4 still run with `ref = nil`, so the ledger kept its findings and convergence row while `coverage.explored_tables`, `summary`, learnings and next-tasks all stayed empty. The phase looked like it had worked. From the gateway's usage records:

```
20:21:45  in=15337  out=3000   <- hit the cap exactly
20:22:28  in=15461  out=2665   <- repair retry (+124 input = the repair suffix)
ledger updated_at = 20:22:28.421   <- 38ms later, findings-only
```

This gets *more* likely over time, since the ledger only grows. Questions has the identical latent bug at 2000 — it works today only because its output is small.

## The change

- Shared `phaseOutputCap` helper: unset env → the model's own cap, matching analysis/recommendations. `DISCOVERY_REFLECTION_MAX_OUTPUT` / `DISCOVERY_QUESTIONS_MAX_OUTPUT` stay as operator overrides, still clamped and never above what the model accepts.
- An unknown model cap (`<= 0`) falls back to the old constant rather than 0. `boundOutputCap` keeps a 0 cap at 0, which would collapse `max_tokens` **and the floor** to nothing — worth guarding explicitly.
- `logOutputCapTruncation`: a response that fails to parse **and** consumed its entire budget is almost certainly truncation, not malformed output. Those need different fixes, and the absence of that distinction is precisely why this stayed hidden.
- Docs updated — both knobs now document "model's output cap" as the default and warn what setting them too low does.

## Tests

Six cases on `phaseOutputCap`, including a regression test that reproduces the production numbers (15337-token prompt, 200K window) and asserts the old path caps at exactly 3000 while the new one clears the 8192 analysis floor.

```
go test ./internal/discovery/ -count=1   ok (9.9s)
go vet ./internal/discovery/             clean
gofmt                                    clean on touched files
```

## Note on scope

This does not change analysis or recommendations — they were already correct. It brings the two newer phases in line with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PDGPb3ae8nV1EeTMqEYCx